### PR TITLE
[docs-sync] Update documentation (English + Japanese)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ GitHub PR (auto-merge)  ←  git push  ←  Claude Code  ←──┘
 - **Stop without clearing** — `/stop` halts a running session while preserving it for resume
 - **Attachment support** — Text-type file attachments are automatically appended to the prompt (up to 5 files, 50 KB each)
 - **Timeout notifications** — Dedicated embed with elapsed seconds and actionable guidance when a session times out
+- **Interactive questions** — When Claude calls `AskUserQuestion`, the bot renders Discord Buttons or a Select Menu and resumes the session with your answer
+- **Cross-thread relay** — `/relay target:#thread message:"..."` lets one Claude session delegate to another, enabling multi-agent coordination patterns
+- **Session status dashboard** — A live pinned embed in the main channel shows which threads are processing vs. waiting for input; owner is @-mentioned when Claude needs a reply
 
 ### CI/CD Automation
 - **Webhook triggers** — Trigger Claude Code tasks from GitHub Actions or any CI/CD system
@@ -141,6 +144,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `CLAUDE_WORKING_DIR` | Working directory for Claude | current dir |
 | `MAX_CONCURRENT_SESSIONS` | Max parallel sessions | `3` |
 | `SESSION_TIMEOUT_SECONDS` | Session inactivity timeout | `300` |
+| `DISCORD_OWNER_ID` | Discord user ID to @-mention when Claude needs input | (optional) |
 
 ## Discord Bot Setup
 
@@ -358,6 +362,7 @@ claude_discord/
   cogs/
     claude_chat.py         # Interactive chat (thread creation, message handling)
     skill_command.py       # /skill slash command with autocomplete
+    thread_relay.py        # /relay slash command for cross-thread Claude messaging
     webhook_trigger.py     # Webhook → Claude Code task execution (CI/CD)
     auto_upgrade.py        # Webhook → package upgrade + restart
     _run_helper.py         # Shared Claude CLI execution logic
@@ -373,6 +378,8 @@ claude_discord/
     status.py              # Emoji reaction status manager (debounced)
     chunker.py             # Fence-aware message splitting
     embeds.py              # Discord embed builders
+    ask_view.py            # Discord Buttons/Select Menus for AskUserQuestion
+    thread_dashboard.py    # Live pinned embed showing session states per thread
   ext/
     api_server.py          # REST API server (optional, requires aiohttp)
   utils/
@@ -392,7 +399,7 @@ claude_discord/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-131 tests covering parser, chunker, repository, runner, streaming, webhook triggers, auto-upgrade, and REST API.
+400+ tests covering parser, chunker, repository, runner, streaming, webhook triggers, auto-upgrade, REST API, AskUserQuestion UI, thread relay, and thread status dashboard.
 
 ## How This Project Was Built
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -54,6 +54,9 @@ GitHub PR (自動マージ)  ←  git push  ←  Claude Code  ←──┘
 - **セッション永続化** — `--resume` による複数メッセージをまたいだ会話継続
 - **スキル実行** — スラッシュコマンドとオートコンプリートで Claude Code スキルを実行（`/skill goodmorning`）
 - **並行セッション** — 複数セッションを並列実行（設定可能な上限）
+- **インタラクティブな質問** — Claude が `AskUserQuestion` を呼び出すと、Discord ボタンまたは Select Menu を表示し、回答を受け取ってセッションを再開
+- **クロススレッドリレー** — `/relay target:#thread message:"..."` で一方の Claude セッションから別のセッションへメッセージを委譲（マルチエージェント連携パターン）
+- **セッションステータスダッシュボード** — メインチャンネルにピン留めされた live embed で各スレッドの状態（処理中 / 入力待ち）を一覧表示。Claude が返答を待っているときはオーナーを @mention で通知
 
 ### CI/CD 自動化
 - **Webhook トリガー** — GitHub Actions や任意の CI/CD システムから Claude Code タスクをトリガー
@@ -127,6 +130,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `CLAUDE_WORKING_DIR` | Claude の作業ディレクトリ | カレントディレクトリ |
 | `MAX_CONCURRENT_SESSIONS` | 最大並行セッション数 | `3` |
 | `SESSION_TIMEOUT_SECONDS` | セッション非アクティブタイムアウト | `300` |
+| `DISCORD_OWNER_ID` | Claude が入力待ちのとき @mention する Discord ユーザー ID | （オプション） |
 
 ## Discord Bot のセットアップ
 
@@ -344,6 +348,7 @@ claude_discord/
   cogs/
     claude_chat.py         # インタラクティブチャット（スレッド作成、メッセージ処理）
     skill_command.py       # /skill スラッシュコマンド（オートコンプリート付き）
+    thread_relay.py        # /relay スラッシュコマンド（クロススレッド Claude メッセージング）
     webhook_trigger.py     # Webhook → Claude Code タスク実行（CI/CD）
     auto_upgrade.py        # Webhook → パッケージアップグレード + 再起動
     _run_helper.py         # 共有 Claude CLI 実行ロジック
@@ -359,6 +364,8 @@ claude_discord/
     status.py              # 絵文字リアクションステータスマネージャー（デバウンス付き）
     chunker.py             # フェンス対応メッセージ分割
     embeds.py              # Discord embed ビルダー
+    ask_view.py            # AskUserQuestion 用 Discord ボタン / Select Menu
+    thread_dashboard.py    # スレッドごとのセッション状態を表示する live ピン留め embed
   ext/
     api_server.py          # REST API サーバー（オプション、aiohttp が必要）
   utils/
@@ -378,7 +385,7 @@ claude_discord/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-131 件のテストがパーサー、チャンカー、リポジトリ、ランナー、ストリーミング、webhook トリガー、自動アップグレード、REST API をカバーしています。
+400 件以上のテストがパーサー、チャンカー、リポジトリ、ランナー、ストリーミング、webhook トリガー、自動アップグレード、REST API、AskUserQuestion UI、スレッドリレー、スレッドステータスダッシュボードをカバーしています。
 
 ## このプロジェクトの構築方法
 


### PR DESCRIPTION
## Summary
- Added three new interactive features to README: AskUserQuestion Discord UI (buttons/select menus for Claude's questions), `/relay` cross-thread command, and thread status dashboard with owner @mention
- Added `DISCORD_OWNER_ID` config variable to configuration table
- Updated architecture diagram with new files (`thread_relay.py`, `ask_view.py`, `thread_dashboard.py`)
- Updated test count from 131 to 400+

## 概要
- 3つの新機能を README に追加: AskUserQuestion Discord UI（Claude の質問にボタン/Select Menu で回答）、`/relay` クロススレッドコマンド、オーナー @mention 付きスレッドステータスダッシュボード
- 設定テーブルに `DISCORD_OWNER_ID` 変数を追加
- アーキテクチャ図を新ファイル（`thread_relay.py`, `ask_view.py`, `thread_dashboard.py`）で更新
- テスト数を 131 件から 400 件以上に更新

## Changed files
- `README.md`
- `docs/ja/README.md`

---
🤖 Auto-generated by [docs-sync](https://github.com/ebibibi/claude-code-discord-bridge)
