### PR TITLE
feat(#56): add ⏹ Stop button and graceful SIGINT interrupt

### DIFF
--- a/claude_discord/claude/runner.py
+++ b/claude_discord/claude/runner.py
@@ -13,6 +13,7 @@ import asyncio
 import logging
 import os
 import re
+import signal
 from collections.abc import AsyncGenerator
 
 from .parser import parse_line
@@ -103,6 +104,20 @@ class ClaudeRunner:
             dangerously_skip_permissions=self.dangerously_skip_permissions,
             include_partial_messages=self.include_partial_messages,
         )
+
+    async def interrupt(self) -> None:
+        """Interrupt the subprocess with SIGINT (graceful stop, like Ctrl+C / Escape).
+
+        Gives Claude Code a chance to flush output and preserve session state
+        before exiting.  Falls back to kill() if the process does not stop
+        within 10 seconds.
+        """
+        if self._process and self._process.returncode is None:
+            self._process.send_signal(signal.SIGINT)
+            try:
+                await asyncio.wait_for(self._process.wait(), timeout=10)
+            except TimeoutError:
+                await self.kill()
 
     async def kill(self) -> None:
         """Terminate the subprocess, force-killing if it doesn't stop in time."""

--- a/claude_discord/discord_ui/views.py
+++ b/claude_discord/discord_ui/views.py
@@ -1,0 +1,65 @@
+"""Discord UI Views for interactive session controls."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+
+import discord
+
+from ..claude.runner import ClaudeRunner
+from .embeds import stopped_embed
+
+logger = logging.getLogger(__name__)
+
+
+class StopView(discord.ui.View):
+    """A ⏹ Stop button attached to the session status message.
+
+    Clicking it sends SIGINT to the active Claude runner (graceful interrupt,
+    like pressing Escape in Claude Code) and posts a stopped_embed.
+
+    After the session ends — either via the button or naturally — call
+    ``disable(message)`` to deactivate the button on the status message.
+    """
+
+    def __init__(self, runner: ClaudeRunner) -> None:
+        super().__init__(timeout=None)
+        self._runner = runner
+        self._stopped = False
+
+    @discord.ui.button(label="⏹ Stop", style=discord.ButtonStyle.danger)
+    async def stop_button(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        """Interrupt the active Claude session."""
+        if self._stopped:
+            await interaction.response.defer()
+            return
+
+        self._stopped = True
+        button.disabled = True
+        self.stop()
+
+        await interaction.response.edit_message(view=self)
+        await self._runner.interrupt()
+
+        with contextlib.suppress(Exception):
+            await interaction.followup.send(embed=stopped_embed())
+
+    async def disable(self, message: discord.Message) -> None:
+        """Disable the button after the session ends naturally.
+
+        No-op if the stop button was already clicked.
+        """
+        if self._stopped:
+            return
+
+        self._stopped = True
+        for child in self.children:
+            if isinstance(child, discord.ui.Button):
+                child.disabled = True
+        self.stop()
+
+        with contextlib.suppress(discord.HTTPException):
+            await message.edit(view=self)

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -76,19 +76,19 @@ class TestStopCommand:
         assert call_kwargs.get("ephemeral") is True
 
     @pytest.mark.asyncio
-    async def test_stop_calls_runner_kill(self) -> None:
-        """Using /stop with an active runner calls runner.kill()."""
+    async def test_stop_calls_runner_interrupt(self) -> None:
+        """Using /stop with an active runner calls runner.interrupt()."""
         cog = _make_cog()
         thread_id = 12345
         interaction = _make_thread_interaction(thread_id=thread_id)
 
         mock_runner = MagicMock()
-        mock_runner.kill = AsyncMock()
+        mock_runner.interrupt = AsyncMock()
         cog._active_runners[thread_id] = mock_runner
 
         await cog.stop_session.callback(cog, interaction)
 
-        mock_runner.kill.assert_called_once()
+        mock_runner.interrupt.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_stop_does_not_delete_session_from_db(self) -> None:
@@ -98,7 +98,7 @@ class TestStopCommand:
         interaction = _make_thread_interaction(thread_id=thread_id)
 
         mock_runner = MagicMock()
-        mock_runner.kill = AsyncMock()
+        mock_runner.interrupt = AsyncMock()
         cog._active_runners[thread_id] = mock_runner
 
         await cog.stop_session.callback(cog, interaction)
@@ -114,7 +114,7 @@ class TestStopCommand:
         interaction = _make_thread_interaction(thread_id=thread_id)
 
         mock_runner = MagicMock()
-        mock_runner.kill = AsyncMock()
+        mock_runner.interrupt = AsyncMock()
         cog._active_runners[thread_id] = mock_runner
 
         await cog.stop_session.callback(cog, interaction)
@@ -130,7 +130,7 @@ class TestStopCommand:
         interaction = _make_thread_interaction(thread_id=thread_id)
 
         mock_runner = MagicMock()
-        mock_runner.kill = AsyncMock()
+        mock_runner.interrupt = AsyncMock()
         cog._active_runners[thread_id] = mock_runner
 
         await cog.stop_session.callback(cog, interaction)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,151 @@
+"""Tests for discord_ui/views.py — StopView."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from claude_discord.discord_ui.views import StopView
+
+
+def _make_runner() -> MagicMock:
+    runner = MagicMock()
+    runner.interrupt = AsyncMock()
+    return runner
+
+
+def _make_interaction() -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _make_message() -> MagicMock:
+    msg = MagicMock(spec=discord.Message)
+    msg.edit = AsyncMock()
+    return msg
+
+
+async def _click(view: StopView, interaction: MagicMock) -> None:
+    """Simulate a button click by invoking the inner callback directly.
+
+    @discord.ui.button wraps the method in a _ViewCallback whose inner
+    .callback attribute is the original function.
+    """
+    btn = view.stop_button
+    await btn.callback.callback(view, interaction, btn)
+
+
+class TestStopViewButtonClick:
+    @pytest.mark.asyncio
+    async def test_click_calls_runner_interrupt(self) -> None:
+        """Clicking ⏹ Stop calls runner.interrupt()."""
+        runner = _make_runner()
+        view = StopView(runner)
+
+        await _click(view, _make_interaction())
+
+        runner.interrupt.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_click_disables_button(self) -> None:
+        """Clicking ⏹ Stop disables the button."""
+        runner = _make_runner()
+        view = StopView(runner)
+        btn = view.stop_button
+
+        await _click(view, _make_interaction())
+
+        assert btn.disabled is True
+
+    @pytest.mark.asyncio
+    async def test_click_edits_message(self) -> None:
+        """Clicking ⏹ Stop edits the interaction message to show the disabled button."""
+        runner = _make_runner()
+        view = StopView(runner)
+        interaction = _make_interaction()
+
+        await _click(view, interaction)
+
+        interaction.response.edit_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_click_sends_stopped_embed_via_followup(self) -> None:
+        """Clicking ⏹ Stop sends stopped_embed via followup."""
+        runner = _make_runner()
+        view = StopView(runner)
+        interaction = _make_interaction()
+
+        await _click(view, interaction)
+
+        interaction.followup.send.assert_called_once()
+        embed = interaction.followup.send.call_args.kwargs.get("embed")
+        assert embed is not None
+        assert "stopped" in embed.title.lower()
+
+    @pytest.mark.asyncio
+    async def test_double_click_is_noop(self) -> None:
+        """A second click after the first is ignored (idempotent)."""
+        runner = _make_runner()
+        view = StopView(runner)
+        interaction = _make_interaction()
+
+        await _click(view, interaction)
+        runner.interrupt.reset_mock()
+        interaction.response.edit_message.reset_mock()
+
+        await _click(view, interaction)
+
+        runner.interrupt.assert_not_called()
+        interaction.response.defer.assert_called_once()
+
+
+class TestStopViewDisable:
+    @pytest.mark.asyncio
+    async def test_disable_edits_message(self) -> None:
+        """disable() edits the status message to show the deactivated button."""
+        runner = _make_runner()
+        view = StopView(runner)
+
+        await view.disable(_make_message())
+
+        _make_message()  # unused; just ensuring no exception
+
+    @pytest.mark.asyncio
+    async def test_disable_edits_message_for_real(self) -> None:
+        """disable() calls message.edit to reflect the disabled button."""
+        runner = _make_runner()
+        view = StopView(runner)
+        msg = _make_message()
+
+        await view.disable(msg)
+
+        msg.edit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_disable_after_click_is_noop(self) -> None:
+        """disable() after the stop button was clicked should not edit the message again."""
+        runner = _make_runner()
+        view = StopView(runner)
+        msg = _make_message()
+
+        await _click(view, _make_interaction())
+        await view.disable(msg)
+
+        msg.edit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_disable_suppresses_http_exception(self) -> None:
+        """disable() swallows discord.HTTPException silently."""
+        runner = _make_runner()
+        view = StopView(runner)
+        msg = _make_message()
+        msg.edit = AsyncMock(side_effect=discord.HTTPException(MagicMock(), "rate limited"))
+
+        await view.disable(msg)  # should not raise


### PR DESCRIPTION
## Summary

Fixes #56 — adds a way to stop a running Claude Code session from Discord.

- **`ClaudeRunner.interrupt()`**: sends SIGINT (equivalent to pressing Escape in Claude Code interactive mode), with a 10-second graceful timeout before falling back to `kill()`
- **`StopView`**: a `discord.ui.View` with a ⏹ Stop button that is attached to a status message at the start of every session; the button auto-disables when the session ends naturally, and is idempotent (double-click is a no-op)
- **`_run_claude` wiring**: `StopView` lifecycle is managed in `_run_claude` — button appears on session start, `disable()` is called in the `finally` block
- **`/stop` command**: now uses `interrupt()` instead of `kill()` for graceful stops
- **Signal-kill fix**: `_read_stream` no longer emits error embeds for signal-killed processes (negative returncode on Linux indicates a signal, not an application error)

## Test plan

- [x] 330 tests pass (`pytest tests/ -q`)
- [x] `ruff check .` passes
- [x] New tests: `TestInterrupt` (4), `TestSignalKillSuppression` (2), `TestStopViewButtonClick` (5), `TestStopViewDisable` (4), `TestStopCommand` updated to assert `interrupt` not `kill`

🤖 Generated with [Claude Code](https://claude.com/claude-code)