### PR TITLE
fix: add missing 'raw' field to StreamEvent dataclass

### DIFF
--- a/claude_discord/claude/types.py
+++ b/claude_discord/claude/types.py
@@ -99,6 +99,7 @@ class StreamEvent:
     """A parsed event from the Claude Code stream-json output."""
 
     message_type: MessageType
+    raw: dict = field(default_factory=dict)
     session_id: str | None = None
     text: str | None = None
     tool_use: ToolUseEvent | None = None


### PR DESCRIPTION
## Summary

- `runner.py` passes `raw={}` to `StreamEvent` constructor in timeout and CLI error paths
- But the `raw` field was never defined on the `StreamEvent` dataclass
- This causes `TypeError: StreamEvent.__init__() got an unexpected keyword argument 'raw'` at runtime
- Added `raw: dict` field with `field(default_factory=dict)` default

## Test plan

- [x] All 198 tests pass
- [x] ruff check + format pass