### PR TITLE
feat: post recent messages in synced session threads

### DIFF
--- a/claude_discord/__init__.py
+++ b/claude_discord/__init__.py
@@ -27,7 +27,7 @@ from .discord_ui.embeds import (
 )
 from .discord_ui.status import StatusManager
 from .protocols import DrainAware
-from .session_sync import CliSession, scan_cli_sessions
+from .session_sync import CliSession, SessionMessage, extract_recent_messages, scan_cli_sessions
 
 __all__ = [
     # Core
@@ -38,6 +38,8 @@ __all__ = [
     "SessionRepository",
     # Session Sync
     "CliSession",
+    "SessionMessage",
+    "extract_recent_messages",
     "scan_cli_sessions",
     # Webhook & Automation
     "WebhookTriggerCog",


### PR DESCRIPTION
## Summary
- `/sync-sessions` now posts the last 6 conversation messages (user + assistant) in each imported thread
- Users can see what a session was about without having to `claude --resume` it
- Content text extraction refactored into shared `_extract_content_text()` helper
- New `SessionMessage` dataclass and `extract_recent_messages()` public API

## Test plan
- [x] 7 new tests for `extract_recent_messages()` (basic, last-N, truncation, meta/XML skip, not-found, content blocks, subdirectory)
- [x] All 260 tests pass
- [x] Messages split into Discord-safe chunks (< 2000 chars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)