### PR TITLE
feat: coordination channel for cross-session awareness (#78)

### DIFF
--- a/claude_discord/bot.py
+++ b/claude_discord/bot.py
@@ -9,6 +9,7 @@ import discord
 from discord.ext import commands
 
 from .concurrency import SessionRegistry
+from .coordination.service import CoordinationService
 
 if TYPE_CHECKING:
     from .discord_ui.thread_dashboard import ThreadStatusDashboard
@@ -19,7 +20,12 @@ logger = logging.getLogger(__name__)
 class ClaudeDiscordBot(commands.Bot):
     """Discord bot that bridges messages to Claude Code CLI."""
 
-    def __init__(self, channel_id: int, owner_id: int | None = None) -> None:
+    def __init__(
+        self,
+        channel_id: int,
+        owner_id: int | None = None,
+        coordination_channel_id: int | None = None,
+    ) -> None:
         intents = discord.Intents.default()
         intents.message_content = True
         intents.guilds = True
@@ -33,6 +39,8 @@ class ClaudeDiscordBot(commands.Bot):
         self.session_registry = SessionRegistry()
         # Populated after on_ready when the channel is resolved
         self.thread_dashboard: ThreadStatusDashboard | None = None
+        # Coordination channel for multi-session awareness (optional)
+        self.coordination = CoordinationService(self, coordination_channel_id)
 
     async def on_ready(self) -> None:
         logger.info("Logged in as %s (ID: %s)", self.user, self.user.id if self.user else "?")

--- a/claude_discord/coordination/__init__.py
+++ b/claude_discord/coordination/__init__.py
@@ -1,0 +1,5 @@
+"""Coordination channel support for multi-session awareness."""
+
+from .service import CoordinationService
+
+__all__ = ["CoordinationService"]

--- a/claude_discord/coordination/service.py
+++ b/claude_discord/coordination/service.py
@@ -1,0 +1,75 @@
+"""CoordinationService — posts session lifecycle events to the coordination channel.
+
+The coordination channel is a shared Discord channel where Claude Code sessions
+broadcast what they are doing. This enables multiple concurrent sessions to be
+aware of each other and avoid accidental conflicts.
+
+Bot side (this module):
+  - Auto-posts session start / end events
+  - Feature is a no-op when COORDINATION_CHANNEL_ID is not configured
+
+Claude side (see ~/.claude/skills/coordination-channel/):
+  - Uses coord_post.py / coord_read.py scripts to post / read at will
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import discord
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+class CoordinationService:
+    """Posts lifecycle events to a shared coordination channel.
+
+    All methods are safe to call when no coordination channel is configured —
+    they become no-ops, so consumers never need to guard against None.
+    """
+
+    def __init__(self, bot: discord.Client, channel_id: int | None) -> None:
+        self._bot = bot
+        self._channel_id = channel_id
+
+    @property
+    def enabled(self) -> bool:
+        return self._channel_id is not None
+
+    def _get_channel(self) -> discord.TextChannel | None:
+        if self._channel_id is None:
+            return None
+        channel = self._bot.get_channel(self._channel_id)
+        if channel is None:
+            logger.warning("Coordination channel %d not found in bot cache", self._channel_id)
+        return channel  # type: ignore[return-value]
+
+    async def post_session_start(self, thread: discord.Thread, prompt_preview: str) -> None:
+        """Post a session-started notice to the coordination channel."""
+        channel = self._get_channel()
+        if channel is None:
+            return
+        preview = prompt_preview[:80].replace("\n", " ")
+        content = f"🔵 **{thread.name}** セッション開始 | {preview}"
+        await self._safe_send(channel, content)
+
+    async def post_session_end(self, thread: discord.Thread) -> None:
+        """Post a session-ended notice to the coordination channel."""
+        channel = self._get_channel()
+        if channel is None:
+            return
+        content = f"✅ **{thread.name}** セッション終了"
+        await self._safe_send(channel, content)
+
+    async def _safe_send(self, channel: discord.TextChannel, content: str) -> None:
+        """Send a message, swallowing HTTP errors so lifecycle events never crash."""
+        try:
+            await channel.send(content)
+        except discord.HTTPException:
+            logger.warning(
+                "Failed to post to coordination channel %d", self._channel_id, exc_info=True
+            )

--- a/claude_discord/main.py
+++ b/claude_discord/main.py
@@ -45,6 +45,7 @@ def load_config() -> dict[str, str]:
         "max_concurrent": os.getenv("MAX_CONCURRENT_SESSIONS", "3"),
         "timeout": os.getenv("SESSION_TIMEOUT_SECONDS", "300"),
         "owner_id": os.getenv("DISCORD_OWNER_ID", ""),
+        "coordination_channel_id": os.getenv("COORDINATION_CHANNEL_ID", ""),
     }
 
 
@@ -70,7 +71,14 @@ async def main() -> None:
     )
 
     owner_id = int(config["owner_id"]) if config["owner_id"] else None
-    bot = ClaudeDiscordBot(channel_id=int(config["channel_id"]), owner_id=owner_id)
+    coordination_channel_id = (
+        int(config["coordination_channel_id"]) if config["coordination_channel_id"] else None
+    )
+    bot = ClaudeDiscordBot(
+        channel_id=int(config["channel_id"]),
+        owner_id=owner_id,
+        coordination_channel_id=coordination_channel_id,
+    )
 
     # Register cog
     cog = ClaudeChatCog(

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -1,0 +1,160 @@
+"""Tests for CoordinationService."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from claude_discord.coordination.service import CoordinationService
+
+
+def _make_thread(name: str = "Test Thread") -> MagicMock:
+    thread = MagicMock(spec=discord.Thread)
+    thread.name = name
+    return thread
+
+
+def _make_channel() -> MagicMock:
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.send = AsyncMock()
+    return channel
+
+
+def _make_bot(channel: MagicMock | None = None) -> MagicMock:
+    bot = MagicMock(spec=discord.Client)
+    bot.get_channel = MagicMock(return_value=channel)
+    return bot
+
+
+class TestCoordinationServiceEnabled:
+    def test_enabled_when_channel_id_set(self) -> None:
+        svc = CoordinationService(_make_bot(), channel_id=1234)
+        assert svc.enabled is True
+
+    def test_disabled_when_channel_id_none(self) -> None:
+        svc = CoordinationService(_make_bot(), channel_id=None)
+        assert svc.enabled is False
+
+
+class TestCoordinationServiceNoOp:
+    """When no channel is configured all methods are no-ops."""
+
+    @pytest.mark.asyncio
+    async def test_post_session_start_noop(self) -> None:
+        bot = _make_bot()
+        svc = CoordinationService(bot, channel_id=None)
+        # Should not raise and should not call get_channel
+        await svc.post_session_start(_make_thread(), "hello")
+        bot.get_channel.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_post_session_end_noop(self) -> None:
+        bot = _make_bot()
+        svc = CoordinationService(bot, channel_id=None)
+        await svc.post_session_end(_make_thread())
+        bot.get_channel.assert_not_called()
+
+
+class TestCoordinationServicePosts:
+    """When a channel is configured, posts are sent."""
+
+    @pytest.mark.asyncio
+    async def test_post_session_start_sends_message(self) -> None:
+        channel = _make_channel()
+        bot = _make_bot(channel)
+        svc = CoordinationService(bot, channel_id=9999)
+
+        thread = _make_thread("Issue #42")
+        await svc.post_session_start(thread, "Fix the login bug")
+
+        channel.send.assert_called_once()
+        sent = channel.send.call_args[0][0]
+        assert "Issue #42" in sent
+        assert "Fix the login bug" in sent
+
+    @pytest.mark.asyncio
+    async def test_post_session_end_sends_message(self) -> None:
+        channel = _make_channel()
+        bot = _make_bot(channel)
+        svc = CoordinationService(bot, channel_id=9999)
+
+        thread = _make_thread("Issue #42")
+        await svc.post_session_end(thread)
+
+        channel.send.assert_called_once()
+        sent = channel.send.call_args[0][0]
+        assert "Issue #42" in sent
+
+    @pytest.mark.asyncio
+    async def test_prompt_preview_truncated_to_80_chars(self) -> None:
+        channel = _make_channel()
+        bot = _make_bot(channel)
+        svc = CoordinationService(bot, channel_id=9999)
+
+        long_prompt = "a" * 200
+        await svc.post_session_start(_make_thread(), long_prompt)
+
+        sent = channel.send.call_args[0][0]
+        # The preview section should not contain 200 'a's
+        assert "a" * 81 not in sent
+
+    @pytest.mark.asyncio
+    async def test_newlines_in_preview_replaced(self) -> None:
+        channel = _make_channel()
+        bot = _make_bot(channel)
+        svc = CoordinationService(bot, channel_id=9999)
+
+        await svc.post_session_start(_make_thread(), "line1\nline2")
+
+        sent = channel.send.call_args[0][0]
+        assert "\n" not in sent
+
+
+class TestCoordinationServiceChannelNotFound:
+    """When get_channel returns None (not in cache), methods are silent no-ops."""
+
+    @pytest.mark.asyncio
+    async def test_start_no_channel_in_cache(self) -> None:
+        bot = _make_bot(channel=None)  # get_channel returns None
+        svc = CoordinationService(bot, channel_id=9999)
+        # Should not raise
+        await svc.post_session_start(_make_thread(), "hello")
+
+    @pytest.mark.asyncio
+    async def test_end_no_channel_in_cache(self) -> None:
+        bot = _make_bot(channel=None)
+        svc = CoordinationService(bot, channel_id=9999)
+        await svc.post_session_end(_make_thread())
+
+
+class TestCoordinationServiceHTTPError:
+    """HTTP errors from Discord are swallowed so they never crash the bot."""
+
+    @pytest.mark.asyncio
+    async def test_http_error_on_start_is_swallowed(self) -> None:
+        channel = _make_channel()
+        http_response = MagicMock()
+        http_response.status = 500
+        http_response.reason = "Internal Server Error"
+        channel.send.side_effect = discord.HTTPException(http_response, "error")
+
+        bot = _make_bot(channel)
+        svc = CoordinationService(bot, channel_id=9999)
+
+        # Should not raise
+        await svc.post_session_start(_make_thread(), "hello")
+
+    @pytest.mark.asyncio
+    async def test_http_error_on_end_is_swallowed(self) -> None:
+        channel = _make_channel()
+        http_response = MagicMock()
+        http_response.status = 500
+        http_response.reason = "Internal Server Error"
+        channel.send.side_effect = discord.HTTPException(http_response, "error")
+
+        bot = _make_bot(channel)
+        svc = CoordinationService(bot, channel_id=9999)
+
+        await svc.post_session_end(_make_thread())


### PR DESCRIPTION
## Summary

- Add `CoordinationService` that auto-posts session lifecycle events to a shared `#ai-communication` Discord channel
- Add skill scripts (`coord_post.py` / `coord_read.py`) + `SKILL.md` so Claude can read/write on demand at any point during a session
- Feature is fully opt-in: no-op when `COORDINATION_CHANNEL_ID` is not set

## Motivation

When multiple Claude Code sessions work in parallel, they have no visibility into each other. This can cause conflicting changes, duplicate work, or accidental overwrites. The coordination channel gives sessions a lightweight shared awareness layer.

## Design

**Bot side** (`CoordinationService`):
- Posts "session started" / "session ended" automatically when `COORDINATION_CHANNEL_ID` is configured
- All calls are safe no-ops when unconfigured — zero impact on existing deployments

**Claude side** (skill scripts, stdlib only — no venv dependency):
- `coord_read.py --minutes N` — read recent messages from `#ai-communication`
- `coord_post.py "message"` — post from Claude to the channel
- `SKILL.md` guides Claude on *when* to read (not just at session start — on demand, so mid-session changes from other sessions are visible)

## Test plan

- [x] `tests/test_coordination.py` — 12 unit tests covering: enabled/disabled state, no-op when unconfigured, correct message content, prompt truncation at 80 chars, newline replacement, channel-not-in-cache handling, HTTP error swallowing
- [x] All 405 existing tests still pass

## Environment variable

```env
COORDINATION_CHANNEL_ID=1474220010158161991   # #ai-communication channel
```

Closes #78