### PR TITLE
fix: handle content blocks list in session scanner

### DIFF
--- a/claude_discord/session_sync.py
+++ b/claude_discord/session_sync.py
@@ -119,6 +119,18 @@ def _parse_session_file(path: Path, *, max_lines: int = 20) -> CliSession | None
 
                 content = data.get("message", {}).get("content", "")
 
+                # content can be a list of content blocks — extract text
+                if isinstance(content, list):
+                    text_parts = [
+                        block.get("text", "")
+                        for block in content
+                        if isinstance(block, dict) and block.get("type") == "text"
+                    ]
+                    content = " ".join(text_parts) if text_parts else ""
+
+                if not isinstance(content, str) or not content:
+                    continue
+
                 # Skip XML-prefixed content (internal commands)
                 if content.startswith("<"):
                     continue

--- a/tests/test_session_sync.py
+++ b/tests/test_session_sync.py
@@ -152,6 +152,34 @@ class TestScanCliSessions:
         sessions = scan_cli_sessions(str(tmp_path))
         assert sessions[0].summary == "Real prompt here"
 
+    def test_scan_handles_content_blocks_list(self, tmp_path):
+        """Content can be a list of content blocks instead of a string."""
+        session_id = "444ddddd-1234-5678-9abc-def012345678"
+        _write_session_jsonl(
+            tmp_path / f"{session_id}.jsonl",
+            session_id,
+            [
+                {
+                    "type": "user",
+                    "isMeta": False,
+                    "sessionId": session_id,
+                    "cwd": "/home/project",
+                    "timestamp": "2026-02-19T10:00:00.000Z",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "Fix the login bug"},
+                            {"type": "text", "text": " and add tests"},
+                        ],
+                    },
+                },
+            ],
+        )
+        sessions = scan_cli_sessions(str(tmp_path))
+        assert len(sessions) == 1
+        assert "Fix the login bug" in sessions[0].summary
+        assert "add tests" in sessions[0].summary
+
     def test_scan_skips_xml_prefixed_content(self, tmp_path):
         session_id = "111aaaaa-1234-5678-9abc-def012345678"
         _write_session_jsonl(


### PR DESCRIPTION
## Summary
- Claude Code messages can have `content` as a list of content blocks (`[{"type": "text", "text": "..."}]`) instead of a plain string
- This caused `AttributeError: 'list' object has no attribute 'startswith'` in `_parse_session_file()`, silently crashing `/sync-sessions`
- Now extracts text from content blocks and joins them

## Test plan
- [x] New test: `test_scan_handles_content_blocks_list` — verifies list content is parsed
- [x] All 253 tests pass
- [x] Verified locally against real `~/.claude/projects/` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)