### PR TITLE
ci: skip auto-merge for draft PRs to prevent mid-work merges

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,10 +1,16 @@
 name: Auto Approve Owner PRs
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # ready_for_review: fires when a draft PR is converted to ready — this is
+    # the intended trigger for multi-commit workflows where the PR is opened
+    # as a draft, all commits are pushed, and then the PR is marked ready.
+    types: [opened, synchronize, reopened, ready_for_review]
 jobs:
   auto-approve-and-merge:
-    if: github.event.pull_request.user.login == 'ebibibi'
+    # Skip draft PRs — only auto-merge when the PR is explicitly marked ready.
+    # This prevents the race condition where auto-merge fires on the first
+    # commit before subsequent commits have been pushed.
+    if: github.event.pull_request.user.login == 'ebibibi' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Problem

When a PR was opened with the **first commit**, the `auto-approve` workflow immediately triggered and enabled auto-merge. As soon as CI passed, GitHub merged the PR — before the second (correct) commit could be pushed.

**Concrete example** — PR #74 in this repo:
1. Commit 1 (header-prepending approach) pushed → PR created → CI passed → auto-merged ✅
2. Commit 2 (code-fence approach, the actual fix) pushed → orphaned on the branch ❌
3. Result: `origin/main` shipped the wrong code; discord-bot rendered raw pipes

## Fix

Two minimal changes to `auto-approve.yml`:

1. **Add `ready_for_review` event** — fires when a Draft PR is converted to ready, which is the new intended trigger
2. **Add `draft == false` guard** — skips auto-approve for any event on a draft PR (`opened`, `synchronize`, `reopened`)

## New workflow for multi-commit PRs

```bash
# 1. Create PR as draft — safe, auto-merge won't fire
gh pr create --draft --title "..." --body "..."

# 2. Push all commits (iterate freely)
git commit -m "first attempt"
git commit -m "correct approach"
git push

# 3. Mark ready — THIS is when CI + auto-approve + auto-merge fires
gh pr ready
```

Non-draft PRs (`gh pr create` without `--draft`) continue to work exactly as before.

## Test plan
- [ ] Open a draft PR → confirm auto-approve workflow is skipped
- [ ] Convert draft to ready → confirm auto-approve fires and merges
- [ ] Open a non-draft PR → confirm existing behavior unchanged