### PR TITLE
fix: prevent duplicate docs-sync PRs

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -7,10 +7,45 @@ on:
 jobs:
   trigger-docs-sync:
     # Skip if the commit is from docs-sync itself (infinite loop prevention)
-    if: "!contains(github.event.head_commit.message, '[docs-sync]')"
+    if: >-
+      !contains(github.event.head_commit.message, '[docs-sync]') &&
+      !contains(github.event.head_commit.message, 'docs-sync/')
     runs-on: ubuntu-latest
     steps:
+      - name: Check for recent docs-sync activity
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Skip if a docs-sync PR was merged within the last 5 minutes
+          # (prevents re-trigger from conflict resolution merges)
+          RECENT_PR=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state merged \
+            --search "head:docs-sync/ merged:>=$(date -u -d '5 minutes ago' '+%Y-%m-%dT%H:%M:%S')" \
+            --json number,mergedAt \
+            --limit 1)
+
+          if [ "$(echo "$RECENT_PR" | jq length)" -gt 0 ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "⏭️ Skipping: docs-sync PR was recently merged"
+          fi
+
+          # Also skip if there's already an open docs-sync PR
+          OPEN_PR=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --search "head:docs-sync/" \
+            --json number \
+            --limit 1)
+
+          if [ "$(echo "$OPEN_PR" | jq length)" -gt 0 ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "⏭️ Skipping: docs-sync PR already open"
+          fi
+
       - name: Trigger docs-sync via Discord webhook
+        if: steps.check.outputs.skip != 'true'
         env:
           WEBHOOK_URL: ${{ secrets.DOCS_SYNC_WEBHOOK_URL }}
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
-# claude-code-discord-bridge
+# claude-code-discord-bridge (ccdb)
 
 Discord frontend for Claude Code CLI. **This is a framework (OSS library), not a personal bot.**
+
+**略称: ccdb** (claude-code-discord-bridge)
 
 ## Framework vs Instance
 


### PR DESCRIPTION
## Summary
- docs-sync PRのコンフリクト解決マージで再トリガーされ、重複PRが作られる問題を修正
- 3層のガードで無限ループを防止:
  1. コミットメッセージに `[docs-sync]` or `docs-sync/` ブランチ名 → ジョブスキップ
  2. 直近5分以内にdocs-sync PRがマージされている → webhookスキップ
  3. openなdocs-sync PRが既に存在する → webhookスキップ

## Test plan
- [ ] docs-sync以外のpushでworkflowが正常に発火することを確認
- [ ] docs-sync PRマージ後に再トリガーされないことを確認
- [ ] openなdocs-sync PRがある状態で新しいpushがあったとき、重複PRが作られないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)