### PR TITLE
feat: Add /sync-sessions command and session filtering

### DIFF
--- a/claude_discord/cogs/session_manage.py
+++ b/claude_discord/cogs/session_manage.py
@@ -3,6 +3,7 @@
 Provides slash commands for viewing and managing Claude Code sessions:
 - /resume-info: Show CLI resume command for the current thread's session
 - /sessions: List all known sessions (Discord and CLI originated)
+- /sync-sessions: Import CLI sessions as Discord threads
 """
 
 from __future__ import annotations
@@ -15,7 +16,8 @@ from discord import app_commands
 from discord.ext import commands
 
 from ..database.repository import SessionRepository
-from ..discord_ui.embeds import COLOR_INFO
+from ..discord_ui.embeds import COLOR_INFO, COLOR_SUCCESS
+from ..session_sync import scan_cli_sessions
 
 if TYPE_CHECKING:
     from ..bot import ClaudeDiscordBot
@@ -27,17 +29,25 @@ _ORIGIN_ICON = {
     "cli": "\U0001f5a5\ufe0f",  # 🖥️
 }
 
+_ORIGIN_CHOICES = [
+    app_commands.Choice(name="All", value="all"),
+    app_commands.Choice(name="Discord", value="discord"),
+    app_commands.Choice(name="CLI", value="cli"),
+]
+
 
 class SessionManageCog(commands.Cog):
-    """Cog for session listing and resume info commands."""
+    """Cog for session listing, resume info, and CLI sync commands."""
 
     def __init__(
         self,
         bot: ClaudeDiscordBot,
         repo: SessionRepository,
+        cli_sessions_path: str | None = None,
     ) -> None:
         self.bot = bot
         self.repo = repo
+        self.cli_sessions_path = cli_sessions_path
 
     @app_commands.command(
         name="resume-info",
@@ -79,9 +89,17 @@ class SessionManageCog(commands.Cog):
         name="sessions",
         description="List all known Claude Code sessions",
     )
-    async def sessions_list(self, interaction: discord.Interaction) -> None:
+    @app_commands.describe(origin="Filter by session origin")
+    @app_commands.choices(origin=_ORIGIN_CHOICES)
+    async def sessions_list(
+        self,
+        interaction: discord.Interaction,
+        origin: str | None = None,
+    ) -> None:
         """List all sessions with origin, summary, and last activity."""
-        records = await self.repo.list_all(limit=25)
+        # Convert "all" to None for the repository
+        origin_filter = None if origin in (None, "all") else origin
+        records = await self.repo.list_all(limit=25, origin=origin_filter)
 
         if not records:
             embed = discord.Embed(
@@ -112,3 +130,96 @@ class SessionManageCog(commands.Cog):
             embed.add_field(name=name, value=value, inline=False)
 
         await interaction.response.send_message(embed=embed)
+
+    @app_commands.command(
+        name="sync-sessions",
+        description="Import CLI sessions from Claude Code as Discord threads",
+    )
+    async def sync_sessions(self, interaction: discord.Interaction) -> None:
+        """Scan CLI session storage and create threads for unknown sessions."""
+        if not self.cli_sessions_path:
+            await interaction.response.send_message(
+                "\u274c CLI sessions path is not configured. "
+                "Set `cli_sessions_path` when initializing SessionManageCog.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.defer()
+
+        cli_sessions = scan_cli_sessions(self.cli_sessions_path)
+        raw_channel = self.bot.get_channel(self.bot.channel_id)
+
+        imported = 0
+        skipped = 0
+
+        if not isinstance(raw_channel, discord.TextChannel):
+            logger.warning("Channel %d is not a TextChannel", self.bot.channel_id)
+            await interaction.followup.send(
+                embed=discord.Embed(
+                    title="\U0001f504 Session Sync Complete",
+                    description="Found **0** CLI session(s).\nChannel not available.",
+                    color=COLOR_SUCCESS,
+                )
+            )
+            return
+
+        channel: discord.TextChannel = raw_channel
+
+        for cli_session in cli_sessions:
+            # Check if already tracked
+            existing = await self.repo.get_by_session_id(cli_session.session_id)
+            if existing:
+                skipped += 1
+                continue
+
+            thread_name = (cli_session.summary or cli_session.session_id)[:100]
+            thread = await channel.create_thread(
+                name=f"\U0001f5a5 {thread_name}",
+                type=discord.ChannelType.public_thread,
+            )
+
+            # Save to DB
+            await self.repo.save(
+                thread_id=thread.id,
+                session_id=cli_session.session_id,
+                working_dir=cli_session.working_dir,
+                origin="cli",
+                summary=cli_session.summary,
+            )
+
+            # Post info embed in the thread
+            embed = discord.Embed(
+                title="\U0001f5a5\ufe0f Imported CLI Session",
+                description=(
+                    f"This thread is linked to a Claude Code CLI session.\n"
+                    f"Reply here to continue the conversation.\n\n"
+                    f"```\nclaude --resume {cli_session.session_id}\n```"
+                ),
+                color=COLOR_INFO,
+            )
+            if cli_session.working_dir:
+                embed.add_field(
+                    name="Working Directory",
+                    value=f"`{cli_session.working_dir}`",
+                    inline=True,
+                )
+            if cli_session.timestamp:
+                embed.add_field(name="Created", value=cli_session.timestamp[:10], inline=True)
+            embed.set_footer(text=f"Session: {cli_session.session_id[:8]}...")
+
+            await thread.send(embed=embed)
+            imported += 1
+
+        # Send result
+        total_found = len(cli_sessions)
+        embed = discord.Embed(
+            title="\U0001f504 Session Sync Complete",
+            description=(
+                f"Found **{total_found}** CLI session(s).\n"
+                f"\u2705 Imported: **{imported}**\n"
+                f"\u23ed\ufe0f Already synced: **{skipped}**"
+            ),
+            color=COLOR_SUCCESS,
+        )
+        await interaction.followup.send(embed=embed)

--- a/claude_discord/database/repository.py
+++ b/claude_discord/database/repository.py
@@ -87,14 +87,25 @@ class SessionRepository:
                 return None
             return SessionRecord(**dict(row))
 
-    async def list_all(self, limit: int = 50) -> list[SessionRecord]:
-        """List all sessions ordered by most recently used."""
+    async def list_all(self, limit: int = 50, origin: str | None = None) -> list[SessionRecord]:
+        """List all sessions ordered by most recently used.
+
+        Args:
+            limit: Maximum number of records to return.
+            origin: Optional filter by origin ('discord', 'cli'). None returns all.
+        """
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
-            cursor = await db.execute(
-                "SELECT * FROM sessions ORDER BY last_used_at DESC LIMIT ?",
-                (limit,),
-            )
+            if origin:
+                cursor = await db.execute(
+                    "SELECT * FROM sessions WHERE origin = ? ORDER BY last_used_at DESC LIMIT ?",
+                    (origin, limit),
+                )
+            else:
+                cursor = await db.execute(
+                    "SELECT * FROM sessions ORDER BY last_used_at DESC LIMIT ?",
+                    (limit,),
+                )
             rows = await cursor.fetchall()
             return [SessionRecord(**dict(row)) for row in rows]
 

--- a/tests/test_sync_command.py
+++ b/tests/test_sync_command.py
@@ -1,0 +1,240 @@
+"""Tests for /sync-sessions command and background sync task."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from claude_discord.database.models import init_db
+from claude_discord.database.repository import SessionRecord, SessionRepository
+
+
+@pytest.fixture
+async def repo(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    await init_db(db_path)
+    return SessionRepository(db_path)
+
+
+def _make_channel_interaction() -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = MagicMock(spec=discord.TextChannel)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _make_record(
+    thread_id: int = 100,
+    session_id: str = "abc-123",
+    origin: str = "discord",
+    summary: str | None = "Fix login bug",
+) -> SessionRecord:
+    return SessionRecord(
+        thread_id=thread_id,
+        session_id=session_id,
+        working_dir="/home/user",
+        model="sonnet",
+        origin=origin,
+        summary=summary,
+        created_at="2026-02-19 10:00:00",
+        last_used_at="2026-02-19 11:00:00",
+    )
+
+
+def _make_cog(
+    cli_sessions_path: str | None = None,
+    channel_id: int = 999,
+):
+    from claude_discord.cogs.session_manage import SessionManageCog
+
+    bot = MagicMock()
+    bot.channel_id = channel_id
+    # Mock get_channel to return an async-capable channel
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.id = channel_id
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = 50000
+    thread.send = AsyncMock()
+    channel.create_thread = AsyncMock(return_value=thread)
+    bot.get_channel = MagicMock(return_value=channel)
+    repo = MagicMock()
+    repo.get = AsyncMock(return_value=None)
+    repo.save = AsyncMock(return_value=_make_record())
+    repo.list_all = AsyncMock(return_value=[])
+    repo.get_by_session_id = AsyncMock(return_value=None)
+    return SessionManageCog(bot=bot, repo=repo, cli_sessions_path=cli_sessions_path)
+
+
+class TestSyncSessions:
+    """Test /sync-sessions command."""
+
+    async def test_sync_no_path_configured(self):
+        cog = _make_cog(cli_sessions_path=None)
+        interaction = _make_channel_interaction()
+        await cog.sync_sessions.callback(cog, interaction)
+        call_args = interaction.response.send_message.call_args
+        assert call_args.kwargs.get("ephemeral") is True
+        assert (
+            "not configured" in str(call_args).lower()
+            or "not configured" in str(call_args.args).lower()
+        )
+
+    async def test_sync_no_new_sessions(self, tmp_path):
+        cog = _make_cog(cli_sessions_path=str(tmp_path))
+        interaction = _make_channel_interaction()
+        await cog.sync_sessions.callback(cog, interaction)
+        # Should defer then send followup
+        interaction.response.defer.assert_called_once()
+        call_args = interaction.followup.send.call_args
+        embed = call_args.kwargs.get("embed")
+        assert embed is not None
+
+    async def test_sync_imports_cli_sessions(self, tmp_path):
+        # Create a CLI session JSONL
+        session_id = "aaa11111-1234-5678-9abc-def012345678"
+        jsonl_path = tmp_path / f"{session_id}.jsonl"
+        with open(jsonl_path, "w") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "type": "user",
+                        "isMeta": False,
+                        "sessionId": session_id,
+                        "cwd": "/home/user/project",
+                        "timestamp": "2026-02-19T10:00:00.000Z",
+                        "message": {"role": "user", "content": "Build the API"},
+                    }
+                )
+                + "\n"
+            )
+
+        cog = _make_cog(cli_sessions_path=str(tmp_path))
+        # Session not yet in DB
+        cog.repo.get_by_session_id = AsyncMock(return_value=None)
+        interaction = _make_channel_interaction()
+        await cog.sync_sessions.callback(cog, interaction)
+
+        # Should have created a thread
+        channel = cog.bot.get_channel(999)
+        channel.create_thread.assert_called_once()
+
+        # Should have saved to DB with origin='cli'
+        save_calls = cog.repo.save.call_args_list
+        assert len(save_calls) >= 1
+        save_kwargs = save_calls[0].kwargs
+        assert save_kwargs["origin"] == "cli"
+        assert save_kwargs["session_id"] == session_id
+
+    async def test_sync_skips_already_known_sessions(self, tmp_path):
+        session_id = "bbb22222-1234-5678-9abc-def012345678"
+        jsonl_path = tmp_path / f"{session_id}.jsonl"
+        with open(jsonl_path, "w") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "type": "user",
+                        "isMeta": False,
+                        "sessionId": session_id,
+                        "cwd": "/home",
+                        "timestamp": "2026-02-19T10:00:00.000Z",
+                        "message": {"role": "user", "content": "Already synced"},
+                    }
+                )
+                + "\n"
+            )
+
+        cog = _make_cog(cli_sessions_path=str(tmp_path))
+        # Session already in DB
+        cog.repo.get_by_session_id = AsyncMock(
+            return_value=_make_record(session_id=session_id, origin="cli")
+        )
+        interaction = _make_channel_interaction()
+        await cog.sync_sessions.callback(cog, interaction)
+
+        # Should NOT create a thread
+        channel = cog.bot.get_channel(999)
+        channel.create_thread.assert_not_called()
+
+
+class TestSyncSessionsEmbed:
+    """Test the sync result embed."""
+
+    async def test_sync_result_shows_count(self, tmp_path):
+        # Create 2 CLI sessions
+        for i, sid in enumerate(
+            ["ccc33333-1234-5678-9abc-def012345678", "ddd44444-1234-5678-9abc-def012345678"]
+        ):
+            jsonl_path = tmp_path / f"{sid}.jsonl"
+            with open(jsonl_path, "w") as f:
+                f.write(
+                    json.dumps(
+                        {
+                            "type": "user",
+                            "isMeta": False,
+                            "sessionId": sid,
+                            "cwd": f"/home/proj{i}",
+                            "timestamp": f"2026-02-19T1{i}:00:00.000Z",
+                            "message": {"role": "user", "content": f"Task {i}"},
+                        }
+                    )
+                    + "\n"
+                )
+
+        cog = _make_cog(cli_sessions_path=str(tmp_path))
+        cog.repo.get_by_session_id = AsyncMock(return_value=None)
+        interaction = _make_channel_interaction()
+        await cog.sync_sessions.callback(cog, interaction)
+
+        embed = interaction.followup.send.call_args.kwargs["embed"]
+        assert "2" in embed.description  # Should mention 2 imported
+
+
+class TestListAllWithOriginFilter:
+    """Test list_all with origin filter in repository."""
+
+    async def test_list_all_filter_by_origin(self, repo):
+        await repo.save(thread_id=5000, session_id="disc-1", origin="discord")
+        await repo.save(thread_id=5001, session_id="cli-1", origin="cli")
+        await repo.save(thread_id=5002, session_id="cli-2", origin="cli")
+
+        cli_only = await repo.list_all(origin="cli")
+        assert len(cli_only) == 2
+        assert all(r.origin == "cli" for r in cli_only)
+
+        discord_only = await repo.list_all(origin="discord")
+        assert len(discord_only) == 1
+        assert discord_only[0].origin == "discord"
+
+    async def test_list_all_no_filter_returns_all(self, repo):
+        await repo.save(thread_id=5100, session_id="d1", origin="discord")
+        await repo.save(thread_id=5101, session_id="c1", origin="cli")
+        all_sessions = await repo.list_all()
+        assert len(all_sessions) == 2
+
+
+class TestSessionsFilterCommand:
+    """Test /sessions with origin filter parameter."""
+
+    async def test_sessions_filter_cli(self):
+        cog = _make_cog()
+        records = [
+            _make_record(session_id="c1", origin="cli", summary="CLI only"),
+        ]
+        cog.repo.list_all = AsyncMock(return_value=records)
+        interaction = _make_channel_interaction()
+        await cog.sessions_list.callback(cog, interaction, origin="cli")
+        cog.repo.list_all.assert_called_once_with(limit=25, origin="cli")
+
+    async def test_sessions_filter_all(self):
+        cog = _make_cog()
+        cog.repo.list_all = AsyncMock(return_value=[])
+        interaction = _make_channel_interaction()
+        await cog.sessions_list.callback(cog, interaction, origin=None)
+        cog.repo.list_all.assert_called_once_with(limit=25, origin=None)


### PR DESCRIPTION
## Summary

Phase 2 & 3 of session sync (#29):
- **`/sync-sessions`**: Scans `~/.claude/projects/` for CLI sessions, creates Discord threads for each untracked session, saves with `origin='cli'`
- **`/sessions` filter**: Now accepts an origin parameter (All/Discord/CLI) via Discord's choices UI
- **`list_all(origin=)` filter**: Repository method supports filtering by origin
- Proper `isinstance` type narrowing for `TextChannel` (pyright clean)

## How /sync-sessions works

1. Scans configured `cli_sessions_path` (typically `~/.claude/projects/`)
2. For each CLI session JSONL file, extracts session ID, first user prompt, working dir
3. Checks if session is already tracked in DB (by session_id)
4. If new: creates a Discord thread with 🖥 prefix, posts info embed with resume command
5. Reports import count vs skipped count

## Test plan

- [x] 9 new tests for /sync-sessions + filtering
- [x] Full suite: 249 passed, 80% coverage
- [x] pyright: 0 errors
- [x] ruff: clean

Closes #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)