### PR TITLE
feat: configurable thread style for session sync

### DIFF
--- a/claude_discord/__init__.py
+++ b/claude_discord/__init__.py
@@ -18,6 +18,7 @@ from .cogs.skill_command import SkillCommandCog
 from .cogs.webhook_trigger import WebhookTrigger, WebhookTriggerCog
 from .database.notification_repo import NotificationRepository
 from .database.repository import SessionRepository
+from .database.settings_repo import SettingsRepository
 from .discord_ui.chunker import chunk_message
 from .discord_ui.embeds import (
     error_embed,
@@ -36,6 +37,7 @@ __all__ = [
     "SessionManageCog",
     "SkillCommandCog",
     "SessionRepository",
+    "SettingsRepository",
     # Session Sync
     "CliSession",
     "SessionMessage",

--- a/claude_discord/database/models.py
+++ b/claude_discord/database/models.py
@@ -23,6 +23,11 @@ CREATE TABLE IF NOT EXISTS sessions (
 
 CREATE INDEX IF NOT EXISTS idx_sessions_last_used ON sessions(last_used_at);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_session_id ON sessions(session_id);
+
+CREATE TABLE IF NOT EXISTS settings (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
 """
 
 # Migrations for existing databases that lack new columns.

--- a/claude_discord/database/settings_repo.py
+++ b/claude_discord/database/settings_repo.py
@@ -1,0 +1,50 @@
+"""Key-value settings repository for bot configuration."""
+
+from __future__ import annotations
+
+import logging
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+
+class SettingsRepository:
+    """Simple key-value store for bot settings, persisted in SQLite."""
+
+    def __init__(self, db_path: str) -> None:
+        self.db_path = db_path
+
+    async def get(self, key: str, *, default: str | None = None) -> str | None:
+        """Get a setting value by key. Returns default if not found."""
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                "SELECT value FROM settings WHERE key = ?",
+                (key,),
+            )
+            row = await cursor.fetchone()
+            return row[0] if row else default
+
+    async def set(self, key: str, value: str) -> None:
+        """Set a setting value. Creates or overwrites."""
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                "INSERT INTO settings (key, value) VALUES (?, ?)"
+                " ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                (key, value),
+            )
+            await db.commit()
+
+    async def delete(self, key: str) -> bool:
+        """Delete a setting. Returns True if a row was deleted."""
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute("DELETE FROM settings WHERE key = ?", (key,))
+            await db.commit()
+            return cursor.rowcount > 0
+
+    async def get_all(self) -> dict[str, str]:
+        """Get all settings as a dict."""
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute("SELECT key, value FROM settings ORDER BY key")
+            rows = await cursor.fetchall()
+            return {row[0]: row[1] for row in rows}

--- a/tests/test_settings_repo.py
+++ b/tests/test_settings_repo.py
@@ -1,0 +1,56 @@
+"""Tests for SettingsRepository — key-value bot settings persistence."""
+
+from __future__ import annotations
+
+import pytest
+
+from claude_discord.database.models import init_db
+from claude_discord.database.settings_repo import SettingsRepository
+
+
+@pytest.fixture
+async def repo(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    await init_db(db_path)
+    return SettingsRepository(db_path)
+
+
+class TestSettingsRepository:
+    async def test_get_returns_none_for_missing_key(self, repo):
+        result = await repo.get("nonexistent")
+        assert result is None
+
+    async def test_get_returns_default_for_missing_key(self, repo):
+        result = await repo.get("nonexistent", default="fallback")
+        assert result == "fallback"
+
+    async def test_set_and_get(self, repo):
+        await repo.set("sync_thread_style", "message")
+        result = await repo.get("sync_thread_style")
+        assert result == "message"
+
+    async def test_set_overwrites_existing(self, repo):
+        await repo.set("sync_thread_style", "message")
+        await repo.set("sync_thread_style", "channel")
+        result = await repo.get("sync_thread_style")
+        assert result == "channel"
+
+    async def test_delete(self, repo):
+        await repo.set("key", "value")
+        deleted = await repo.delete("key")
+        assert deleted is True
+        assert await repo.get("key") is None
+
+    async def test_delete_nonexistent(self, repo):
+        deleted = await repo.delete("nonexistent")
+        assert deleted is False
+
+    async def test_get_all(self, repo):
+        await repo.set("a", "1")
+        await repo.set("b", "2")
+        all_settings = await repo.get_all()
+        assert all_settings == {"a": "1", "b": "2"}
+
+    async def test_get_all_empty(self, repo):
+        all_settings = await repo.get_all()
+        assert all_settings == {}

--- a/tests/test_sync_settings.py
+++ b/tests/test_sync_settings.py
@@ -1,0 +1,175 @@
+"""Tests for /sync-settings command and thread style switching."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+
+from claude_discord.database.repository import SessionRecord
+
+
+def _make_record(
+    thread_id: int = 100,
+    session_id: str = "abc-123",
+    origin: str = "cli",
+    summary: str | None = "Test session",
+) -> SessionRecord:
+    return SessionRecord(
+        thread_id=thread_id,
+        session_id=session_id,
+        working_dir="/home/user",
+        model="sonnet",
+        origin=origin,
+        summary=summary,
+        created_at="2026-02-19 10:00:00",
+        last_used_at="2026-02-19 11:00:00",
+    )
+
+
+def _make_interaction() -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = MagicMock(spec=discord.TextChannel)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _make_cog(
+    cli_sessions_path: str | None = None,
+    channel_id: int = 999,
+):
+    from claude_discord.cogs.session_manage import SessionManageCog
+
+    bot = MagicMock()
+    bot.channel_id = channel_id
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.id = channel_id
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = 50000
+    thread.send = AsyncMock()
+    # For message-based threads: channel.send() returns msg, msg.create_thread()
+    summary_msg = MagicMock()
+    summary_msg.create_thread = AsyncMock(return_value=thread)
+    channel.send = AsyncMock(return_value=summary_msg)
+    # For channel-based threads: channel.create_thread()
+    channel.create_thread = AsyncMock(return_value=thread)
+    bot.get_channel = MagicMock(return_value=channel)
+
+    repo = MagicMock()
+    repo.get = AsyncMock(return_value=None)
+    repo.save = AsyncMock(return_value=_make_record())
+    repo.list_all = AsyncMock(return_value=[])
+    repo.get_by_session_id = AsyncMock(return_value=None)
+
+    settings_repo = MagicMock()
+    settings_repo.get = AsyncMock(return_value=None)
+    settings_repo.set = AsyncMock()
+
+    return SessionManageCog(
+        bot=bot,
+        repo=repo,
+        cli_sessions_path=cli_sessions_path,
+        settings_repo=settings_repo,
+    )
+
+
+class TestSyncSettings:
+    """Test /sync-settings command."""
+
+    async def test_shows_current_style_default_channel(self):
+        """When no setting is stored, shows 'channel' as current."""
+        cog = _make_cog()
+        cog.settings_repo.get = AsyncMock(return_value=None)
+        interaction = _make_interaction()
+        await cog.sync_settings.callback(cog, interaction)
+        call_args = interaction.response.send_message.call_args
+        embed = call_args.kwargs.get("embed")
+        assert embed is not None
+        assert "channel" in embed.description.lower()
+
+    async def test_shows_current_style_message(self):
+        """When setting is 'message', shows it."""
+        cog = _make_cog()
+        cog.settings_repo.get = AsyncMock(return_value="message")
+        interaction = _make_interaction()
+        await cog.sync_settings.callback(cog, interaction)
+        call_args = interaction.response.send_message.call_args
+        embed = call_args.kwargs.get("embed")
+        assert embed is not None
+        assert "message" in embed.description.lower()
+
+
+class TestSyncThreadStyleChannel:
+    """Test that sync_sessions uses channel threads when style is 'channel'."""
+
+    async def test_channel_style_uses_create_thread(self, tmp_path):
+        """With channel style, should use channel.create_thread() directly."""
+        import json
+
+        session_id = "aaa11111-1234-5678-9abc-def012345678"
+        jsonl_path = tmp_path / f"{session_id}.jsonl"
+        with open(jsonl_path, "w") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "type": "user",
+                        "isMeta": False,
+                        "sessionId": session_id,
+                        "cwd": "/home/user/project",
+                        "timestamp": "2026-02-19T10:00:00.000Z",
+                        "message": {"role": "user", "content": "Build the API"},
+                    }
+                )
+                + "\n"
+            )
+
+        cog = _make_cog(cli_sessions_path=str(tmp_path))
+        # Default style = channel
+        cog.settings_repo.get = AsyncMock(return_value=None)
+        interaction = _make_interaction()
+        await cog.sync_sessions.callback(cog, interaction)
+
+        channel = cog.bot.get_channel(999)
+        # Channel style: should call channel.create_thread, NOT channel.send
+        channel.create_thread.assert_called_once()
+        # channel.send should NOT be called for the summary message
+        # (it's only used in message style)
+        channel.send.assert_not_called()
+
+    async def test_message_style_uses_msg_create_thread(self, tmp_path):
+        """With message style, should post embed then create thread from it."""
+        import json
+
+        session_id = "bbb22222-1234-5678-9abc-def012345678"
+        jsonl_path = tmp_path / f"{session_id}.jsonl"
+        with open(jsonl_path, "w") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "type": "user",
+                        "isMeta": False,
+                        "sessionId": session_id,
+                        "cwd": "/home/user/project",
+                        "timestamp": "2026-02-19T10:00:00.000Z",
+                        "message": {"role": "user", "content": "Fix bug"},
+                    }
+                )
+                + "\n"
+            )
+
+        cog = _make_cog(cli_sessions_path=str(tmp_path))
+        cog.settings_repo.get = AsyncMock(return_value="message")
+        interaction = _make_interaction()
+        await cog.sync_sessions.callback(cog, interaction)
+
+        channel = cog.bot.get_channel(999)
+        # Message style: should call channel.send (embed), then msg.create_thread
+        channel.send.assert_called_once()
+        summary_msg = channel.send.return_value
+        summary_msg.create_thread.assert_called_once()
+        # channel.create_thread should NOT be called directly
+        channel.create_thread.assert_not_called()


### PR DESCRIPTION
## Summary
- Add `/sync-settings` slash command to switch between **channel threads** (hidden in Threads panel) and **message threads** (visible in channel)
- New `SettingsRepository` — generic key-value persistence for bot settings
- `sync_sessions` respects the configured thread style setting
- Default style: **channel** (keeps the main channel clean when syncing many sessions)

## Changes
- `claude_discord/database/settings_repo.py` — New key-value settings repository
- `claude_discord/database/models.py` — Added `settings` table to schema
- `claude_discord/cogs/session_manage.py` — Added `/sync-settings` command, thread style branching in `sync_sessions`
- `claude_discord/__init__.py` — Export `SettingsRepository`
- `tests/test_settings_repo.py` — 8 tests (100% coverage)
- `tests/test_sync_settings.py` — 4 tests for command and thread style switching

## Test plan
- [x] All 272 tests pass
- [x] Ruff lint + format clean
- [x] 81% overall coverage, 100% on settings_repo, 92% on session_manage
- [ ] Manual test: `/sync-settings` shows current style
- [ ] Manual test: `/sync-settings thread_style:Message threads` updates setting
- [ ] Manual test: `/sync-sessions` creates threads in the selected style

🤖 Generated with [Claude Code](https://claude.com/claude-code)