### PR TITLE
fix: add merge-wait + webhook to auto-approve workflow

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -20,3 +20,25 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --squash
+      - name: Wait for merge and notify EbiBot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          WEBHOOK_URL: ${{ secrets.DOCS_SYNC_WEBHOOK_URL }}
+        run: |
+          # GITHUB_TOKEN merges don't trigger other workflows (push/PR events).
+          # So we poll for merge completion and send the webhook directly.
+          for i in $(seq 1 30); do
+            STATE=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state -q .state)
+            if [ "$STATE" = "MERGED" ]; then
+              echo "PR merged! Sending upgrade webhook..."
+              curl -s -o /dev/null -w "%{http_code}" \
+                -H "Content-Type: application/json" \
+                -d '{"content":"🔄 ebibot-upgrade"}' \
+                "$WEBHOOK_URL"
+              exit 0
+            fi
+            echo "Waiting for merge... ($i/30)"
+            sleep 10
+          done
+          echo "PR not merged within 5 minutes, skipping webhook"


### PR DESCRIPTION
## Summary
- GITHUB_TOKEN-triggered events don't propagate to other workflows (both `push` and `pull_request:closed`)
- This means `notify-upgrade.yml` never fires after auto-merged PRs
- Solution: poll for merge completion directly in `auto-approve.yml` and send the Discord webhook inline
- Polls every 10s for up to 5 minutes, then gives up gracefully

## Test plan
- [ ] This PR itself will be the first test — if EbiBot auto-upgrades after merge, it works!
- [ ] Verify the webhook message appears in Discord