### PR TITLE
fix: keep Markdown tables intact when chunking for Discord

### DIFF
--- a/claude_discord/discord_ui/chunker.py
+++ b/claude_discord/discord_ui/chunker.py
@@ -1,7 +1,11 @@
-"""Fence-aware message chunker for Discord's 2000-character limit.
+"""Fence-aware and table-aware message chunker for Discord's 2000-character limit.
 
 Inspired by OpenClaw: never split inside a code block. If forced to split,
 properly close and reopen the fence markers.
+
+Tables (GitHub Flavored Markdown pipe-tables) are treated as atomic blocks:
+the chunker walks back from any candidate split point to the start of the
+enclosing table so that Discord can render the whole table in one message.
 """
 
 from __future__ import annotations
@@ -18,7 +22,8 @@ def chunk_message(text: str, max_chars: int = EFFECTIVE_MAX) -> list[str]:
     1. Prefer splitting at paragraph boundaries (blank lines)
     2. Never split inside a code fence if possible
     3. If forced to split inside a fence, close it and reopen in next chunk
-    4. Respect max_chars limit per chunk
+    4. Never split inside a markdown table block
+    5. Respect max_chars limit per chunk
     """
     if not text:
         return []
@@ -57,22 +62,68 @@ def _find_split_point(text: str, max_chars: int) -> int:
     1. Paragraph break (blank line) before max_chars
     2. Line break before max_chars
     3. Hard split at max_chars
+
+    After finding a candidate, the split is moved back to the start of any
+    enclosing markdown table block so tables are never split mid-block.
     """
-    # Look for paragraph break
     search_region = text[:max_chars]
 
     # Search backward from max_chars for a blank line
     last_paragraph = search_region.rfind("\n\n")
     if last_paragraph > max_chars // 3:
-        return last_paragraph + 1
+        candidate = last_paragraph + 1
+    else:
+        # Search backward for any newline
+        last_newline = search_region.rfind("\n")
+        candidate = last_newline + 1 if last_newline > max_chars // 3 else max_chars
 
-    # Search backward for any newline
-    last_newline = search_region.rfind("\n")
-    if last_newline > max_chars // 3:
-        return last_newline + 1
+    # Don't split inside a markdown table block
+    return _retreat_to_table_start(text, candidate)
 
-    # Hard split at max_chars
-    return max_chars
+
+def _is_table_line(line: str) -> bool:
+    """Return True if *line* looks like a markdown table row.
+
+    A table row must start **and** end with a pipe character (after stripping
+    whitespace) and contain at least one character between the pipes.
+    """
+    stripped = line.strip()
+    return len(stripped) >= 3 and stripped.startswith("|") and stripped.endswith("|")
+
+
+def _retreat_to_table_start(text: str, split_pos: int) -> int:
+    """If *split_pos* falls inside a markdown table block, return the position
+    of the first character of that block.  Otherwise return *split_pos* unchanged.
+
+    Ensures tables are kept intact so Discord can render them correctly.
+    If the table starts at position 0 we cannot retreat further, so we return
+    the original split_pos to avoid an infinite loop in the caller.
+    """
+    text_before = text[:split_pos]
+    lines = text_before.split("\n")
+
+    # Walk backwards, skipping any trailing blank lines
+    i = len(lines) - 1
+    while i >= 0 and not lines[i].strip():
+        i -= 1
+
+    # If the last non-blank line is not a table line, we're not inside a table
+    if i < 0 or not _is_table_line(lines[i]):
+        return split_pos
+
+    # Walk further back to find the first line of the table block
+    while i >= 0 and _is_table_line(lines[i]):
+        i -= 1
+
+    # i now points to the last line *before* the table
+    table_first_line_idx = i + 1
+    table_start_char = sum(len(lines[j]) + 1 for j in range(table_first_line_idx))
+
+    if table_start_char == 0:
+        # Table starts at the very beginning — cannot retreat, avoid infinite loop
+        return split_pos
+
+    return table_start_char
 
 
 def _close_open_fence(chunk: str) -> tuple[str, str | None]:

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1,6 +1,10 @@
 """Tests for fence-aware message chunker."""
 
-from claude_discord.discord_ui.chunker import _close_open_fence, chunk_message
+from claude_discord.discord_ui.chunker import (
+    _close_open_fence,
+    _is_table_line,
+    chunk_message,
+)
 
 
 class TestChunkMessage:
@@ -37,18 +41,72 @@ class TestChunkMessage:
         text = "Before\n```python\n" + "x = 1\n" * 200 + "```\nAfter"
         chunks = chunk_message(text, max_chars=500)
         assert len(chunks) >= 2
-
-        # First chunk should close the fence
-        # and subsequent chunk should reopen it
         for i, chunk in enumerate(chunks):
             fence_count = chunk.count("```")
-            # Each chunk should have balanced fences (even count)
             assert fence_count % 2 == 0, f"Chunk {i} has unbalanced fences: {fence_count}"
 
     def test_no_empty_chunks(self):
         text = "Hello\n\n\n\nWorld"
         chunks = chunk_message(text, max_chars=10)
         assert all(c.strip() for c in chunks)
+
+
+TABLE_3ROW = "| A | B |\n|---|---|\n| 1 | 2 |\n| 3 | 4 |"
+
+
+class TestIsTableLine:
+    def test_table_row(self):
+        assert _is_table_line("| Col1 | Col2 |")
+
+    def test_separator_row(self):
+        assert _is_table_line("|------|------|")
+
+    def test_not_table(self):
+        assert not _is_table_line("Just a normal line")
+
+    def test_empty_line(self):
+        assert not _is_table_line("")
+
+    def test_partial_pipe_only_start(self):
+        assert not _is_table_line("| only starts with pipe")
+
+
+class TestTableChunking:
+    def test_table_not_split(self):
+        """A table that fits within a single chunk must not be split."""
+        text = "Intro paragraph.\n\n" + TABLE_3ROW
+        chunks = chunk_message(text)
+        assert any(TABLE_3ROW in chunk for chunk in chunks)
+
+    def test_splits_before_table(self):
+        """Long preamble followed by a table: split before the table, not inside it."""
+        # 880 + "\n\n" (2) + table (~38) = ~920 > max_chars=900
+        preamble = "X" * 880
+        text = preamble + "\n\n" + TABLE_3ROW
+        chunks = chunk_message(text, max_chars=900)
+        assert len(chunks) >= 2
+        assert any(TABLE_3ROW in chunk for chunk in chunks)
+
+    def test_table_at_message_start(self):
+        """Table at the very start is returned intact if it fits."""
+        text = TABLE_3ROW + "\n\nTrailing text."
+        chunks = chunk_message(text)
+        assert any(TABLE_3ROW in chunk for chunk in chunks)
+
+    def test_header_and_separator_in_same_chunk(self):
+        """Header and separator rows must never end up in different chunks."""
+        header = "| Col |\n|-----|\n"
+        many_rows = "| val |\n" * 300  # ~2400 chars — forces multiple splits
+        text = header + many_rows
+        chunks = chunk_message(text, max_chars=500)
+        for chunk in chunks:
+            lines = [ln for ln in chunk.splitlines() if _is_table_line(ln)]
+            if not lines:
+                continue
+            # A separator-only row as the first table line means the header
+            # ended up in a previous chunk — Discord cannot render that.
+            first_cell = lines[0].replace("|", "").replace("-", "").replace(" ", "")
+            assert first_cell != "", f"Chunk starts with separator row (no header): {chunk[:120]!r}"
 
 
 class TestCloseOpenFence:


### PR DESCRIPTION
## Summary

- Treats GFM pipe-tables as atomic blocks in `chunk_message`, analogous to existing code-fence handling
- Adds `_retreat_to_table_start` which walks the candidate split point back to the first line of any enclosing table block
- Adds `_is_table_line` helper that detects header, separator, and data rows

## Problem

When Claude's response contained a Markdown table, the chunker could split it across multiple Discord messages. Discord requires the **entire table** (header + separator + data rows) in one message to render it correctly. A split table appeared as raw `|` characters.

## Implementation

`_find_split_point` → `_retreat_to_table_start` → walks back through lines until the first non-table line, returns the character position of the table's first row.

Edge case: if the table starts at position 0, we cannot retreat further — the function returns the original split_pos to avoid an infinite loop.

## Test plan

- [x] `TestIsTableLine` — 5 cases covering header rows, separator rows, non-table lines, empty lines, partial pipes
- [x] `TestTableChunking` — 4 cases: table intact in one chunk, split before table, table at message start, header+separator always in same chunk
- [x] All 315 existing tests still pass

Closes #55