### PR TITLE
docs: enforce TDD and security audit in all agent configs

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -14,8 +14,10 @@ Discord frontend for Claude Code CLI. Python 3.10+ with discord.py v2.
 - Type hints required on ALL function signatures
 - `from __future__ import annotations` in EVERY file
 - ruff for linting/formatting (line-length: 100)
+- **TDD enforced**: Write tests FIRST (RED), implement (GREEN), refactor. No exceptions.
 - pytest with pytest-asyncio (auto mode) for testing
 - Logging via `logging.getLogger(__name__)`, never print()
+- Security audit mandatory before committing changes to runner/Cog code
 
 ## Security (Non-Negotiable)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,7 +22,9 @@ Discord frontend for Claude Code CLI. Python 3.10+ with discord.py v2.
 - `claude_discord/discord_ui/` — Status reactions, message chunking, embeds
 - `tests/` — pytest suite
 
-## Testing
+## Testing (TDD Enforced)
+
+**Write tests FIRST, then implement.** Follow RED → GREEN → REFACTOR for all new features and bug fixes.
 
 ```bash
 uv run pytest tests/ -v --cov=claude_discord
@@ -30,7 +32,8 @@ uv run ruff check claude_discord/
 uv run ruff format --check claude_discord/
 ```
 
-## Security
+## Security (Mandatory Pre-Commit)
 
 This project spawns Claude Code CLI as a subprocess. All user input flows through to CLI args.
 Never interpolate user input into shell commands. Strip secrets from subprocess env.
+Run security audit before committing changes to runner.py, _run_helper.py, or any Cog.


### PR DESCRIPTION
## Summary
- CLAUDE.md/AGENTS.md: Testing section → "TDD Enforced" with explicit RED-GREEN-REFACTOR steps
- CLAUDE.md/AGENTS.md: Security section → audit mandatory before committing runner/Cog changes
- .github/copilot-instructions.md: Same TDD + security enforcement
- .cursorrules: Same TDD + security enforcement

## Why
Vercel's benchmarks: passive context (AGENTS.md) = 100% activation rate. Skills alone = 79% (agents fail to invoke them 56% of the time). By writing "TDD enforced" directly in the always-loaded config files, every AI agent automatically follows TDD without needing to discover the skill.

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)