### PR TITLE
fix(#93): SchedulerCog posts starter message before creating thread

### DIFF
--- a/claude_discord/cogs/scheduler.py
+++ b/claude_discord/cogs/scheduler.py
@@ -110,9 +110,13 @@ class SchedulerCog(commands.Cog):
                 logger.warning("SchedulerCog: channel %d is not a TextChannel", task["channel_id"])
                 return
 
-            thread = await channel.create_thread(
+            # Post a starter message first so the thread appears in the channel
+            # timeline and shows up in the left sidebar under the parent channel.
+            # channel.create_thread() without a message only appears in the
+            # Threads panel (🧵), not in the channel list.
+            starter = await channel.send(f"🔄 **[Scheduled]** `{task['name']}`")
+            thread = await starter.create_thread(
                 name=f"[Scheduled] {task['name']}",
-                type=discord.ChannelType.public_thread,
             )
 
             cloned = self.runner.clone()


### PR DESCRIPTION
## Summary
- Post `🔄 **[Scheduled]** `task-name`` to the channel first
- Then call `message.create_thread()` on that starter message
- Previously used `channel.create_thread()` which only showed in the Threads panel (🧵), not the channel list sidebar

## Why this matters
Discord shows `message.create_thread()` threads as sub-entries under the parent channel in the left sidebar. `channel.create_thread()` without a message attachment goes only to the Threads panel, which is not visible unless explicitly opened.

## Test plan
- [x] `test_run_task_creates_starter_message_then_thread` — verifies call chain: `channel.send` → `message.create_thread` → `run_claude_in_thread`
- [x] All 8 scheduler tests pass
- [x] ruff format + lint clean