### PR TITLE
perf: add limit and max_lines to scan_cli_sessions

### DIFF
--- a/claude_discord/cogs/session_manage.py
+++ b/claude_discord/cogs/session_manage.py
@@ -8,6 +8,7 @@ Provides slash commands for viewing and managing Claude Code sessions:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING
 
@@ -147,7 +148,8 @@ class SessionManageCog(commands.Cog):
 
         await interaction.response.defer()
 
-        cli_sessions = scan_cli_sessions(self.cli_sessions_path)
+        # Run CPU/IO-heavy scan in a thread to avoid blocking the event loop
+        cli_sessions = await asyncio.to_thread(scan_cli_sessions, self.cli_sessions_path)
         raw_channel = self.bot.get_channel(self.bot.channel_id)
 
         imported = 0


### PR DESCRIPTION
## Summary
- **Root cause**: /sync-sessions was hanging for 10+ minutes on systems with 1,658 session files (1.5GB total)
- Add `limit` param (default 50) — only parse newest N files by mtime
- Add `max_lines_per_file` param (default 20) — stop reading after N lines per file
- Run `scan_cli_sessions` via `asyncio.to_thread` to avoid blocking Discord event loop
- 3 new tests for limit, limit=0, and max_lines behavior

## Test plan
- [x] All 252 tests pass
- [x] ruff check passes
- [ ] /sync-sessions completes in seconds instead of 10+ minutes