### PR TITLE
chore: release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-02-20
+
 ### Added
 - **Scheduled Task Executor** (`SchedulerCog`) — register periodic Claude Code tasks via Discord chat or REST API. Tasks are stored in SQLite and executed by a single 30-second master loop. No code changes needed to add new tasks (#90)
 - **`/api/tasks` REST endpoints** — `POST`, `GET`, `DELETE`, `PATCH` for managing scheduled tasks. Claude Code calls these via Bash tool using `CCDB_API_URL` env var
 - **`TaskRepository`** (`database/task_repo.py`) — CRUD for `scheduled_tasks` table with `get_due()`, `update_next_run()`, enable/disable support
 - **`ClaudeRunner.api_port` / `api_secret` params** — when set, `CCDB_API_URL` (and optionally `CCDB_API_SECRET`) are injected into Claude subprocess env, enabling Claude to self-register tasks
+- **`setup_bridge()` auto-discovery** — convenience factory that auto-wires `ClaudeRunner`, `SessionStore`, and `CoordinationChannel` from env vars; consumer smoke test in CI (#92)
+- **Zero-config coordination** — `CoordinationChannel` auto-creates its channel from `CCDB_COORDINATION_CHANNEL_NAME` env var with no consumer wiring needed (#89)
+- **LiveToolTimer** — live elapsed-time updates on long-running tool call embeds (#84, #85)
+- **Coordination channel** — cross-session awareness so concurrent Claude Code sessions can see each other (#78)
+- **Persistent AskView buttons** — bus routing and restart recovery for interactive Discord buttons (#81, #86)
+- **AskUserQuestion integration** — `AskUserQuestion` tool calls render as Discord Buttons and Select Menus (#45, #66)
+- **Thread status dashboard** — owner mention when session is waiting for input (#67, #68)
+- **Token usage display** — cache hit rate and token counts shown in session-complete embed (#41, #63)
+- **Redacted thinking placeholder** — embed shown for `redacted_thinking` blocks instead of silent skip (#49, #64)
+- **Auto-discover registry** — bot auto-discovers cog registry; zero-config for consumers (#54)
+- **Concurrency awareness** — multiple simultaneous sessions detected and surfaced in Discord (#53)
 - **Architecture decisions recorded** — CLAUDE.md §Key Design Decisions #7-9 document the REST API control plane pattern and dynamic scheduler design rationale
 
 ### Changed
-- **Test coverage**: 462 tests (up from 152), overall 78% coverage
+- **Test coverage**: 152 → 473 tests
+- Tool result embeds show elapsed time in description rather than title field (#84, #88)
+
+### Fixed
+- Persistent AskView buttons survive bot restarts via bus routing (#81)
+- SchedulerCog posts starter message before creating thread (#93, #94)
+- GFM tables wrapped in code fences for consistent Discord rendering (#73, #76)
+- Table header prepended to continuation chunks (#73, #74)
+- Markdown tables kept intact when chunking for Discord (#55, #57)
+- Concurrency notice strengthened with diagnostic logging (#52, #62)
 
 ## [1.1.0] - 2026-02-19
 
@@ -61,6 +83,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI pipeline: Python 3.10/3.11/3.12, ruff, pytest
 - Branch protection and PR workflow
 
+[Unreleased]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v0.1.0...v1.0.0
 [0.1.0]: https://github.com/ebibibi/claude-code-discord-bridge/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-code-discord-bridge"
-version = "1.0.0"
+version = "1.2.0"
 description = "Connect Claude Code to Discord and GitHub — interactive chat, CI/CD automation, and workflow integration"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- Update `CHANGELOG.md`: move `[Unreleased]` → `[1.2.0] - 2026-02-20` with comprehensive release notes covering all features since v1.1.0
- Update `pyproject.toml`: `1.0.0` → `1.2.0`

## Changes included in v1.2.0
- SchedulerCog — SQLite-backed periodic Claude Code task executor (#90–#94)
- /api/tasks REST endpoints for task management
- setup_bridge() auto-discovery (#92)
- Zero-config CoordinationChannel (#89)
- LiveToolTimer — live elapsed-time on tool embeds (#84–#85)
- Coordination channel for cross-session awareness (#78–#79)
- Persistent AskView buttons with restart recovery (#81, #86)
- AskUserQuestion → Discord Buttons/Select Menus (#45, #66)
- Thread status dashboard with owner mention (#67–#68)
- Token usage + cache hit rate display (#41, #63)
- Redacted thinking placeholder embed (#49, #64)
- Auto-discover registry / zero-config consumers (#54)
- Concurrency awareness (#53)
- Test coverage: 152 → 473 tests

## After merging
1. Create git tag `v1.1.0` at commit `1236395` (retroactive — /stop, attachments, timeout)
2. Create git tag `v1.2.0` at the merge commit
3. Create GitHub releases for both versions