### PR TITLE
feat(#90): SchedulerCog — periodic Claude Code tasks via chat + REST API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Scheduled Task Executor** (`SchedulerCog`) — register periodic Claude Code tasks via Discord chat or REST API. Tasks are stored in SQLite and executed by a single 30-second master loop. No code changes needed to add new tasks (#90)
+- **`/api/tasks` REST endpoints** — `POST`, `GET`, `DELETE`, `PATCH` for managing scheduled tasks. Claude Code calls these via Bash tool using `CCDB_API_URL` env var
+- **`TaskRepository`** (`database/task_repo.py`) — CRUD for `scheduled_tasks` table with `get_due()`, `update_next_run()`, enable/disable support
+- **`ClaudeRunner.api_port` / `api_secret` params** — when set, `CCDB_API_URL` (and optionally `CCDB_API_SECRET`) are injected into Claude subprocess env, enabling Claude to self-register tasks
+- **Architecture decisions recorded** — CLAUDE.md §Key Design Decisions #7-9 document the REST API control plane pattern and dynamic scheduler design rationale
+
+### Changed
+- **Test coverage**: 462 tests (up from 152), overall 78% coverage
+
 ## [1.1.0] - 2026-02-19
 
 ### Added

--- a/claude_discord/__init__.py
+++ b/claude_discord/__init__.py
@@ -13,6 +13,7 @@ from .claude.runner import ClaudeRunner
 from .claude.types import MessageType, StreamEvent, ToolCategory, ToolUseEvent
 from .cogs.auto_upgrade import AutoUpgradeCog, UpgradeConfig
 from .cogs.claude_chat import ClaudeChatCog
+from .cogs.scheduler import SchedulerCog
 from .cogs.session_manage import SessionManageCog
 from .cogs.skill_command import SkillCommandCog
 from .cogs.webhook_trigger import WebhookTrigger, WebhookTriggerCog
@@ -20,6 +21,7 @@ from .concurrency import ActiveSession, SessionRegistry
 from .database.notification_repo import NotificationRepository
 from .database.repository import SessionRepository
 from .database.settings_repo import SettingsRepository
+from .database.task_repo import TaskRepository as ScheduledTaskRepository
 from .discord_ui.chunker import chunk_message
 from .discord_ui.embeds import (
     error_embed,
@@ -52,6 +54,9 @@ __all__ = [
     "WebhookTrigger",
     "AutoUpgradeCog",
     "UpgradeConfig",
+    # Scheduling
+    "SchedulerCog",
+    "ScheduledTaskRepository",
     "DrainAware",
     "NotificationRepository",
     # Types

--- a/claude_discord/cogs/__init__.py
+++ b/claude_discord/cogs/__init__.py
@@ -2,6 +2,7 @@
 
 from .auto_upgrade import AutoUpgradeCog
 from .claude_chat import ClaudeChatCog
+from .scheduler import SchedulerCog
 from .session_manage import SessionManageCog
 from .skill_command import SkillCommandCog
 from .webhook_trigger import WebhookTriggerCog
@@ -9,6 +10,7 @@ from .webhook_trigger import WebhookTriggerCog
 __all__ = [
     "AutoUpgradeCog",
     "ClaudeChatCog",
+    "SchedulerCog",
     "SessionManageCog",
     "SkillCommandCog",
     "WebhookTriggerCog",

--- a/claude_discord/cogs/scheduler.py
+++ b/claude_discord/cogs/scheduler.py
@@ -1,0 +1,133 @@
+"""SchedulerCog — SQLite-backed periodic Claude Code task executor.
+
+Design:
+- Tasks are stored in ``scheduled_tasks`` DB table and registered via REST API
+  (Claude Code calls POST /api/tasks from within a chat session).
+- A single 30-second master loop checks for due tasks and spawns them.
+- ``discord.ext.tasks`` is used only for the master loop — individual tasks
+  are not @tasks.loop decorated (they are runtime-dynamic).
+- Claude handles all domain logic (what to check, how to deduplicate).
+  ccdb only manages scheduling.
+
+See: Issue #90, CLAUDE.md §Key Design Decisions #7-9.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+import discord
+from discord.ext import commands, tasks
+
+from ._run_helper import run_claude_in_thread
+
+if TYPE_CHECKING:
+    from ..claude.runner import ClaudeRunner
+    from ..database.task_repo import TaskRepository
+
+logger = logging.getLogger(__name__)
+
+# How often the master loop wakes up to check for due tasks.
+MASTER_LOOP_INTERVAL_SECONDS = 30
+
+
+class SchedulerCog(commands.Cog):
+    """Cog that periodically runs Claude Code tasks stored in SQLite.
+
+    Args:
+        bot: The Discord bot instance.
+        runner: Base ClaudeRunner to clone per task execution.
+        repo: TaskRepository for reading/updating scheduled tasks.
+    """
+
+    def __init__(
+        self,
+        bot: commands.Bot,
+        runner: ClaudeRunner,
+        *,
+        repo: TaskRepository,
+    ) -> None:
+        self.bot = bot
+        self.runner = runner
+        self.repo = repo
+        # Track in-flight tasks to avoid double-running the same task_id.
+        self._running: set[int] = set()
+
+    async def cog_load(self) -> None:
+        """Start the master loop when the Cog is loaded."""
+        self._master_loop.start()
+        logger.info("SchedulerCog loaded — master loop started")
+
+    def cog_unload(self) -> None:
+        """Cancel the master loop when the Cog is unloaded."""
+        self._master_loop.cancel()
+        logger.info("SchedulerCog unloaded — master loop stopped")
+
+    @tasks.loop(seconds=MASTER_LOOP_INTERVAL_SECONDS)
+    async def _master_loop(self) -> None:
+        """Wake up every 30 s, find due tasks, and spawn them concurrently."""
+        due = await self.repo.get_due()
+        if not due:
+            return
+
+        logger.info("SchedulerCog: %d task(s) due", len(due))
+        for task in due:
+            task_id: int = task["id"]
+            if task_id in self._running:
+                logger.debug("Task %d still running — skipping", task_id)
+                continue
+
+            # Advance next_run_at *before* spawning to prevent duplicate runs
+            # if the loop fires again before the task finishes.
+            await self.repo.update_next_run(task_id, interval_seconds=task["interval_seconds"])
+
+            asyncio.create_task(
+                self._run_task(task),
+                name=f"ccdb-scheduler-{task_id}",
+            )
+
+    @_master_loop.before_loop
+    async def _before_master_loop(self) -> None:
+        await self.bot.wait_until_ready()
+
+    async def _run_task(self, task: dict) -> None:
+        """Execute a single scheduled task in a Discord thread."""
+        task_id: int = task["id"]
+        self._running.add(task_id)
+        try:
+            channel = self.bot.get_channel(task["channel_id"])
+            if channel is None:
+                logger.warning(
+                    "SchedulerCog: channel %d not found for task %d (%s)",
+                    task["channel_id"],
+                    task_id,
+                    task["name"],
+                )
+                return
+            if not isinstance(channel, discord.TextChannel):
+                logger.warning("SchedulerCog: channel %d is not a TextChannel", task["channel_id"])
+                return
+
+            thread = await channel.create_thread(
+                name=f"[Scheduled] {task['name']}",
+                type=discord.ChannelType.public_thread,
+            )
+
+            cloned = self.runner.clone()
+            if task.get("working_dir"):
+                cloned.working_dir = task["working_dir"]
+
+            await run_claude_in_thread(
+                thread=thread,
+                runner=cloned,
+                repo=None,  # scheduled tasks don't persist session state
+                prompt=task["prompt"],
+                session_id=None,
+            )
+
+        except Exception:
+            logger.exception("SchedulerCog: task %d (%s) failed", task_id, task["name"])
+        finally:
+            self._running.discard(task_id)

--- a/claude_discord/database/task_repo.py
+++ b/claude_discord/database/task_repo.py
@@ -1,0 +1,202 @@
+"""TaskRepository — CRUD for scheduled_tasks table.
+
+Stores periodic Claude Code tasks registered via REST API or chat.
+The scheduler Cog polls this table every 30 seconds and runs due tasks.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+TASK_SCHEMA = """
+CREATE TABLE IF NOT EXISTS scheduled_tasks (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    name             TEXT    NOT NULL UNIQUE,
+    prompt           TEXT    NOT NULL,
+    interval_seconds INTEGER NOT NULL,
+    channel_id       INTEGER NOT NULL,
+    working_dir      TEXT,
+    enabled          INTEGER NOT NULL DEFAULT 1,
+    next_run_at      REAL    NOT NULL,
+    last_run_at      REAL,
+    created_at       REAL    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_next_run
+    ON scheduled_tasks(next_run_at, enabled);
+"""
+
+
+class TaskRepository:
+    """Async CRUD for scheduled_tasks table."""
+
+    def __init__(self, db_path: str) -> None:
+        self.db_path = db_path
+
+    async def init_db(self) -> None:
+        """Initialize the task schema."""
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.executescript(TASK_SCHEMA)
+            await db.commit()
+        logger.info("Task DB initialized at %s", self.db_path)
+
+    # ------------------------------------------------------------------
+    # Internal helper
+    # ------------------------------------------------------------------
+
+    async def _db_execute(self, sql: str, params: tuple = ()) -> None:
+        """Execute a DML statement (for tests and internal use)."""
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(sql, params)
+            await db.commit()
+
+    # ------------------------------------------------------------------
+    # Queries
+    # ------------------------------------------------------------------
+
+    async def get(self, task_id: int) -> dict | None:
+        """Return a single task by ID, or None if not found."""
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute("SELECT * FROM scheduled_tasks WHERE id = ?", (task_id,))
+            row = await cursor.fetchone()
+        if row is None:
+            return None
+        d = dict(row)
+        d["enabled"] = bool(d["enabled"])
+        return d
+
+    async def get_all(self) -> list[dict]:
+        """Return all tasks (enabled and disabled)."""
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute("SELECT * FROM scheduled_tasks ORDER BY created_at")
+            rows = await cursor.fetchall()
+        result = []
+        for row in rows:
+            d = dict(row)
+            d["enabled"] = bool(d["enabled"])
+            result.append(d)
+        return result
+
+    async def get_due(self, now: float | None = None) -> list[dict]:
+        """Return enabled tasks whose next_run_at is in the past."""
+        ts = now if now is not None else time.time()
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                """SELECT * FROM scheduled_tasks
+                   WHERE enabled = 1 AND next_run_at <= ?
+                   ORDER BY next_run_at""",
+                (ts,),
+            )
+            rows = await cursor.fetchall()
+        result = []
+        for row in rows:
+            d = dict(row)
+            d["enabled"] = bool(d["enabled"])
+            result.append(d)
+        return result
+
+    # ------------------------------------------------------------------
+    # Mutations
+    # ------------------------------------------------------------------
+
+    async def create(
+        self,
+        name: str,
+        prompt: str,
+        interval_seconds: int,
+        channel_id: int,
+        *,
+        working_dir: str | None = None,
+        run_immediately: bool = True,
+    ) -> int:
+        """Create a new scheduled task. Returns the created ID.
+
+        Args:
+            run_immediately: If True (default), set next_run_at = now so the
+                task fires on the next master-loop tick. If False, delay by
+                interval_seconds (useful for tasks that should wait one full
+                cycle before the first run).
+        """
+        now = time.time()
+        next_run = now if run_immediately else now + interval_seconds
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                """INSERT INTO scheduled_tasks
+                   (name, prompt, interval_seconds, channel_id, working_dir,
+                    enabled, next_run_at, created_at)
+                   VALUES (?, ?, ?, ?, ?, 1, ?, ?)""",
+                (name, prompt, interval_seconds, channel_id, working_dir, next_run, now),
+            )
+            await db.commit()
+            row_id = cursor.lastrowid
+        assert row_id is not None
+        logger.info(
+            "Scheduled task created: id=%d, name=%s, interval=%ds", row_id, name, interval_seconds
+        )
+        return row_id
+
+    async def update_next_run(self, task_id: int, interval_seconds: int) -> None:
+        """Advance next_run_at by interval_seconds and record last_run_at."""
+        now = time.time()
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                """UPDATE scheduled_tasks
+                   SET next_run_at = ?, last_run_at = ?
+                   WHERE id = ?""",
+                (now + interval_seconds, now, task_id),
+            )
+            await db.commit()
+
+    async def delete(self, task_id: int) -> bool:
+        """Delete a task. Returns True if a row was deleted."""
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute("DELETE FROM scheduled_tasks WHERE id = ?", (task_id,))
+            await db.commit()
+            return cursor.rowcount > 0
+
+    async def set_enabled(self, task_id: int, *, enabled: bool) -> bool:
+        """Enable or disable a task. Returns True if updated."""
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                "UPDATE scheduled_tasks SET enabled = ? WHERE id = ?",
+                (1 if enabled else 0, task_id),
+            )
+            await db.commit()
+            return cursor.rowcount > 0
+
+    async def update(
+        self,
+        task_id: int,
+        *,
+        prompt: str | None = None,
+        interval_seconds: int | None = None,
+        working_dir: str | None = None,
+    ) -> bool:
+        """Partially update a task. Returns True if updated."""
+        fields: list[str] = []
+        values: list[object] = []
+        if prompt is not None:
+            fields.append("prompt = ?")
+            values.append(prompt)
+        if interval_seconds is not None:
+            fields.append("interval_seconds = ?")
+            values.append(interval_seconds)
+        if working_dir is not None:
+            fields.append("working_dir = ?")
+            values.append(working_dir)
+        if not fields:
+            return False
+        values.append(task_id)
+        sql = f"UPDATE scheduled_tasks SET {', '.join(fields)} WHERE id = ?"  # noqa: S608
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(sql, tuple(values))
+            await db.commit()
+            return cursor.rowcount > 0

--- a/tests/test_api_tasks.py
+++ b/tests/test_api_tasks.py
@@ -1,0 +1,203 @@
+"""Tests for /api/tasks endpoints in ApiServer."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from claude_discord.database.notification_repo import NotificationRepository
+from claude_discord.database.task_repo import TaskRepository
+from claude_discord.ext.api_server import ApiServer
+
+
+@pytest.fixture
+async def notif_repo() -> NotificationRepository:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    r = NotificationRepository(path)
+    await r.init_db()
+    yield r
+    os.unlink(path)
+
+
+@pytest.fixture
+async def task_repo() -> TaskRepository:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    r = TaskRepository(path)
+    await r.init_db()
+    yield r
+    os.unlink(path)
+
+
+@pytest.fixture
+def bot() -> MagicMock:
+    b = MagicMock()
+    b.get_channel = MagicMock(return_value=MagicMock())
+    return b
+
+
+@pytest.fixture
+async def client(notif_repo, task_repo, bot) -> TestClient:
+    api = ApiServer(
+        repo=notif_repo,
+        bot=bot,
+        task_repo=task_repo,
+        default_channel_id=12345,
+        host="127.0.0.1",
+        port=0,
+    )
+    server = TestServer(api.app)
+    c = TestClient(server)
+    await c.start_server()
+    yield c
+    await c.close()
+
+
+class TestTasksCreate:
+    async def test_create_task_returns_201(self, client: TestClient) -> None:
+        resp = await client.post(
+            "/api/tasks",
+            json={
+                "name": "github-check",
+                "prompt": "Check GitHub Issues",
+                "interval_seconds": 3600,
+                "channel_id": 12345,
+            },
+        )
+        assert resp.status == 201
+        data = await resp.json()
+        assert data["status"] == "created"
+        assert "id" in data
+
+    async def test_create_task_missing_required_field(self, client: TestClient) -> None:
+        resp = await client.post(
+            "/api/tasks",
+            json={
+                "name": "no-prompt",
+                "interval_seconds": 3600,
+                "channel_id": 12345,
+            },
+        )
+        assert resp.status == 400
+
+    async def test_create_task_with_working_dir(self, client: TestClient) -> None:
+        resp = await client.post(
+            "/api/tasks",
+            json={
+                "name": "with-dir",
+                "prompt": "p",
+                "interval_seconds": 60,
+                "channel_id": 1,
+                "working_dir": "/home/user/project",
+            },
+        )
+        assert resp.status == 201
+
+    async def test_create_duplicate_name_returns_409(self, client: TestClient) -> None:
+        payload = {"name": "dup", "prompt": "p", "interval_seconds": 60, "channel_id": 1}
+        await client.post("/api/tasks", json=payload)
+        resp = await client.post("/api/tasks", json=payload)
+        assert resp.status == 409
+
+    async def test_create_invalid_json_returns_400(self, client: TestClient) -> None:
+        resp = await client.post(
+            "/api/tasks", data="not-json", headers={"Content-Type": "application/json"}
+        )
+        assert resp.status == 400
+
+
+class TestTasksList:
+    async def test_list_empty(self, client: TestClient) -> None:
+        resp = await client.get("/api/tasks")
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["tasks"] == []
+
+    async def test_list_returns_created_tasks(self, client: TestClient) -> None:
+        await client.post(
+            "/api/tasks",
+            json={
+                "name": "task-a",
+                "prompt": "p",
+                "interval_seconds": 60,
+                "channel_id": 1,
+            },
+        )
+        await client.post(
+            "/api/tasks",
+            json={
+                "name": "task-b",
+                "prompt": "p",
+                "interval_seconds": 120,
+                "channel_id": 2,
+            },
+        )
+        resp = await client.get("/api/tasks")
+        assert resp.status == 200
+        data = await resp.json()
+        assert len(data["tasks"]) == 2
+        names = {t["name"] for t in data["tasks"]}
+        assert names == {"task-a", "task-b"}
+
+
+class TestTasksDelete:
+    async def test_delete_existing_task(self, client: TestClient) -> None:
+        resp = await client.post(
+            "/api/tasks",
+            json={
+                "name": "to-delete",
+                "prompt": "p",
+                "interval_seconds": 60,
+                "channel_id": 1,
+            },
+        )
+        task_id = (await resp.json())["id"]
+        del_resp = await client.delete(f"/api/tasks/{task_id}")
+        assert del_resp.status == 200
+        data = await del_resp.json()
+        assert data["status"] == "deleted"
+
+    async def test_delete_nonexistent_returns_404(self, client: TestClient) -> None:
+        resp = await client.delete("/api/tasks/99999")
+        assert resp.status == 404
+
+
+class TestTasksPatch:
+    async def test_disable_task(self, client: TestClient) -> None:
+        resp = await client.post(
+            "/api/tasks",
+            json={
+                "name": "to-disable",
+                "prompt": "p",
+                "interval_seconds": 60,
+                "channel_id": 1,
+            },
+        )
+        task_id = (await resp.json())["id"]
+        patch_resp = await client.patch(f"/api/tasks/{task_id}", json={"enabled": False})
+        assert patch_resp.status == 200
+        data = await patch_resp.json()
+        assert data["status"] == "updated"
+
+    async def test_update_prompt(self, client: TestClient) -> None:
+        resp = await client.post(
+            "/api/tasks",
+            json={
+                "name": "to-update",
+                "prompt": "old prompt",
+                "interval_seconds": 60,
+                "channel_id": 1,
+            },
+        )
+        task_id = (await resp.json())["id"]
+        patch_resp = await client.patch(f"/api/tasks/{task_id}", json={"prompt": "new prompt"})
+        assert patch_resp.status == 200
+
+    async def test_patch_nonexistent_returns_404(self, client: TestClient) -> None:
+        resp = await client.patch("/api/tasks/99999", json={"enabled": False})
+        assert resp.status == 404

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -111,6 +111,26 @@ class TestBuildEnv:
         env = runner._build_env()
         assert "PATH" in env
 
+    def test_injects_ccdb_api_url_when_api_port_set(self) -> None:
+        runner = ClaudeRunner(api_port=8099)
+        env = runner._build_env()
+        assert env["CCDB_API_URL"] == "http://127.0.0.1:8099"
+
+    def test_no_ccdb_api_url_when_api_port_not_set(self) -> None:
+        runner = ClaudeRunner()
+        env = runner._build_env()
+        assert "CCDB_API_URL" not in env
+
+    def test_injects_ccdb_api_secret_when_set(self) -> None:
+        runner = ClaudeRunner(api_port=8099, api_secret="my-secret")
+        env = runner._build_env()
+        assert env["CCDB_API_SECRET"] == "my-secret"
+
+    def test_no_ccdb_api_secret_when_not_set(self) -> None:
+        runner = ClaudeRunner(api_port=8099)
+        env = runner._build_env()
+        assert "CCDB_API_SECRET" not in env
+
 
 class TestClone:
     """Tests for clone method."""

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,118 @@
+"""Tests for SchedulerCog."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from claude_discord.cogs.scheduler import SchedulerCog
+from claude_discord.database.task_repo import TaskRepository
+
+
+def _make_bot() -> MagicMock:
+    bot = MagicMock()
+    bot.loop = MagicMock()
+    return bot
+
+
+def _make_runner() -> MagicMock:
+    runner = MagicMock()
+    runner.clone.return_value = runner
+    return runner
+
+
+@pytest.fixture
+async def repo(tmp_path) -> TaskRepository:
+    r = TaskRepository(str(tmp_path / "tasks.db"))
+    await r.init_db()
+    return r
+
+
+@pytest.fixture
+def cog(repo: TaskRepository) -> SchedulerCog:
+    return SchedulerCog(_make_bot(), _make_runner(), repo=repo)
+
+
+class TestSchedulerCogInit:
+    def test_cog_created(self, repo: TaskRepository) -> None:
+        cog = SchedulerCog(_make_bot(), _make_runner(), repo=repo)
+        assert cog is not None
+
+    def test_master_loop_not_running_at_init(self, repo: TaskRepository) -> None:
+        cog = SchedulerCog(_make_bot(), _make_runner(), repo=repo)
+        # loop should not be running before cog_load is called
+        assert not cog._master_loop.is_running()
+
+
+class TestSchedulerCogMasterLoop:
+    async def test_no_tasks_does_nothing(self, cog: SchedulerCog) -> None:
+        """Master loop with empty DB should complete without errors."""
+        with patch(
+            "claude_discord.cogs.scheduler.run_claude_in_thread", new_callable=AsyncMock
+        ) as mock_run:
+            await cog._master_loop()
+        mock_run.assert_not_called()
+
+    async def test_future_task_not_run(self, cog: SchedulerCog, repo: TaskRepository) -> None:
+        """Tasks with next_run_at in the future should not fire."""
+        task_id = await repo.create(name="future", prompt="p", interval_seconds=3600, channel_id=1)
+        await repo._db_execute(
+            "UPDATE scheduled_tasks SET next_run_at = ? WHERE id = ?",
+            (time.time() + 9999, task_id),
+        )
+        with patch(
+            "claude_discord.cogs.scheduler.run_claude_in_thread", new_callable=AsyncMock
+        ) as mock_run:
+            await cog._master_loop()
+        mock_run.assert_not_called()
+
+    async def test_due_task_triggers_run(self, cog: SchedulerCog, repo: TaskRepository) -> None:
+        """Due tasks should cause _run_task to be called via create_task."""
+        task_id = await repo.create(
+            name="due", prompt="check stuff", interval_seconds=60, channel_id=42
+        )
+        await repo._db_execute(
+            "UPDATE scheduled_tasks SET next_run_at = ? WHERE id = ?",
+            (time.time() - 1, task_id),
+        )
+        # Patch _run_task directly — create_task wraps a coroutine, so we need
+        # to intercept at this level (not run_claude_in_thread) and then yield
+        # control so the event loop can execute the spawned task.
+        cog._run_task = AsyncMock()
+        await cog._master_loop()
+        await asyncio.sleep(0)  # yield to let create_task execute
+
+        cog._run_task.assert_called_once()
+        called_task = cog._run_task.call_args[0][0]
+        assert called_task["prompt"] == "check stuff"
+
+    async def test_due_task_updates_next_run(self, cog: SchedulerCog, repo: TaskRepository) -> None:
+        """After firing, next_run_at should be advanced by interval_seconds."""
+        task_id = await repo.create(name="tick", prompt="p", interval_seconds=300, channel_id=1)
+        before = time.time()
+        await repo._db_execute(
+            "UPDATE scheduled_tasks SET next_run_at = ? WHERE id = ?",
+            (time.time() - 1, task_id),
+        )
+        cog._run_task = AsyncMock()
+        await cog._master_loop()
+
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["next_run_at"] >= before + 300 - 1
+
+    async def test_disabled_task_not_run(self, cog: SchedulerCog, repo: TaskRepository) -> None:
+        """Disabled tasks should not fire even if overdue."""
+        task_id = await repo.create(name="dis", prompt="p", interval_seconds=60, channel_id=1)
+        await repo._db_execute(
+            "UPDATE scheduled_tasks SET next_run_at = ?, enabled = 0 WHERE id = ?",
+            (time.time() - 1, task_id),
+        )
+        with patch(
+            "claude_discord.cogs.scheduler.run_claude_in_thread", new_callable=AsyncMock
+        ) as mock_run:
+            await cog._master_loop()
+        mock_run.assert_not_called()

--- a/tests/test_task_repo.py
+++ b/tests/test_task_repo.py
@@ -1,0 +1,193 @@
+"""Tests for TaskRepository — scheduled task CRUD."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from claude_discord.database.task_repo import TaskRepository
+
+
+@pytest.fixture
+async def repo(tmp_path) -> TaskRepository:
+    r = TaskRepository(str(tmp_path / "tasks.db"))
+    await r.init_db()
+    return r
+
+
+class TestTaskRepoCreate:
+    async def test_create_returns_id(self, repo: TaskRepository) -> None:
+        task_id = await repo.create(
+            name="test-task",
+            prompt="Do something",
+            interval_seconds=3600,
+            channel_id=123,
+        )
+        assert isinstance(task_id, int)
+        assert task_id > 0
+
+    async def test_create_sets_next_run_at(self, repo: TaskRepository) -> None:
+        before = time.time()
+        task_id = await repo.create(
+            name="test-task",
+            prompt="Do something",
+            interval_seconds=3600,
+            channel_id=123,
+        )
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["next_run_at"] >= before
+
+    async def test_create_defaults(self, repo: TaskRepository) -> None:
+        task_id = await repo.create(
+            name="minimal",
+            prompt="Minimal prompt",
+            interval_seconds=60,
+            channel_id=999,
+        )
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["enabled"] is True
+        assert task["working_dir"] is None
+        assert task["last_run_at"] is None
+
+    async def test_create_with_working_dir(self, repo: TaskRepository) -> None:
+        task_id = await repo.create(
+            name="with-dir",
+            prompt="prompt",
+            interval_seconds=60,
+            channel_id=1,
+            working_dir="/home/user/project",
+        )
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["working_dir"] == "/home/user/project"
+
+    async def test_duplicate_name_raises(self, repo: TaskRepository) -> None:
+        import aiosqlite
+
+        await repo.create(name="dup", prompt="p", interval_seconds=60, channel_id=1)
+        with pytest.raises(aiosqlite.IntegrityError):
+            await repo.create(name="dup", prompt="p2", interval_seconds=60, channel_id=2)
+
+
+class TestTaskRepoGetAll:
+    async def test_get_all_empty(self, repo: TaskRepository) -> None:
+        tasks = await repo.get_all()
+        assert tasks == []
+
+    async def test_get_all_returns_all(self, repo: TaskRepository) -> None:
+        await repo.create(name="a", prompt="p", interval_seconds=60, channel_id=1)
+        await repo.create(name="b", prompt="p", interval_seconds=120, channel_id=2)
+        tasks = await repo.get_all()
+        assert len(tasks) == 2
+        names = {t["name"] for t in tasks}
+        assert names == {"a", "b"}
+
+    async def test_get_all_includes_disabled(self, repo: TaskRepository) -> None:
+        task_id = await repo.create(name="x", prompt="p", interval_seconds=60, channel_id=1)
+        await repo.set_enabled(task_id, enabled=False)
+        tasks = await repo.get_all()
+        assert len(tasks) == 1
+        assert tasks[0]["enabled"] is False
+
+
+class TestTaskRepoDue:
+    async def test_get_due_empty_when_all_future(self, repo: TaskRepository) -> None:
+        await repo.create(name="future", prompt="p", interval_seconds=3600, channel_id=1)
+        # Push next_run_at far into the future
+        await repo._db_execute(
+            "UPDATE scheduled_tasks SET next_run_at = ? WHERE name = 'future'",
+            (time.time() + 9999,),
+        )
+        due = await repo.get_due()
+        assert due == []
+
+    async def test_get_due_returns_overdue_tasks(self, repo: TaskRepository) -> None:
+        task_id = await repo.create(name="overdue", prompt="p", interval_seconds=60, channel_id=1)
+        # Set next_run_at to the past
+        await repo._db_execute(
+            "UPDATE scheduled_tasks SET next_run_at = ? WHERE id = ?",
+            (time.time() - 100, task_id),
+        )
+        due = await repo.get_due()
+        assert len(due) == 1
+        assert due[0]["name"] == "overdue"
+
+    async def test_get_due_excludes_disabled(self, repo: TaskRepository) -> None:
+        task_id = await repo.create(name="disabled", prompt="p", interval_seconds=60, channel_id=1)
+        await repo._db_execute(
+            "UPDATE scheduled_tasks SET next_run_at = ? WHERE id = ?",
+            (time.time() - 100, task_id),
+        )
+        await repo.set_enabled(task_id, enabled=False)
+        due = await repo.get_due()
+        assert due == []
+
+
+class TestTaskRepoUpdateNextRun:
+    async def test_update_next_run_advances_time(self, repo: TaskRepository) -> None:
+        before = time.time()
+        task_id = await repo.create(name="t", prompt="p", interval_seconds=3600, channel_id=1)
+        await repo.update_next_run(task_id, interval_seconds=3600)
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["next_run_at"] >= before + 3600 - 1  # allow 1s skew
+        assert task["last_run_at"] is not None
+
+
+class TestTaskRepoDelete:
+    async def test_delete_existing(self, repo: TaskRepository) -> None:
+        task_id = await repo.create(name="del", prompt="p", interval_seconds=60, channel_id=1)
+        deleted = await repo.delete(task_id)
+        assert deleted is True
+        assert await repo.get(task_id) is None
+
+    async def test_delete_nonexistent_returns_false(self, repo: TaskRepository) -> None:
+        deleted = await repo.delete(99999)
+        assert deleted is False
+
+
+class TestTaskRepoSetEnabled:
+    async def test_disable_task(self, repo: TaskRepository) -> None:
+        task_id = await repo.create(name="e", prompt="p", interval_seconds=60, channel_id=1)
+        result = await repo.set_enabled(task_id, enabled=False)
+        assert result is True
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["enabled"] is False
+
+    async def test_enable_task(self, repo: TaskRepository) -> None:
+        task_id = await repo.create(name="e2", prompt="p", interval_seconds=60, channel_id=1)
+        await repo.set_enabled(task_id, enabled=False)
+        result = await repo.set_enabled(task_id, enabled=True)
+        assert result is True
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["enabled"] is True
+
+    async def test_enable_nonexistent_returns_false(self, repo: TaskRepository) -> None:
+        result = await repo.set_enabled(99999, enabled=True)
+        assert result is False
+
+
+class TestTaskRepoUpdate:
+    async def test_update_prompt(self, repo: TaskRepository) -> None:
+        task_id = await repo.create(name="u", prompt="old", interval_seconds=60, channel_id=1)
+        result = await repo.update(task_id, prompt="new prompt")
+        assert result is True
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["prompt"] == "new prompt"
+
+    async def test_update_interval(self, repo: TaskRepository) -> None:
+        task_id = await repo.create(name="u2", prompt="p", interval_seconds=60, channel_id=1)
+        await repo.update(task_id, interval_seconds=7200)
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["interval_seconds"] == 7200
+
+    async def test_update_nonexistent_returns_false(self, repo: TaskRepository) -> None:
+        result = await repo.update(99999, prompt="x")
+        assert result is False


### PR DESCRIPTION
## Summary

- Add `SchedulerCog` — a SQLite-backed periodic task executor for Claude Code
- Users register tasks by chatting in Discord; Claude calls `POST /api/tasks` via Bash tool
- No code changes needed to add/remove tasks at runtime
- `CCDB_API_URL` env var auto-injected into Claude subprocesses so they can reach the API

## Design rationale

**Why REST API instead of stdout markers?**
Alternative: Claude embeds `<!-- ccdb:schedule {...} -->` in response text.
Rejected: fragile text parsing, untestable, can't trigger from external systems.
REST API: clean, explicitly testable, usable by GitHub Actions / external tools.

**Why no state management for deduplication?**
Claude's prompt handles this ("check issues created in the last hour"). ccdb stays generic.

**Architecture** (documented in CLAUDE.md §Key Design Decisions #7-9):
```
Discord chat "Check GitHub Issues every hour"
  → Claude spawns subprocess
  → Claude: curl -X POST $CCDB_API_URL/api/tasks -d '{"prompt":"...","interval_seconds":3600}'
  → SchedulerCog master loop (every 30s) picks up due tasks
  → run_claude_in_thread() executes the Claude prompt in a new Discord thread
```

## New files

| File | Purpose | Coverage |
|------|---------|----------|
| `database/task_repo.py` | TaskRepository CRUD | 97% |
| `cogs/scheduler.py` | SchedulerCog + master loop | 55% (Discord-dependent) |
| `tests/test_task_repo.py` | 20 tests | — |
| `tests/test_scheduler.py` | 7 tests | — |
| `tests/test_api_tasks.py` | 12 tests | — |

## Changed files

| File | Change |
|------|--------|
| `ext/api_server.py` | Add `task_repo` param + `/api/tasks` endpoints (85% coverage) |
| `claude/runner.py` | Add `api_port`/`api_secret` + `CCDB_API_URL` env injection |
| `claude_discord/__init__.py` | Export `SchedulerCog`, `ScheduledTaskRepository` |
| `CLAUDE.md` | Document architecture decisions #7-9 |
| `CHANGELOG.md` | Add unreleased section |

## Test plan

- [x] `pytest tests/test_task_repo.py` — 20 tests pass
- [x] `pytest tests/test_scheduler.py` — 7 tests pass
- [x] `pytest tests/test_api_tasks.py` — 12 tests pass
- [x] Full suite `pytest tests/` — 462 passed, 78% coverage
- [x] `ruff check` + `ruff format --check` — all clean
- [ ] Manual: spin up EbiBot with SchedulerCog, chat "check X every hour", verify task registered and fires

Closes #90