### PR TITLE
feat: add pyright type checking to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,8 @@ jobs:
       - name: Format check
         run: uv run ruff format --check claude_discord/
 
+      - name: Type check
+        run: uv run pyright claude_discord/
+
       - name: Test
         run: uv run pytest tests/ -v --cov=claude_discord --cov-report=term-missing

--- a/claude_discord/cogs/skill_command.py
+++ b/claude_discord/cogs/skill_command.py
@@ -185,10 +185,10 @@ class SkillCommandCog(commands.Cog):
         await interaction.response.defer()
 
         # In-thread mode: if invoked inside a thread under the claude channel, resume it
-        if self._is_claude_thread(interaction.channel):
-            thread = interaction.channel
+        channel = interaction.channel
+        if isinstance(channel, discord.Thread) and self._is_claude_thread(channel):
             session_id = None
-            record = await self.repo.get(thread.id)
+            record = await self.repo.get(channel.id)
             if record:
                 session_id = record.session_id
 
@@ -197,7 +197,7 @@ class SkillCommandCog(commands.Cog):
 
             runner = self.runner.clone()
             await run_claude_in_thread(
-                thread=thread,
+                thread=channel,
                 runner=runner,
                 repo=self.repo,
                 prompt=prompt,

--- a/claude_discord/database/notification_repo.py
+++ b/claude_discord/database/notification_repo.py
@@ -83,6 +83,7 @@ class NotificationRepository:
             )
             await db.commit()
             row_id = cursor.lastrowid
+        assert row_id is not None, "INSERT should always return a lastrowid"
         logger.info("Notification scheduled: id=%d, at=%s", row_id, scheduled_at)
         return row_id
 

--- a/claude_discord/discord_ui/status.py
+++ b/claude_discord/discord_ui/status.py
@@ -91,7 +91,9 @@ class StatusManager:
             self._debounce_task.cancel()
         if self._current_emoji:
             with contextlib.suppress(discord.HTTPException, AttributeError):
-                await self._message.remove_reaction(self._current_emoji, self._message.guild.me)
+                guild = self._message.guild
+                if guild:
+                    await self._message.remove_reaction(self._current_emoji, guild.me)
             self._current_emoji = None
 
     async def _set_status(self, emoji: str) -> None:
@@ -114,7 +116,9 @@ class StatusManager:
             # Remove old emoji
             if self._current_emoji:
                 with contextlib.suppress(discord.HTTPException, AttributeError):
-                    await self._message.remove_reaction(self._current_emoji, self._message.guild.me)
+                    guild = self._message.guild
+                    if guild:
+                        await self._message.remove_reaction(self._current_emoji, guild.me)
 
             # Add new emoji
             if self._target_emoji:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
     "pytest-cov>=5.0",
     "ruff>=0.4",
     "aiohttp>=3.9",
+    "pyright>=1.1.408",
 ]
 
 [tool.pytest.ini_options]
@@ -37,6 +38,10 @@ testpaths = ["tests"]
 [tool.ruff]
 target-version = "py311"
 line-length = 100
+
+[tool.pyright]
+pythonVersion = "3.10"
+typeCheckingMode = "basic"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP", "B", "A", "SIM"]

--- a/uv.lock
+++ b/uv.lock
@@ -258,6 +258,7 @@ api = [
 [package.dev-dependencies]
 dev = [
     { name = "aiohttp" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -276,6 +277,7 @@ provides-extras = ["api"]
 [package.metadata.requires-dev]
 dev = [
     { name = "aiohttp", specifier = ">=3.9" },
+    { name = "pyright", specifier = ">=1.1.408" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "pytest-cov", specifier = ">=5.0" },
@@ -712,6 +714,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -850,6 +861,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add **pyright** (basic mode) to CI pipeline to catch type errors before merge
- Prevents bugs like #20 where `runner.py` passed `raw={}` to `StreamEvent` but the field wasn't defined
- Fix all 12 existing type errors (Discord channel narrowing, aiohttp middleware signature, Optional access)

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | Add pyright to dev deps + config |
| `.github/workflows/ci.yml` | Add type check step |
| `cogs/skill_command.py` | Narrow `interaction.channel` to `Thread` before use |
| `database/notification_repo.py` | Assert `lastrowid` is not None |
| `discord_ui/status.py` | Guard `guild` access before `.me` |
| `ext/api_server.py` | Fix middleware handler type, guard `channel.send` |

## Test plan

- [x] `uv run pyright claude_discord/` — 0 errors
- [x] `uv run pytest tests/ -v` — 198 passed
- [x] `uv run ruff check claude_discord/` — clean

Closes #21