### PR TITLE
fix(#52): strengthen concurrency notice and add diagnostic logging

### DIFF
--- a/claude_discord/cogs/_run_helper.py
+++ b/claude_discord/cogs/_run_helper.py
@@ -149,7 +149,17 @@ async def run_claude_in_thread(
     # Layer 1 + 2: Register session and prepend concurrency notice
     if registry is not None:
         registry.register(thread.id, prompt[:100], runner.working_dir)
-        prompt = registry.build_concurrency_notice(thread.id) + "\n\n" + prompt
+        others = registry.list_others(thread.id)
+        notice = registry.build_concurrency_notice(thread.id)
+        prompt = notice + "\n\n" + prompt
+        logger.info(
+            "Concurrency notice injected for thread %d (%d other active session(s), dir=%s)",
+            thread.id,
+            len(others),
+            runner.working_dir or "(default)",
+        )
+    else:
+        logger.debug("No session registry — concurrency notice skipped for thread %d", thread.id)
 
     state = SessionState(session_id=session_id, thread_id=thread.id)
     streamer = StreamingMessageManager(thread)

--- a/claude_discord/concurrency.py
+++ b/claude_discord/concurrency.py
@@ -27,27 +27,28 @@ class ActiveSession:
 
 
 _BASE_CONCURRENCY_NOTICE = """\
-[CONCURRENCY NOTICE] You are running via Discord. \
-Multiple Claude Code sessions may be active simultaneously. \
-To avoid conflicts:
+[CONCURRENCY NOTICE — MANDATORY] You are one of MULTIPLE Claude Code sessions \
+running simultaneously via Discord. Other sessions ARE active right now. \
+You MUST follow these rules to avoid destroying each other's work:
 
-- **Git**: Before making changes, create a branch or worktree \
-(`git worktree add ../wt-{thread_id} -b session/{thread_id}`). \
-Always commit and push before finishing — uncommitted changes in a shared \
-working directory WILL be lost when another session switches branches.
-- **Files**: Another session may be editing the same files outside of git. \
-Check for recent modifications before overwriting.
-- **Ports & processes**: Shared network ports or lock files may already be in use. \
-Verify availability before binding.
-- **Resources**: Shared databases, APIs with rate limits, or singleton processes \
-may be accessed by other sessions concurrently.
+1. **Git — USE A WORKTREE (REQUIRED)**: Run \
+`git worktree add ../wt-{thread_id} -b session/{thread_id}` BEFORE making \
+any changes. Work ONLY inside your worktree. NEVER modify the main working \
+directory directly. Always commit and push before finishing — uncommitted \
+changes WILL be lost.
+2. **Files**: Another session may be editing the same files RIGHT NOW. \
+Check `git status` and recent file modification times before overwriting.
+3. **Ports & processes**: Shared network ports or lock files may already be in use.
+4. **Resources**: Shared databases, APIs with rate limits, or singleton processes \
+may be accessed concurrently.
 
-If you detect a potential conflict with another session, \
-stop and warn the user before proceeding.\
+CRITICAL: If your target repository is the same as another active session's, \
+you MUST use a separate worktree or stop and warn the user. \
+Do NOT proceed without isolation.\
 """
 
 _OTHER_SESSIONS_HEADER = """
-Currently active sessions (avoid conflicts with these):
+⚠️ ACTIVE SESSIONS RIGHT NOW (you MUST avoid conflicts with these):
 """
 
 
@@ -122,5 +123,8 @@ class SessionRegistry:
                 if s.working_dir:
                     line += f" (working in {s.working_dir})"
                 notice += line + "\n"
-            notice += "\nIf your work may conflict with any of the above, stop and warn the user.\n"
+            notice += (
+                "\nIf your work targets the same repository as any session above, "
+                "you MUST use a git worktree. Do NOT proceed without isolation.\n"
+            )
         return notice

--- a/tests/test_run_helper.py
+++ b/tests/test_run_helper.py
@@ -420,7 +420,7 @@ class TestConcurrencyIntegration:
         await run_claude_in_thread(thread, runner, repo, "fix the bug", None, registry=registry)
 
         assert len(captured_prompt) == 1
-        assert captured_prompt[0].startswith("[CONCURRENCY NOTICE]")
+        assert captured_prompt[0].startswith("[CONCURRENCY NOTICE")
         assert "fix the bug" in captured_prompt[0]
 
     @pytest.mark.asyncio

--- a/tests/test_session_registry.py
+++ b/tests/test_session_registry.py
@@ -99,9 +99,9 @@ class TestConcurrencyNotice:
         registry = SessionRegistry()
         registry.register(1001, "my task")
         notice = registry.build_concurrency_notice(1001)
-        assert "concurrent" in notice.lower() or "simultaneous" in notice.lower()
+        assert "concurrency notice" in notice.lower()
         # Should NOT list specific other sessions
-        assert "Currently active sessions" not in notice
+        assert "ACTIVE SESSIONS RIGHT NOW" not in notice
 
     def test_with_others_includes_session_info(self) -> None:
         registry = SessionRegistry()


### PR DESCRIPTION
## Summary
- Add INFO/DEBUG logging to `run_claude_in_thread()` to verify concurrency notice injection is actually happening (addresses the "not reaching Claude" concern)
- Strengthen notice wording significantly: mild suggestions → mandatory requirements with MUST/REQUIRED language
- Make the other-sessions header more urgent and the footer more explicit about worktree requirement

Fixes part of #52 — this addresses the observability and soft-enforcement strength. Hard isolation (Layer 3) is tracked separately.

## Test plan
- [x] 315 tests pass (`uv run pytest tests/ -v`)
- [x] `ruff check` + `ruff format --check` pass
- [x] Updated test assertions for new notice wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)