### PR TITLE
fix: trigger notify-upgrade on PR merged, not push (GITHUB_TOKEN limitation)

### DIFF
--- a/.github/workflows/notify-upgrade.yml
+++ b/.github/workflows/notify-upgrade.yml
@@ -1,13 +1,18 @@
 name: Notify EbiBot Upgrade
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches: [main]
 
 jobs:
   trigger-upgrade:
-    # Skip docs-sync commits (no code change = no upgrade needed)
-    if: "!contains(github.event.head_commit.message, '[docs-sync]')"
+    # Only run when a PR is actually merged (not just closed), and skip docs-sync PRs.
+    # Note: github.event.pull_request.title is used only in the if: expression,
+    # which is evaluated by GitHub Actions — not bash. No injection risk here.
+    if: |
+      github.event.pull_request.merged == true &&
+      !contains(github.event.pull_request.title, '[docs-sync]')
     runs-on: ubuntu-latest
     steps:
       - name: Trigger EbiBot auto-upgrade via Discord webhook


### PR DESCRIPTION
## Problem

`notify-upgrade.yml` was triggered by `push` to `main`, but PRs merged by `auto-approve-and-merge` use `GITHUB_TOKEN`. **GitHub intentionally does not fire push-triggered workflows when `GITHUB_TOKEN` performs the push** (prevents infinite loops). So EbiBot never received the upgrade webhook after recent merges.

## Fix

Switch the trigger from `push: branches: [main]` to `pull_request: types: [closed]`. The `pull_request` event fires reliably even when `GITHUB_TOKEN` merges the PR.

The `if:` condition filters to:
- `merged == true` (ignore PRs that were just closed without merging)
- `!contains(pr.title, '[docs-sync]')` (skip docs-only updates)

## Security note

`github.event.pull_request.title` appears in the `if:` expression only — evaluated by GitHub Actions' expression engine, not bash. No injection risk.