### PR TITLE
[docs-sync] Update documentation (English + Japanese)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ GitHub PR (auto-merge)  ←  git push  ←  Claude Code  ←──┘
 - **Attachment support** — Text-type file attachments are automatically appended to the prompt (up to 5 files, 50 KB each)
 - **Timeout notifications** — Dedicated embed with elapsed seconds and actionable guidance when a session times out
 - **Interactive questions** — When Claude calls `AskUserQuestion`, the bot renders Discord Buttons or a Select Menu and resumes the session with your answer
-- **Cross-thread relay** — `/relay target:#thread message:"..."` lets one Claude session delegate to another, enabling multi-agent coordination patterns
 - **Session status dashboard** — A live pinned embed in the main channel shows which threads are processing vs. waiting for input; owner is @-mentioned when Claude needs a reply
 
 ### CI/CD Automation
@@ -362,7 +361,6 @@ claude_discord/
   cogs/
     claude_chat.py         # Interactive chat (thread creation, message handling)
     skill_command.py       # /skill slash command with autocomplete
-    thread_relay.py        # /relay slash command for cross-thread Claude messaging
     webhook_trigger.py     # Webhook → Claude Code task execution (CI/CD)
     auto_upgrade.py        # Webhook → package upgrade + restart
     _run_helper.py         # Shared Claude CLI execution logic
@@ -376,7 +374,7 @@ claude_discord/
     notification_repo.py   # Scheduled notification CRUD
   discord_ui/
     status.py              # Emoji reaction status manager (debounced)
-    chunker.py             # Fence-aware message splitting
+    chunker.py             # Fence- and table-aware message splitting
     embeds.py              # Discord embed builders
     ask_view.py            # Discord Buttons/Select Menus for AskUserQuestion
     thread_dashboard.py    # Live pinned embed showing session states per thread
@@ -399,7 +397,7 @@ claude_discord/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-400+ tests covering parser, chunker, repository, runner, streaming, webhook triggers, auto-upgrade, REST API, AskUserQuestion UI, thread relay, and thread status dashboard.
+400+ tests covering parser, chunker, repository, runner, streaming, webhook triggers, auto-upgrade, REST API, AskUserQuestion UI, and thread status dashboard.
 
 ## How This Project Was Built
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -55,7 +55,6 @@ GitHub PR (自動マージ)  ←  git push  ←  Claude Code  ←──┘
 - **スキル実行** — スラッシュコマンドとオートコンプリートで Claude Code スキルを実行（`/skill goodmorning`）
 - **並行セッション** — 複数セッションを並列実行（設定可能な上限）
 - **インタラクティブな質問** — Claude が `AskUserQuestion` を呼び出すと、Discord ボタンまたは Select Menu を表示し、回答を受け取ってセッションを再開
-- **クロススレッドリレー** — `/relay target:#thread message:"..."` で一方の Claude セッションから別のセッションへメッセージを委譲（マルチエージェント連携パターン）
 - **セッションステータスダッシュボード** — メインチャンネルにピン留めされた live embed で各スレッドの状態（処理中 / 入力待ち）を一覧表示。Claude が返答を待っているときはオーナーを @mention で通知
 
 ### CI/CD 自動化
@@ -348,7 +347,6 @@ claude_discord/
   cogs/
     claude_chat.py         # インタラクティブチャット（スレッド作成、メッセージ処理）
     skill_command.py       # /skill スラッシュコマンド（オートコンプリート付き）
-    thread_relay.py        # /relay スラッシュコマンド（クロススレッド Claude メッセージング）
     webhook_trigger.py     # Webhook → Claude Code タスク実行（CI/CD）
     auto_upgrade.py        # Webhook → パッケージアップグレード + 再起動
     _run_helper.py         # 共有 Claude CLI 実行ロジック
@@ -362,7 +360,7 @@ claude_discord/
     notification_repo.py   # スケジュール通知 CRUD
   discord_ui/
     status.py              # 絵文字リアクションステータスマネージャー（デバウンス付き）
-    chunker.py             # フェンス対応メッセージ分割
+    chunker.py             # フェンス・テーブル対応メッセージ分割
     embeds.py              # Discord embed ビルダー
     ask_view.py            # AskUserQuestion 用 Discord ボタン / Select Menu
     thread_dashboard.py    # スレッドごとのセッション状態を表示する live ピン留め embed
@@ -385,7 +383,7 @@ claude_discord/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-400 件以上のテストがパーサー、チャンカー、リポジトリ、ランナー、ストリーミング、webhook トリガー、自動アップグレード、REST API、AskUserQuestion UI、スレッドリレー、スレッドステータスダッシュボードをカバーしています。
+400 件以上のテストがパーサー、チャンカー、リポジトリ、ランナー、ストリーミング、webhook トリガー、自動アップグレード、REST API、AskUserQuestion UI、スレッドステータスダッシュボードをカバーしています。
 
 ## このプロジェクトの構築方法
 


### PR DESCRIPTION
## Summary
- Removed `ThreadRelayCog` (`/relay` command) references from docs — the feature was added in `feat(#69)` and immediately reverted in `revert/issue-69-thread-relay` after a design discussion
- Updated `chunker.py` description to reflect table-aware splitting — `fix(#73)` added table header prepending for continuation chunks, ensuring large GFM tables render correctly across multiple Discord messages
- Removed `thread_relay.py` entry from the project structure tree

## 概要
- `ThreadRelayCog`（`/relay` コマンド）の記述をドキュメントから削除 — `feat(#69)` で追加されたが、設計議論の結果 `revert/issue-69-thread-relay` で即座に差し戻し
- `chunker.py` の説明をテーブル対応に更新 — `fix(#73)` でテーブル継続チャンクへのヘッダー付加処理が追加され、大きな GFM テーブルが複数の Discord メッセージにまたがっても正しくレンダリングされるように
- プロジェクト構造ツリーから `thread_relay.py` の記述を削除

## Changed files
- `README.md`
- `docs/ja/README.md`

---
🤖 Auto-generated by [docs-sync](https://github.com/ebibibi/claude-code-discord-bridge)
