### PR TITLE
feat: auto-discover session registry from bot

### DIFF
--- a/claude_discord/bot.py
+++ b/claude_discord/bot.py
@@ -7,6 +7,8 @@ import logging
 import discord
 from discord.ext import commands
 
+from .concurrency import SessionRegistry
+
 logger = logging.getLogger(__name__)
 
 
@@ -23,6 +25,7 @@ class ClaudeDiscordBot(commands.Bot):
             intents=intents,
         )
         self.channel_id = channel_id
+        self.session_registry = SessionRegistry()
 
     async def on_ready(self) -> None:
         logger.info("Logged in as %s (ID: %s)", self.user, self.user.id if self.user else "?")

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -58,7 +58,7 @@ class ClaudeChatCog(commands.Cog):
         self.runner = runner
         self._max_concurrent = max_concurrent
         self._allowed_user_ids = allowed_user_ids
-        self._registry = registry
+        self._registry = registry or getattr(bot, "session_registry", None)
         self._semaphore = asyncio.Semaphore(max_concurrent)
         self._active_runners: dict[int, ClaudeRunner] = {}
 

--- a/claude_discord/cogs/skill_command.py
+++ b/claude_discord/cogs/skill_command.py
@@ -94,7 +94,7 @@ class SkillCommandCog(commands.Cog):
         self.runner = runner
         self.claude_channel_id = claude_channel_id
         self._allowed_user_ids = allowed_user_ids
-        self._registry = registry
+        self._registry = registry or getattr(bot, "session_registry", None)
 
         # Default to ~/.claude/skills/
         if skills_dir is None:

--- a/claude_discord/cogs/webhook_trigger.py
+++ b/claude_discord/cogs/webhook_trigger.py
@@ -78,7 +78,7 @@ class WebhookTriggerCog(commands.Cog):
         self.triggers = triggers
         self.allowed_webhook_ids = allowed_webhook_ids
         self.channel_ids = channel_ids
-        self._registry = registry
+        self._registry = registry or getattr(bot, "session_registry", None)
         self._locks: dict[str, asyncio.Lock] = {prefix: asyncio.Lock() for prefix in triggers}
         self._active_count: int = 0
 


### PR DESCRIPTION
## Summary

Follow-up to #53. Makes concurrency awareness work automatically without any consumer-side changes.

- `ClaudeDiscordBot` now creates a `SessionRegistry` by default
- All 3 Cogs auto-discover it via `getattr(bot, "session_registry", None)` when no explicit registry is passed
- Consumers (EbiBot etc.) just update the package — zero config needed

## Test plan

- [x] 3 new tests for auto-discovery (306 total pass)
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)