### PR TITLE
docs: add /stop, attachments, and timeout notifications to README and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-02-19
+
+### Added
+- **`/stop` command** — Stop a running Claude Code session without clearing the session ID, so users can resume by sending a new message (unlike `/clear` which deletes the session)
+- **Attachment support** — Text-type file attachments (plain text, Markdown, CSV, JSON, XML, etc.) are automatically appended to the prompt; up to 5 files × 50 KB per file, 100 KB total
+- **Timeout notifications** — Dedicated timeout embed with elapsed seconds and actionable guidance replaces the generic error embed for `SESSION_TIMEOUT_SECONDS` timeouts
+
+### Changed
+- **Test coverage**: 131 → 152 tests
+
 ## [1.0.0] - 2026-02-19
 
 ### Added
@@ -39,5 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI pipeline: Python 3.10/3.11/3.12, ruff, pytest
 - Branch protection and PR workflow
 
+[1.1.0]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v0.1.0...v1.0.0
 [0.1.0]: https://github.com/ebibibi/claude-code-discord-bridge/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ GitHub PR (auto-merge)  ←  git push  ←  Claude Code  ←──┘
 - **Session persistence** — Continue conversations across messages via `--resume`
 - **Skill execution** — Run Claude Code skills (`/skill goodmorning`) via slash commands with autocomplete
 - **Concurrent sessions** — Run multiple sessions in parallel (configurable limit)
+- **Stop without clearing** — `/stop` halts a running session while preserving it for resume
+- **Attachment support** — Text-type file attachments are automatically appended to the prompt (up to 5 files, 50 KB each)
+- **Timeout notifications** — Dedicated embed with elapsed seconds and actionable guidance when a session times out
 
 ### CI/CD Automation
 - **Webhook triggers** — Trigger Claude Code tasks from GitHub Actions or any CI/CD system


### PR DESCRIPTION
## Summary
- Added `/stop`, attachment support, and timeout notification features to README Features section
- Added CHANGELOG entry for v1.1.0 with all three features

These were omitted from PR #10.