### PR TITLE
[docs-sync] Update documentation (English + Japanese)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ GitHub PR (auto-merge)  ←  git push  ←  Claude Code  ←──┘
 - **Timeout notifications** — Dedicated embed with elapsed seconds and actionable guidance when a session times out
 - **Interactive questions** — When Claude calls `AskUserQuestion`, the bot renders Discord Buttons or a Select Menu and resumes the session with your answer
 - **Session status dashboard** — A live pinned embed in the main channel shows which threads are processing vs. waiting for input; owner is @-mentioned when Claude needs a reply
+- **Multi-session coordination** — When `COORDINATION_CHANNEL_ID` is set, each session broadcasts start/end events to a shared channel so concurrent sessions stay aware of each other
 
 ### CI/CD Automation
 - **Webhook triggers** — Trigger Claude Code tasks from GitHub Actions or any CI/CD system
@@ -144,6 +145,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `MAX_CONCURRENT_SESSIONS` | Max parallel sessions | `3` |
 | `SESSION_TIMEOUT_SECONDS` | Session inactivity timeout | `300` |
 | `DISCORD_OWNER_ID` | Discord user ID to @-mention when Claude needs input | (optional) |
+| `COORDINATION_CHANNEL_ID` | Channel ID for multi-session coordination broadcasts | (optional) |
 
 ## Discord Bot Setup
 
@@ -372,6 +374,8 @@ claude_discord/
     models.py              # SQLite schema
     repository.py          # Session CRUD operations
     notification_repo.py   # Scheduled notification CRUD
+  coordination/
+    service.py             # CoordinationService — posts session lifecycle events to a shared channel
   discord_ui/
     status.py              # Emoji reaction status manager (debounced)
     chunker.py             # Fence- and table-aware message splitting

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -56,6 +56,7 @@ GitHub PR (自動マージ)  ←  git push  ←  Claude Code  ←──┘
 - **並行セッション** — 複数セッションを並列実行（設定可能な上限）
 - **インタラクティブな質問** — Claude が `AskUserQuestion` を呼び出すと、Discord ボタンまたは Select Menu を表示し、回答を受け取ってセッションを再開
 - **セッションステータスダッシュボード** — メインチャンネルにピン留めされた live embed で各スレッドの状態（処理中 / 入力待ち）を一覧表示。Claude が返答を待っているときはオーナーを @mention で通知
+- **マルチセッション協調** — `COORDINATION_CHANNEL_ID` を設定すると、各セッションの開始・終了イベントを共有チャンネルにブロードキャストし、並行セッション同士がお互いの状況を把握できる
 
 ### CI/CD 自動化
 - **Webhook トリガー** — GitHub Actions や任意の CI/CD システムから Claude Code タスクをトリガー
@@ -130,6 +131,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `MAX_CONCURRENT_SESSIONS` | 最大並行セッション数 | `3` |
 | `SESSION_TIMEOUT_SECONDS` | セッション非アクティブタイムアウト | `300` |
 | `DISCORD_OWNER_ID` | Claude が入力待ちのとき @mention する Discord ユーザー ID | （オプション） |
+| `COORDINATION_CHANNEL_ID` | マルチセッション協調ブロードキャスト用チャンネル ID | （オプション） |
 
 ## Discord Bot のセットアップ
 
@@ -358,6 +360,8 @@ claude_discord/
     models.py              # SQLite スキーマ
     repository.py          # セッション CRUD 操作
     notification_repo.py   # スケジュール通知 CRUD
+  coordination/
+    service.py             # CoordinationService — セッションライフサイクルイベントを共有チャンネルに投稿
   discord_ui/
     status.py              # 絵文字リアクションステータスマネージャー（デバウンス付き）
     chunker.py             # フェンス・テーブル対応メッセージ分割


### PR DESCRIPTION
## Summary
- Added `CoordinationService` documentation: new `COORDINATION_CHANNEL_ID` environment variable, multi-session coordination feature bullet, and `coordination/` directory in the architecture tree
- The new module broadcasts session start/end events to a shared Discord channel, enabling awareness across concurrent Claude Code sessions

## 概要
- `CoordinationService` のドキュメントを追加: 新しい `COORDINATION_CHANNEL_ID` 環境変数、マルチセッション協調機能の説明、アーキテクチャツリーへの `coordination/` ディレクトリ追記
- 新モジュールは、セッションの開始・終了イベントを共有 Discord チャンネルにブロードキャストし、並行する Claude Code セッション同士が互いの状況を把握できるようにします

## Changed files
- `README.md`
- `docs/ja/README.md`

---
🤖 Auto-generated by [docs-sync](https://github.com/ebibibi/claude-code-discord-bridge)
