### PR TITLE
fix(#73): wrap GFM tables in code fences for consistent Discord rendering

### DIFF
--- a/claude_discord/discord_ui/chunker.py
+++ b/claude_discord/discord_ui/chunker.py
@@ -1,14 +1,12 @@
-"""Fence-aware and table-aware message chunker for Discord's 2000-character limit.
+"""Fence-aware message chunker for Discord's 2000-character limit.
 
 Inspired by OpenClaw: never split inside a code block. If forced to split,
 properly close and reopen the fence markers.
 
-Tables (GitHub Flavored Markdown pipe-tables) are treated as atomic blocks:
-the chunker walks back from any candidate split point to the start of the
-enclosing table so that Discord can render the whole table in one message.
-When a table is too large to fit in a single message, continuation chunks
-receive the table header+separator prepended so each chunk renders as a
-standalone table.
+GFM pipe-tables are wrapped in triple-backtick fences before chunking.
+This gives consistent monospace rendering in Discord for any table size:
+small tables that fit in one message and large tables that must be split
+across messages both appear with correct column alignment.
 """
 
 from __future__ import annotations
@@ -22,15 +20,16 @@ def chunk_message(text: str, max_chars: int = EFFECTIVE_MAX) -> list[str]:
     """Split a message into Discord-safe chunks.
 
     Rules:
-    1. Prefer splitting at paragraph boundaries (blank lines)
-    2. Never split inside a code fence if possible
-    3. If forced to split inside a fence, close it and reopen in next chunk
-    4. Never split inside a markdown table block
+    1. Wrap GFM pipe-tables in code fences for consistent monospace rendering
+    2. Prefer splitting at paragraph boundaries (blank lines)
+    3. Never split inside a code fence if possible
+    4. If forced to split inside a fence, close it and reopen in next chunk
     5. Respect max_chars limit per chunk
-    6. If a table must be split, prepend its header to continuation chunks
     """
     if not text:
         return []
+
+    text = _wrap_tables_in_fences(text)
 
     if len(text) <= max_chars:
         return [text]
@@ -56,38 +55,71 @@ def chunk_message(text: str, max_chars: int = EFFECTIVE_MAX) -> list[str]:
         if fence_lang is not None:
             remaining = f"```{fence_lang}\n{remaining}"
 
-    raw = [c for c in chunks if c.strip()]
-    return _fix_table_continuations(raw)
+    return [c for c in chunks if c.strip()]
 
 
-def _fix_table_continuations(chunks: list[str]) -> list[str]:
-    """Prepend the table header to any chunk that starts mid-table.
+def _wrap_tables_in_fences(text: str) -> str:
+    """Wrap every GFM pipe-table block in a triple-backtick code fence.
 
-    When a large table is split across messages, continuation chunks start
-    with data rows but no header.  Discord requires a header+separator in
-    every message to render the table correctly.  This pass tracks the active
-    table header across chunks and prepends it where needed.
+    Discord renders GFM tables natively only when the complete table fits in
+    a single message.  When a large table must be split, continuation chunks
+    have no header and appear as raw pipe characters.  Wrapping tables in
+    code fences lets the existing fence-aware chunker handle splitting with
+    proper close/reopen semantics, giving monospace alignment in every chunk.
+
+    Tables already inside a code fence are left untouched.
     """
+    lines = text.splitlines(keepends=True)
     result: list[str] = []
-    current_header: str | None = None
+    in_fence = False
+    in_table = False
 
-    for chunk in chunks:
-        if current_header and _is_table_continuation_chunk(chunk):
-            chunk = current_header + chunk
+    for line in lines:
+        stripped = line.rstrip("\n\r")
 
-        # Update the active header: keep it if this chunk ends mid-table,
-        # clear it if the chunk ends outside a table.
-        if _chunk_ends_in_table(chunk):
-            new_header = _find_chunk_table_header(chunk)
-            if new_header is not None:
-                current_header = new_header
-            # else: keep current_header (shouldn't happen if table is well-formed)
-        else:
-            current_header = None
+        # Track outer code fences — don't double-wrap already-fenced content
+        if stripped.strip().startswith("```"):
+            if in_table:
+                # Close the table fence before the outer fence opens
+                _ensure_newline(result)
+                result.append("```\n")
+                in_table = False
+            in_fence = not in_fence
+            result.append(line)
+            continue
 
-        result.append(chunk)
+        if in_fence:
+            result.append(line)
+            continue
 
-    return result
+        is_table = _is_table_line(stripped)
+
+        if is_table and not in_table:
+            result.append("```\n")
+            in_table = True
+        elif not is_table and in_table:
+            _ensure_newline(result)
+            result.append("```\n")
+            in_table = False
+
+        result.append(line)
+
+    if in_table:
+        _ensure_newline(result)
+        result.append("```\n")
+
+    return "".join(result)
+
+
+def _ensure_newline(parts: list[str]) -> None:
+    """Append a newline to *parts* if the last part does not end with one.
+
+    Used by ``_wrap_tables_in_fences`` to guarantee that a closing fence
+    marker always starts on its own line, even when the last table row
+    was not terminated with a newline.
+    """
+    if parts and not parts[-1].endswith("\n"):
+        parts.append("\n")
 
 
 def _find_split_point(text: str, max_chars: int) -> int:
@@ -97,23 +129,17 @@ def _find_split_point(text: str, max_chars: int) -> int:
     1. Paragraph break (blank line) before max_chars
     2. Line break before max_chars
     3. Hard split at max_chars
-
-    After finding a candidate, the split is moved back to the start of any
-    enclosing markdown table block so tables are never split mid-block.
     """
     search_region = text[:max_chars]
 
     # Search backward from max_chars for a blank line
     last_paragraph = search_region.rfind("\n\n")
     if last_paragraph > max_chars // 3:
-        candidate = last_paragraph + 1
-    else:
-        # Search backward for any newline
-        last_newline = search_region.rfind("\n")
-        candidate = last_newline + 1 if last_newline > max_chars // 3 else max_chars
+        return last_paragraph + 1
 
-    # Don't split inside a markdown table block
-    return _retreat_to_table_start(text, candidate)
+    # Search backward for any newline
+    last_newline = search_region.rfind("\n")
+    return last_newline + 1 if last_newline > max_chars // 3 else max_chars
 
 
 def _is_table_line(line: str) -> bool:
@@ -124,129 +150,6 @@ def _is_table_line(line: str) -> bool:
     """
     stripped = line.strip()
     return len(stripped) >= 3 and stripped.startswith("|") and stripped.endswith("|")
-
-
-def _is_separator_row(line: str) -> bool:
-    """Return True if *line* is a GFM table separator row.
-
-    Separator rows contain only pipes, dashes, spaces, and optional colons
-    (for alignment).  Example: ``|---|:---:|---:|``
-    """
-    if not _is_table_line(line):
-        return False
-    inner = line.strip()[1:-1]  # strip outer pipes
-    return all(c in "-: |" for c in inner)
-
-
-def _chunk_ends_in_table(chunk: str) -> bool:
-    """Return True if the last non-blank line of *chunk* is a table line."""
-    for line in reversed(chunk.splitlines()):
-        if line.strip():
-            return _is_table_line(line)
-    return False
-
-
-def _find_chunk_table_header(chunk: str) -> str | None:
-    """Return the header+separator string of the table that *chunk* ends in.
-
-    Scans *chunk* forward to find the last complete header+separator pair
-    belonging to the table that the chunk ends with.  Returns
-    ``"header_row\\nsep_row\\n"`` or ``None`` if the table has no parseable
-    header in this chunk.
-
-    Only call this after confirming ``_chunk_ends_in_table(chunk)`` is True.
-    """
-    lines = chunk.splitlines()
-    header_line: str | None = None
-    sep_line: str | None = None
-
-    for line in lines:
-        if not _is_table_line(line):
-            # Any non-table line (blank or text) marks a boundary between tables.
-            # Reset tracking so the next table is treated as independent.
-            header_line = None
-            sep_line = None
-            continue
-
-        if _is_separator_row(line):
-            if header_line is not None and sep_line is None:
-                sep_line = line
-        else:
-            if sep_line is None:
-                # Before we've seen the separator — this could be the header row
-                header_line = line
-            # After separator: data row; keep the captured header+sep
-
-    if header_line and sep_line:
-        return f"{header_line}\n{sep_line}\n"
-    return None
-
-
-def _is_table_continuation_chunk(chunk: str) -> bool:
-    """Return True if *chunk* starts with table data rows but has no header.
-
-    A "continuation chunk" is one produced by splitting a large table: it
-    begins with rows that belong to the previous chunk's table but has no
-    header+separator of its own.
-    """
-    lines = [ln for ln in chunk.splitlines() if ln.strip()]
-    if not lines or not _is_table_line(lines[0]):
-        return False
-
-    # If the first table line is a separator, the header was in the previous chunk.
-    if _is_separator_row(lines[0]):
-        return True
-
-    # First line is a data/header row.  A proper new table has a separator as
-    # the second table line.  If we don't see one in the first few table lines,
-    # this chunk is a continuation.
-    table_lines_seen = 0
-    for line in lines:
-        if not _is_table_line(line):
-            break
-        table_lines_seen += 1
-        if table_lines_seen == 1:
-            continue  # skip the first (already checked above)
-        # Second table line is also a data row → continuation (no separator found)
-        return not _is_separator_row(line)
-
-    # Only one table line found (or zero non-table lines after first)
-    return True
-
-
-def _retreat_to_table_start(text: str, split_pos: int) -> int:
-    """If *split_pos* falls inside a markdown table block, return the position
-    of the first character of that block.  Otherwise return *split_pos* unchanged.
-
-    Ensures tables are kept intact so Discord can render them correctly.
-    If the table starts at position 0 we cannot retreat further, so we return
-    the original split_pos to avoid an infinite loop in the caller.
-    """
-    text_before = text[:split_pos]
-    lines = text_before.split("\n")
-
-    # Walk backwards, skipping any trailing blank lines
-    i = len(lines) - 1
-    while i >= 0 and not lines[i].strip():
-        i -= 1
-
-    # If the last non-blank line is not a table line, we're not inside a table
-    if i < 0 or not _is_table_line(lines[i]):
-        return split_pos
-
-    # Walk further back to find the first line of the table block
-    while i >= 0 and _is_table_line(lines[i]):
-        i -= 1
-
-    # i now points to the last line *before* the table
-    table_first_line_idx = i + 1
-    table_start_char = sum(len(lines[j]) + 1 for j in range(table_first_line_idx))
-
-    if table_start_char == 0:
-        # Table starts at the very beginning — cannot retreat, avoid infinite loop
-        return split_pos
-
-    return table_start_char
 
 
 def _close_open_fence(chunk: str) -> tuple[str, str | None]:


### PR DESCRIPTION
## Summary

- Replaces the header-prepending approach from #74 with a simpler strategy: pre-process every GFM pipe-table into a ` ``` ` code fence before chunking
- The header-prepending approach had a subtle infinite-loop risk and required complex continuation-detection logic
- Code-fence wrapping reuses the existing `_close_open_fence` / reopen logic with no new state machine

## Why code fence instead of native GFM table

Discord's native GFM table rendering requires the **complete** table (header + separator + all rows) in a single message. When a large table is split, continuation chunks have no header and render as raw `| pipe | chars |`.

Wrapping in a code fence gives monospace alignment in every case:
- Small table (fits in one message): single fenced block ✅
- Large table (must be split): each chunk is a valid fenced block with balanced markers ✅

## Changes

- `_wrap_tables_in_fences(text)`: new pre-processing step; tables already inside a fence are left untouched
- `_ensure_newline(parts)`: helper to guarantee closing fence starts on its own line
- **Removed** (no longer needed): `_retreat_to_table_start`, `_fix_table_continuations`, `_chunk_ends_in_table`, `_find_chunk_table_header`, `_is_table_continuation_chunk`, `_is_separator_row`
- Tests updated (29 tests, all passing)

## Note

PR #74 auto-merged before the correct commit was pushed — this PR supersedes it.

Closes #73

## Test plan

- [x] `pytest tests/test_chunker.py` — 29 tests pass
- [x] Small table: verify rendered as fenced monospace block
- [x] Large table (>1950 chars): verify each split chunk has balanced fence markers