### PR TITLE
refactor: remove dead code from 4 modules

### DIFF
--- a/claude_discord/cogs/_run_helper.py
+++ b/claude_discord/cogs/_run_helper.py
@@ -11,7 +11,6 @@ import contextlib
 import logging
 import re
 import time
-from typing import TYPE_CHECKING
 
 import discord
 
@@ -31,9 +30,6 @@ from ..discord_ui.embeds import (
     tool_use_embed,
 )
 from ..discord_ui.status import StatusManager
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 

--- a/claude_discord/cogs/auto_upgrade.py
+++ b/claude_discord/cogs/auto_upgrade.py
@@ -16,15 +16,11 @@ import asyncio
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
 import discord
 from discord.ext import commands
 
 from ..protocols import DrainAware
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 

--- a/claude_discord/cogs/session_manage.py
+++ b/claude_discord/cogs/session_manage.py
@@ -48,9 +48,6 @@ _STYLE_CHOICES = [
     app_commands.Choice(name="Message threads (visible in channel)", value=THREAD_STYLE_MESSAGE),
 ]
 
-SETTING_SYNC_SINCE_DAYS = "sync_since_days"
-_DEFAULT_SINCE_DAYS = 3
-
 SETTING_SYNC_SINCE_HOURS = "sync_since_hours"
 _DEFAULT_SINCE_HOURS = 24
 SETTING_SYNC_MIN_RESULTS = "sync_min_results"
@@ -80,15 +77,6 @@ class SessionManageCog(commands.Cog):
         if style in _VALID_THREAD_STYLES:
             return style
         return THREAD_STYLE_CHANNEL
-
-    async def _get_since_days(self) -> int:
-        """Get the configured since_days filter, defaulting to 3."""
-        if self.settings_repo is None:
-            return _DEFAULT_SINCE_DAYS
-        raw = await self.settings_repo.get(SETTING_SYNC_SINCE_DAYS)
-        if raw is not None and raw.isdigit():
-            return int(raw)
-        return _DEFAULT_SINCE_DAYS
 
     async def _get_since_hours(self) -> int:
         """Get the configured since_hours filter, defaulting to 24."""

--- a/claude_discord/database/notification_repo.py
+++ b/claude_discord/database/notification_repo.py
@@ -7,7 +7,6 @@ Used by the REST API extension for push notifications to Discord.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
 
 import aiosqlite
 
@@ -31,23 +30,6 @@ CREATE TABLE IF NOT EXISTS scheduled_notifications (
 CREATE INDEX IF NOT EXISTS idx_notif_status_scheduled
     ON scheduled_notifications(status, scheduled_at);
 """
-
-
-@dataclass
-class NotificationRecord:
-    """A scheduled notification record."""
-
-    id: int
-    message: str
-    title: str | None
-    color: int
-    scheduled_at: str
-    source: str
-    channel_id: int | None
-    status: str
-    sent_at: str | None
-    error_message: str | None
-    created_at: str
 
 
 class NotificationRepository:


### PR DESCRIPTION
## Summary
- Remove unused `NotificationRecord` dataclass (defined but never referenced by any code)
- Remove empty `if TYPE_CHECKING: pass` blocks from `_run_helper.py` and `auto_upgrade.py`
- Remove `_get_since_days()` method and associated constants from `session_manage.py` (never called)

Pure deletion — 38 lines removed, 0 added. All 344 tests pass.

## Test plan
- [x] `uv run pytest tests/ -q` — 344 passed
- [x] `uv run ruff check claude_discord/` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)