### PR TITLE
feat(#84): live elapsed-time counter for long-running tool embeds

### DIFF
--- a/claude_discord/claude/types.py
+++ b/claude_discord/claude/types.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any
@@ -141,11 +142,15 @@ class StreamEvent:
 class SessionState:
     """Tracks the state of a Claude Code session during a single run.
 
-    active_tools maps tool_use_id -> Discord Message, enabling Phase 2
-    live embed updates when tool results arrive.
+    active_tools maps tool_use_id -> Discord Message, enabling live embed
+    updates when tool results arrive.
+
+    active_timers maps tool_use_id -> asyncio.Task that periodically edits
+    the in-progress embed to show elapsed execution time. Cancelled on result.
     """
 
     session_id: str | None = None
     thread_id: int = 0
     accumulated_text: str = ""
     active_tools: dict[str, discord.Message] = field(default_factory=dict)
+    active_timers: dict[str, asyncio.Task[None]] = field(default_factory=dict)

--- a/claude_discord/discord_ui/embeds.py
+++ b/claude_discord/discord_ui/embeds.py
@@ -25,11 +25,26 @@ CATEGORY_ICON: dict[ToolCategory, str] = {
 }
 
 
-def tool_use_embed(tool: ToolUseEvent, in_progress: bool = True) -> discord.Embed:
-    """Create an embed for a tool use event."""
+def tool_use_embed(
+    tool: ToolUseEvent,
+    in_progress: bool = True,
+    elapsed_s: int | None = None,
+) -> discord.Embed:
+    """Create an embed for a tool use event.
+
+    Args:
+        tool: The tool use event to display.
+        in_progress: Whether the tool is still running.
+        elapsed_s: Seconds elapsed since the tool started. When provided and
+                   the tool is in-progress, the elapsed time is shown in the
+                   title so the user can track long-running commands.
+    """
     icon = CATEGORY_ICON.get(tool.category, "\U0001f916")
-    status = "..." if in_progress else ""
-    title = f"{icon} {tool.display_name}{status}"
+    if in_progress:
+        elapsed_str = f" ({elapsed_s}s)" if elapsed_s is not None else ""
+        title = f"{icon} {tool.display_name}{elapsed_str}..."
+    else:
+        title = f"{icon} {tool.display_name}"
 
     embed = discord.Embed(
         title=title[:256],


### PR DESCRIPTION
## Summary

Closes #84

When Claude Code runs a Bash command (or any tool), users previously saw a static
"🔧 Running: az login..." embed with zero updates until the command completed.
For long-running commands like `az login --use-device-code`, this meant the
embed froze indefinitely while waiting for user action.

This PR adds a `LiveToolTimer` that ticks every 10 seconds, editing the embed
to show elapsed time:

```
🔧 Running: az login --use-device-code... (10s)
🔧 Running: az login --use-device-code... (20s)
🔧 Running: az login --use-device-code... (30s)
```

## Changes

- **`LiveToolTimer`** (`_run_helper.py`): asyncio background task that edits the
  in-progress embed with elapsed seconds. Started on `tool_use`, cancelled on
  `tool_result` or session end (even on errors/interrupts).
- **`tool_use_embed`** (`embeds.py`): new optional `elapsed_s: int | None`
  parameter — renders `(Ns)...` suffix in the title when in-progress.
- **`SessionState.active_timers`** (`types.py`): `dict[str, asyncio.Task]` that
  tracks per-tool timers alongside the existing `active_tools` dict.
- **`TOOL_TIMER_INTERVAL = 10`** — module-level constant, easy to patch in tests.

## Limitations (noted in the issue)

The `stream-json` protocol does not expose intermediate stdout from Bash
execution, so actual command output cannot be streamed. This PR provides the
best available signal: elapsed time. The `tool_result` embed still shows the
full output once the command finishes.

## Test plan

- [x] `TestToolUseEmbed` — elapsed_s rendering, title length cap, in_progress vs completed
- [x] `TestLiveToolTimer` — timer fires after interval, stops on cancel, cancels on tool_result
- [x] Full test suite: 413 passed, 0 failures