### PR TITLE
fix: remove spoiler from thinking embed, use plain code block (#12)

### DIFF
--- a/claude_discord/discord_ui/embeds.py
+++ b/claude_discord/discord_ui/embeds.py
@@ -90,17 +90,22 @@ def tool_result_embed(tool_title: str, result_content: str) -> discord.Embed:
 def thinking_embed(thinking_text: str) -> discord.Embed:
     """Create an embed for extended thinking content.
 
-    Wraps the text in a spoiler + code block so the revealed content is always
-    readable regardless of Discord theme (dark/light) or embed accent color.
+    Uses a plain code block (no spoiler) so the text is always rendered with
+    Discord's own code block background/foreground — guaranteed readable in
+    both dark and light themes regardless of the embed accent color.
+
+    Note: spoiler + code block combinations (||```text```||) do not apply code
+    block styling when revealed inside embed descriptions; the text still picks
+    up the embed accent color and can become unreadable.
     """
-    # Reserve chars for spoiler + code block markers: ||```\n...\n```|| = 14 chars overhead
-    max_text = 4096 - 14 - len("\n... (truncated)")
+    # Reserve chars for code block markers: ```\n...\n``` = 8 chars overhead
+    max_text = 4096 - 8 - len("\n... (truncated)")
     truncated = thinking_text[:max_text]
     if len(thinking_text) > max_text:
         truncated += "\n... (truncated)"
     return discord.Embed(
         title="\U0001f4ad Thinking",
-        description=f"||```\n{truncated}\n```||",
+        description=f"```\n{truncated}\n```",
         color=COLOR_THINKING,
     )
 

--- a/tests/test_embeds.py
+++ b/tests/test_embeds.py
@@ -6,12 +6,18 @@ from claude_discord.discord_ui.embeds import thinking_embed
 
 
 class TestThinkingEmbed:
-    def test_description_uses_spoiler_and_code_block(self) -> None:
-        """Thinking embed must use spoiler+code block for readability across all Discord themes."""
+    def test_description_uses_plain_code_block(self) -> None:
+        """Thinking embed must use a plain code block (no spoiler) for guaranteed readability.
+
+        spoiler+code block (||```text```||) does not apply code block styling
+        when revealed inside Discord embed descriptions — the embed accent color
+        bleeds into the revealed text, making it unreadable.
+        """
         embed = thinking_embed("Let me think about this.")
         assert embed.description is not None
-        assert embed.description.startswith("||```\n")
-        assert embed.description.endswith("\n```||")
+        assert embed.description.startswith("```\n")
+        assert embed.description.endswith("\n```")
+        assert "||" not in embed.description
 
     def test_thinking_text_preserved(self) -> None:
         """Original thinking text should appear inside the code block."""

--- a/tests/test_run_helper.py
+++ b/tests/test_run_helper.py
@@ -224,11 +224,12 @@ class TestRunClaudeInThread:
             and "Thinking" in (c.kwargs["embed"].title or "")
         ]
         assert len(thinking_embeds) == 1
-        # Description must use spoiler + code block for readability across all themes
+        # Description must use a plain code block (no spoiler) for guaranteed readability
         embed = thinking_embeds[0].kwargs["embed"]
         assert embed.description is not None
-        assert embed.description.startswith("||```")
-        assert embed.description.endswith("```||")
+        assert embed.description.startswith("```")
+        assert embed.description.endswith("```")
+        assert "||" not in embed.description
 
     @pytest.mark.asyncio
     async def test_error_handling(
@@ -278,9 +279,7 @@ class TestRunClaudeInThread:
         assert len(final_msgs) == 1
 
     @pytest.mark.asyncio
-    async def test_repo_none_skips_save(
-        self, thread: MagicMock, runner: MagicMock
-    ) -> None:
+    async def test_repo_none_skips_save(self, thread: MagicMock, runner: MagicMock) -> None:
         """When repo is None (automated workflows), session save should be skipped."""
         events = [
             StreamEvent(message_type=MessageType.SYSTEM, session_id="sess-1"),


### PR DESCRIPTION
## Summary

- Previous fix (#14) used `||```text```||` (spoiler + code block) — this does **not** apply code block styling when revealed inside Discord embed descriptions. The embed accent color (purple) still bled through, leaving the text unreadable.
- This fix removes the spoiler entirely and uses a plain code block, which Discord renders with its own fixed background/foreground colors — readable in both dark and light themes regardless of embed accent color.

## Changes

- `claude_discord/discord_ui/embeds.py` — `||```\ntext\n```||` → ` ```\ntext\n``` `
- `tests/test_embeds.py` — updated assertion: no spoiler, plain code block
- `tests/test_run_helper.py` — updated assertion to match

## Test plan

- [ ] All 26 tests pass
- [ ] Thinking content is readable when displayed in Discord (dark and light themes)

Closes #12