### PR TITLE
feat: add concurrency awareness for multiple simultaneous sessions

### DIFF
--- a/claude_discord/__init__.py
+++ b/claude_discord/__init__.py
@@ -16,6 +16,7 @@ from .cogs.claude_chat import ClaudeChatCog
 from .cogs.session_manage import SessionManageCog
 from .cogs.skill_command import SkillCommandCog
 from .cogs.webhook_trigger import WebhookTrigger, WebhookTriggerCog
+from .concurrency import ActiveSession, SessionRegistry
 from .database.notification_repo import NotificationRepository
 from .database.repository import SessionRepository
 from .database.settings_repo import SettingsRepository
@@ -34,6 +35,9 @@ __all__ = [
     # Core
     "ClaudeRunner",
     "ClaudeChatCog",
+    # Concurrency
+    "ActiveSession",
+    "SessionRegistry",
     "SessionManageCog",
     "SkillCommandCog",
     "SessionRepository",

--- a/claude_discord/cogs/skill_command.py
+++ b/claude_discord/cogs/skill_command.py
@@ -25,6 +25,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from ..claude.runner import ClaudeRunner
+from ..concurrency import SessionRegistry
 from ..database.repository import SessionRepository
 from ._run_helper import run_claude_in_thread
 
@@ -86,12 +87,14 @@ class SkillCommandCog(commands.Cog):
         claude_channel_id: int,
         skills_dir: Path | str | None = None,
         allowed_user_ids: set[int] | None = None,
+        registry: SessionRegistry | None = None,
     ) -> None:
         self.bot = bot
         self.repo = repo
         self.runner = runner
         self.claude_channel_id = claude_channel_id
         self._allowed_user_ids = allowed_user_ids
+        self._registry = registry
 
         # Default to ~/.claude/skills/
         if skills_dir is None:
@@ -201,6 +204,7 @@ class SkillCommandCog(commands.Cog):
                 repo=self.repo,
                 prompt=prompt,
                 session_id=session_id,
+                registry=self._registry,
             )
             return
 
@@ -227,4 +231,5 @@ class SkillCommandCog(commands.Cog):
             repo=self.repo,
             prompt=prompt,
             session_id=None,
+            registry=self._registry,
         )

--- a/claude_discord/cogs/webhook_trigger.py
+++ b/claude_discord/cogs/webhook_trigger.py
@@ -21,6 +21,7 @@ import discord
 from discord.ext import commands
 
 from ..cogs._run_helper import run_claude_in_thread
+from ..concurrency import SessionRegistry
 
 if TYPE_CHECKING:
     from ..claude.runner import ClaudeRunner
@@ -70,12 +71,14 @@ class WebhookTriggerCog(commands.Cog):
         triggers: dict[str, WebhookTrigger],
         allowed_webhook_ids: set[int] | None = None,
         channel_ids: set[int] | None = None,
+        registry: SessionRegistry | None = None,
     ) -> None:
         self.bot = bot
         self.runner = runner
         self.triggers = triggers
         self.allowed_webhook_ids = allowed_webhook_ids
         self.channel_ids = channel_ids
+        self._registry = registry
         self._locks: dict[str, asyncio.Lock] = {prefix: asyncio.Lock() for prefix in triggers}
         self._active_count: int = 0
 
@@ -152,6 +155,7 @@ class WebhookTriggerCog(commands.Cog):
                 prompt=trigger.prompt,
                 session_id=None,
                 status=None,
+                registry=self._registry,
             )
 
             if session_id:

--- a/claude_discord/concurrency.py
+++ b/claude_discord/concurrency.py
@@ -1,0 +1,126 @@
+"""Concurrency awareness for multiple simultaneous Claude Code sessions.
+
+Layer 1: Every session receives a generic concurrency warning in its prompt.
+Layer 2: An in-memory registry tracks active sessions so each one knows
+         what others are doing and can avoid conflicts.
+
+See: https://github.com/ebibibi/claude-code-discord-bridge/issues/52
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+
+# ---------------------------------------------------------------------------
+# Layer 2: Active Session Registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ActiveSession:
+    """Tracks a single active Claude Code session."""
+
+    thread_id: int
+    description: str
+    working_dir: str | None = None
+
+
+_BASE_CONCURRENCY_NOTICE = """\
+[CONCURRENCY NOTICE] You are running via Discord. \
+Multiple Claude Code sessions may be active simultaneously. \
+To avoid conflicts:
+
+- **Git**: Before making changes, create a branch or worktree \
+(`git worktree add ../wt-{thread_id} -b session/{thread_id}`). \
+Always commit and push before finishing — uncommitted changes in a shared \
+working directory WILL be lost when another session switches branches.
+- **Files**: Another session may be editing the same files outside of git. \
+Check for recent modifications before overwriting.
+- **Ports & processes**: Shared network ports or lock files may already be in use. \
+Verify availability before binding.
+- **Resources**: Shared databases, APIs with rate limits, or singleton processes \
+may be accessed by other sessions concurrently.
+
+If you detect a potential conflict with another session, \
+stop and warn the user before proceeding.\
+"""
+
+_OTHER_SESSIONS_HEADER = """
+Currently active sessions (avoid conflicts with these):
+"""
+
+
+class SessionRegistry:
+    """Thread-safe registry of active Claude Code sessions.
+
+    Designed to be shared across all Cogs in a single bot instance.
+    """
+
+    def __init__(self) -> None:
+        self._sessions: dict[int, ActiveSession] = {}
+        self._lock = threading.Lock()
+
+    def register(
+        self,
+        thread_id: int,
+        description: str,
+        working_dir: str | None = None,
+    ) -> None:
+        """Register or replace an active session."""
+        with self._lock:
+            self._sessions[thread_id] = ActiveSession(
+                thread_id=thread_id,
+                description=description,
+                working_dir=working_dir,
+            )
+
+    def unregister(self, thread_id: int) -> None:
+        """Remove a session from the registry."""
+        with self._lock:
+            self._sessions.pop(thread_id, None)
+
+    def update(
+        self,
+        thread_id: int,
+        *,
+        description: str | None = None,
+        working_dir: str | None = None,
+    ) -> None:
+        """Update fields of an existing session. No-op if not registered."""
+        with self._lock:
+            session = self._sessions.get(thread_id)
+            if session is None:
+                return
+            if description is not None:
+                session.description = description
+            if working_dir is not None:
+                session.working_dir = working_dir
+
+    def list_active(self) -> list[ActiveSession]:
+        """Return all active sessions."""
+        with self._lock:
+            return list(self._sessions.values())
+
+    def list_others(self, thread_id: int) -> list[ActiveSession]:
+        """Return all active sessions except the given thread."""
+        with self._lock:
+            return [s for s in self._sessions.values() if s.thread_id != thread_id]
+
+    def build_concurrency_notice(self, thread_id: int) -> str:
+        """Build the full concurrency notice for a session.
+
+        Combines the base Layer 1 warning with Layer 2 context about
+        other active sessions.
+        """
+        notice = _BASE_CONCURRENCY_NOTICE.format(thread_id=thread_id)
+        others = self.list_others(thread_id)
+        if others:
+            notice += _OTHER_SESSIONS_HEADER
+            for s in others:
+                line = f"- {s.description}"
+                if s.working_dir:
+                    line += f" (working in {s.working_dir})"
+                notice += line + "\n"
+            notice += "\nIf your work may conflict with any of the above, stop and warn the user.\n"
+        return notice

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -113,10 +113,13 @@ class TestNotify:
 class TestSchedule:
     @pytest.mark.asyncio
     async def test_schedule_creates_notification(self, client: TestClient) -> None:
-        resp = await client.post("/api/schedule", json={
-            "message": "Reminder",
-            "scheduled_at": "2026-01-01T09:00:00",
-        })
+        resp = await client.post(
+            "/api/schedule",
+            json={
+                "message": "Reminder",
+                "scheduled_at": "2026-01-01T09:00:00",
+            },
+        )
         assert resp.status == 200
         data = await resp.json()
         assert data["status"] == "scheduled"
@@ -134,10 +137,13 @@ class TestSchedule:
 
     @pytest.mark.asyncio
     async def test_schedule_invalid_time(self, client: TestClient) -> None:
-        resp = await client.post("/api/schedule", json={
-            "message": "test",
-            "scheduled_at": "not-a-date",
-        })
+        resp = await client.post(
+            "/api/schedule",
+            json={
+                "message": "test",
+                "scheduled_at": "not-a-date",
+            },
+        )
         assert resp.status == 400
 
 
@@ -151,10 +157,13 @@ class TestListScheduled:
 
     @pytest.mark.asyncio
     async def test_list_after_schedule(self, client: TestClient) -> None:
-        await client.post("/api/schedule", json={
-            "message": "test",
-            "scheduled_at": "2026-01-01T09:00:00",
-        })
+        await client.post(
+            "/api/schedule",
+            json={
+                "message": "test",
+                "scheduled_at": "2026-01-01T09:00:00",
+            },
+        )
         resp = await client.get("/api/scheduled")
         data = await resp.json()
         assert len(data["notifications"]) == 1
@@ -163,10 +172,13 @@ class TestListScheduled:
 class TestCancelScheduled:
     @pytest.mark.asyncio
     async def test_cancel_existing(self, client: TestClient) -> None:
-        resp = await client.post("/api/schedule", json={
-            "message": "test",
-            "scheduled_at": "2026-01-01T09:00:00",
-        })
+        resp = await client.post(
+            "/api/schedule",
+            json={
+                "message": "test",
+                "scheduled_at": "2026-01-01T09:00:00",
+            },
+        )
         nid = (await resp.json())["id"]
         resp = await client.delete(f"/api/scheduled/{nid}")
         assert resp.status == 200

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -35,11 +35,7 @@ class TestNoDirectRunnerRunInCogs:
 
     def _get_cog_files(self) -> list[Path]:
         """Return all .py files in cogs/ except _run_helper.py."""
-        return [
-            f
-            for f in COGS_DIR.glob("*.py")
-            if f.name not in ("_run_helper.py", "__init__.py")
-        ]
+        return [f for f in COGS_DIR.glob("*.py") if f.name not in ("_run_helper.py", "__init__.py")]
 
     def test_no_direct_runner_run_in_cogs(self) -> None:
         """No Cog file should call runner.run() directly."""
@@ -51,14 +47,13 @@ class TestNoDirectRunnerRunInCogs:
                 lines = content.splitlines()
                 for match in matches:
                     # Find line number
-                    line_no = content[:match.start()].count("\n") + 1
+                    line_no = content[: match.start()].count("\n") + 1
                     violations.append(f"  {cog_file.name}:{line_no}: {lines[line_no - 1].strip()}")
 
         if violations:
             msg = (
                 "Direct runner.run() calls found in Cog files.\n"
-                "Use run_claude_in_thread() from _run_helper instead:\n"
-                + "\n".join(violations)
+                "Use run_claude_in_thread() from _run_helper instead:\n" + "\n".join(violations)
             )
             pytest.fail(msg)
 

--- a/tests/test_session_registry.py
+++ b/tests/test_session_registry.py
@@ -1,0 +1,136 @@
+"""Tests for the active session registry (Layer 2 of concurrency awareness)."""
+
+from __future__ import annotations
+
+from claude_discord.concurrency import ActiveSession, SessionRegistry
+
+
+class TestSessionRegistry:
+    """Core registry operations."""
+
+    def test_register_and_list(self) -> None:
+        registry = SessionRegistry()
+        registry.register(1001, "Working on ccdb Issue #52", "/home/ebi/ccdb")
+        sessions = registry.list_active()
+        assert len(sessions) == 1
+        assert sessions[0].thread_id == 1001
+        assert sessions[0].description == "Working on ccdb Issue #52"
+        assert sessions[0].working_dir == "/home/ebi/ccdb"
+
+    def test_unregister(self) -> None:
+        registry = SessionRegistry()
+        registry.register(1001, "task A")
+        registry.unregister(1001)
+        assert registry.list_active() == []
+
+    def test_unregister_nonexistent_is_noop(self) -> None:
+        registry = SessionRegistry()
+        registry.unregister(9999)  # Should not raise
+
+    def test_multiple_sessions(self) -> None:
+        registry = SessionRegistry()
+        registry.register(1001, "task A", "/home/ebi/repo-a")
+        registry.register(1002, "task B", "/home/ebi/repo-b")
+        registry.register(1003, "task C")
+        assert len(registry.list_active()) == 3
+
+    def test_list_others_excludes_self(self) -> None:
+        registry = SessionRegistry()
+        registry.register(1001, "task A", "/home/ebi/repo-a")
+        registry.register(1002, "task B", "/home/ebi/repo-b")
+        others = registry.list_others(1001)
+        assert len(others) == 1
+        assert others[0].thread_id == 1002
+
+    def test_list_others_empty_when_alone(self) -> None:
+        registry = SessionRegistry()
+        registry.register(1001, "task A")
+        assert registry.list_others(1001) == []
+
+    def test_update_description(self) -> None:
+        registry = SessionRegistry()
+        registry.register(1001, "initial task")
+        registry.update(1001, description="updated task")
+        sessions = registry.list_active()
+        assert sessions[0].description == "updated task"
+
+    def test_update_working_dir(self) -> None:
+        registry = SessionRegistry()
+        registry.register(1001, "task A")
+        registry.update(1001, working_dir="/home/ebi/new-repo")
+        sessions = registry.list_active()
+        assert sessions[0].working_dir == "/home/ebi/new-repo"
+
+    def test_update_nonexistent_is_noop(self) -> None:
+        registry = SessionRegistry()
+        registry.update(9999, description="nope")  # Should not raise
+
+    def test_re_register_overwrites(self) -> None:
+        registry = SessionRegistry()
+        registry.register(1001, "old task")
+        registry.register(1001, "new task")
+        sessions = registry.list_active()
+        assert len(sessions) == 1
+        assert sessions[0].description == "new task"
+
+
+class TestActiveSession:
+    """ActiveSession data class."""
+
+    def test_default_working_dir_is_none(self) -> None:
+        session = ActiveSession(thread_id=1, description="test")
+        assert session.working_dir is None
+
+    def test_fields(self) -> None:
+        session = ActiveSession(
+            thread_id=42,
+            description="fixing bug",
+            working_dir="/tmp/repo",
+        )
+        assert session.thread_id == 42
+        assert session.description == "fixing bug"
+        assert session.working_dir == "/tmp/repo"
+
+
+class TestConcurrencyNotice:
+    """Tests for building the concurrency context string."""
+
+    def test_no_others_returns_base_notice_only(self) -> None:
+        registry = SessionRegistry()
+        registry.register(1001, "my task")
+        notice = registry.build_concurrency_notice(1001)
+        assert "concurrent" in notice.lower() or "simultaneous" in notice.lower()
+        # Should NOT list specific other sessions
+        assert "Currently active sessions" not in notice
+
+    def test_with_others_includes_session_info(self) -> None:
+        registry = SessionRegistry()
+        registry.register(1001, "task A", "/home/ebi/repo-a")
+        registry.register(1002, "task B", "/home/ebi/repo-b")
+        notice = registry.build_concurrency_notice(1001)
+        assert "task B" in notice
+        assert "repo-b" in notice
+
+    def test_with_multiple_others(self) -> None:
+        registry = SessionRegistry()
+        registry.register(1001, "my task")
+        registry.register(1002, "task B", "/home/ebi/repo-b")
+        registry.register(1003, "task C", "/home/ebi/repo-c")
+        notice = registry.build_concurrency_notice(1001)
+        assert "task B" in notice
+        assert "task C" in notice
+
+    def test_notice_mentions_git_worktree(self) -> None:
+        """The notice should advise git worktree usage."""
+        registry = SessionRegistry()
+        registry.register(1001, "my task")
+        notice = registry.build_concurrency_notice(1001)
+        assert "worktree" in notice.lower()
+
+    def test_notice_mentions_shared_resources(self) -> None:
+        """The notice should warn about non-git conflicts too."""
+        registry = SessionRegistry()
+        registry.register(1001, "my task")
+        notice = registry.build_concurrency_notice(1001)
+        # Should mention files, ports, or processes
+        assert any(word in notice.lower() for word in ["file", "port", "process", "resource"])


### PR DESCRIPTION
## Summary

- **Layer 1**: Every Claude Code session receives a generic concurrency warning in its prompt covering git (with worktree advice), files, ports/processes, and shared resources
- **Layer 2**: In-memory `SessionRegistry` tracks active sessions so each one knows what others are doing and can avoid conflicts
- All three Cogs that call `run_claude_in_thread()` (ClaudeChatCog, SkillCommandCog, WebhookTriggerCog) now accept and pass through the registry

## Design

See Issue #52 for the full design discussion, including why container/worktree/OverlayFS approaches were deferred to a future Layer 3.

## New files

- `claude_discord/concurrency.py` — `ActiveSession` dataclass + `SessionRegistry` class
- `tests/test_session_registry.py` — 17 unit tests for registry and notice building

## Modified files

- `claude_discord/cogs/_run_helper.py` — register/unregister + prompt prefixing
- `claude_discord/cogs/claude_chat.py` — pass registry to run helper
- `claude_discord/cogs/skill_command.py` — pass registry to run helper
- `claude_discord/cogs/webhook_trigger.py` — pass registry to run helper
- `claude_discord/__init__.py` — export new types
- `tests/test_run_helper.py` — 6 integration tests for concurrency behavior

## Test plan

- [x] 17 unit tests for SessionRegistry (register, unregister, update, list, notice building)
- [x] 6 integration tests verifying prompt injection, session lifecycle, error cleanup, backward compat
- [x] Full suite: 303 tests pass, 0 failures
- [x] ruff check + ruff format clean
- [ ] Manual test: run multiple Discord threads simultaneously and verify concurrency notice appears

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)