### PR TITLE
fix: elapsed time to description + result expanded to 30 lines

### DIFF
--- a/claude_discord/cogs/_run_helper.py
+++ b/claude_discord/cogs/_run_helper.py
@@ -43,8 +43,10 @@ STREAM_EDIT_INTERVAL = 1.5
 # Max characters before starting a new streaming message
 STREAM_MAX_CHARS = 1900
 
-# Max characters for tool result display
-TOOL_RESULT_MAX_CHARS = 500
+# Max characters for tool result display.
+# Sized to show ~30 lines of typical output (100 chars/line × 30 = 3000).
+# The embed description limit is 4096, so this leaves room for code block markers.
+TOOL_RESULT_MAX_CHARS = 3000
 
 # How often to update in-progress tool embeds with elapsed time (seconds).
 # Gives users visibility into long-running commands (builds, auth flows, etc.).

--- a/tests/test_run_helper.py
+++ b/tests/test_run_helper.py
@@ -579,10 +579,12 @@ class TestLiveToolTimer:
             rh.TOOL_TIMER_INTERVAL = original_interval
 
         msg.edit.assert_called()
-        # The embed passed to edit should include elapsed time in the title
+        # Elapsed time must be in description (title stays stable across ticks)
         call_embed = msg.edit.call_args.kwargs.get("embed")
         assert call_embed is not None
-        assert "s)" in call_embed.title  # e.g. "(0s)..." or "(1s)..."
+        assert call_embed.description is not None
+        assert "s" in call_embed.description  # e.g. "⏳ 0s elapsed..."
+        assert "s)" not in call_embed.title  # title must NOT contain elapsed time
 
     @pytest.mark.asyncio
     async def test_timer_cancelled_stops_updates(self) -> None:


### PR DESCRIPTION
## Summary

Two UX improvements from live testing of the `LiveToolTimer` feature (#84):

### 1. Elapsed time moved from title → description

**Before** (title rewrites every 10s → hard to read):
```
🔧 Running: for i in $(seq 1 7); do echo... (10s)...
🔧 Running: for i in $(seq 1 7); do echo... (20s)...
```

**After** (title is stable, description updates):
```
🔧 Running: for i in $(seq 1 7); do echo...   ← never changes
⏳ 10s elapsed...                              ← only this updates
```

### 2. Tool result display: field → description, 500 → 3000 chars

- Discord field limit: **1024 chars** → description limit: **4096 chars**
- `TOOL_RESULT_MAX_CHARS`: **500** → **3000** (~30 lines × 100 chars/line)
- Switched from `embed.add_field()` to `embed.description` (same code block style as `thinking_embed`)

## Test plan

- [x] `test_in_progress_with_elapsed_shows_description` — elapsed in description, not title
- [x] `test_title_stable_across_ticks` — title identical at t=0, t=10, t=20
- [x] `test_completed_ignores_elapsed` — description is None when in_progress=False
- [x] `test_30_lines_fit_without_truncation` — 30 lines appear in full
- [x] `test_result_in_description_not_field` — no fields used
- [x] Full suite: 419 passed