### PR TITLE
[docs-sync] Update documentation and translations for v1.2.0

### DIFF
--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -9,31 +9,31 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Conecta [Claude Code](https://docs.anthropic.com/en/docs/claude-code) con Discord y GitHub. Un framework que conecta Claude Code CLI con Discord para **chat interactivo, automatización CI/CD e integración con flujos de trabajo de GitHub**.
+Conecta [Claude Code](https://docs.anthropic.com/en/docs/claude-code) a Discord y GitHub. Un framework que une Claude Code CLI con Discord para **chat interactivo, automatización CI/CD e integración de flujos de trabajo con GitHub**.
 
-Claude Code es genial en la terminal, pero puede hacer mucho más. Este puente te permite **usar Claude Code en tu flujo de desarrollo con GitHub**: sincronizar documentación automáticamente, revisar y fusionar PRs, y ejecutar cualquier tarea de Claude Code activada por GitHub Actions. Todo usando Discord como el pegamento universal.
+Claude Code es excelente en la terminal, pero puede hacer mucho más. Este puente te permite **usar Claude Code en tu flujo de desarrollo con GitHub**: sincronizar documentación automáticamente, revisar y fusionar PRs, y ejecutar cualquier tarea de Claude Code activada desde GitHub Actions. Todo a través de Discord como pegamento universal.
 
 **[English](../../README.md)** | **[日本語](../ja/README.md)** | **[简体中文](../zh-CN/README.md)** | **[한국어](../ko/README.md)** | **[Português](../pt-BR/README.md)** | **[Français](../fr/README.md)**
 
-> **Descargo de responsabilidad:** Este proyecto no está afiliado, respaldado ni conectado oficialmente con Anthropic. "Claude" y "Claude Code" son marcas registradas de Anthropic, PBC. Esta es una herramienta de código abierto independiente que interactúa con Claude Code CLI.
+> **Aviso legal:** Este proyecto no está afiliado, respaldado ni oficialmente conectado a Anthropic. "Claude" y "Claude Code" son marcas registradas de Anthropic, PBC. Esta es una herramienta de código abierto independiente que interactúa con el Claude Code CLI.
 
-> **Construido completamente por Claude Code.** Este proyecto fue diseñado, implementado, probado y documentado por Claude Code, el agente de codificación con IA de Anthropic. El autor humano no ha leído el código fuente. Ver [Cómo se construyó este proyecto](#cómo-se-construyó-este-proyecto) para más detalles.
+> **Construido completamente por Claude Code.** Este proyecto fue diseñado, implementado, probado y documentado por el propio Claude Code — el agente de codificación con IA de Anthropic. El autor humano no ha leído el código fuente. Consulta [Cómo se construyó este proyecto](#cómo-se-construyó-este-proyecto) para más detalles.
 
 ## Dos formas de usarlo
 
 ### 1. Chat interactivo (Móvil / Escritorio)
 
-Usa Claude Code desde tu teléfono o cualquier dispositivo con Discord. Cada conversación se convierte en un hilo con persistencia completa de sesión.
+Usa Claude Code desde tu teléfono o cualquier dispositivo con Discord. Cada conversación se convierte en un hilo con persistencia de sesión completa.
 
 ```
 Tú (Discord)  →  Bridge  →  Claude Code CLI
     ↑                              ↓
-    ←──── salida stream-json ─────←
+    ←──── salida stream-json ──────←
 ```
 
 ### 2. Automatización CI/CD (GitHub → Discord → Claude Code → GitHub)
 
-Activa tareas de Claude Code desde GitHub Actions mediante webhooks de Discord. Claude Code funciona de forma autónoma: lee código, actualiza documentación, crea PRs y habilita auto-merge.
+Activa tareas de Claude Code desde GitHub Actions mediante webhooks de Discord. Claude Code se ejecuta de forma autónoma — leyendo código, actualizando docs, creando PRs y habilitando fusión automática.
 
 ```
 GitHub Actions  →  Discord Webhook  →  Bridge  →  Claude Code CLI
@@ -41,31 +41,60 @@ GitHub Actions  →  Discord Webhook  →  Bridge  →  Claude Code CLI
 GitHub PR (auto-merge)  ←  git push  ←  Claude Code  ←──┘
 ```
 
-**Ejemplo real:** En cada push a main, Claude Code analiza automáticamente los cambios, actualiza la documentación en inglés y japonés, crea un PR con resumen bilingüe y habilita auto-merge. Sin intervención humana.
+**Ejemplo real:** En cada push a main, Claude Code analiza automáticamente los cambios, actualiza la documentación en inglés y japonés, crea un PR con un resumen bilingüe y habilita la fusión automática. Sin intervención humana.
 
 ## Características
 
 ### Chat interactivo
-- **Thread = Session** — Cada tarea tiene su propio hilo de Discord, mapeado 1:1 con una sesión de Claude Code
-- **Estado en tiempo real** — Reacciones emoji muestran qué está haciendo Claude (🧠 pensando, 🛠️ leyendo archivos, 💻 editando, 🌐 búsqueda web)
-- **Texto en streaming** — El texto intermedio aparece mientras Claude trabaja
-- **Visualización de resultados de herramientas** — Resultados mostrados como embeds en tiempo real
-- **Pensamiento extendido** — El razonamiento de Claude aparece en embeds con spoiler (clic para revelar)
-- **Persistencia de sesión** — Continúa conversaciones entre mensajes via `--resume`
-- **Ejecución de skills** — Ejecuta skills de Claude Code (`/skill goodmorning`) via comandos slash con autocompletado
+- **Thread = Session** — Cada tarea tiene su propio hilo de Discord, mapeado 1:1 a una sesión de Claude Code
+- **Estado en tiempo real** — Las reacciones con emojis muestran qué está haciendo Claude (🧠 pensando, 🛠️ leyendo archivos, 💻 editando, 🌐 búsqueda web)
+- **Texto en streaming** — El texto intermedio aparece mientras Claude trabaja, no solo al final
+- **Visualización de resultados de herramientas** — Los resultados del uso de herramientas se muestran como embeds en tiempo real
+- **Temporización de herramientas en vivo** — Los embeds de herramientas en progreso actualizan el tiempo transcurrido cada 10s para comandos de larga duración (autenticación, compilaciones), para que siempre sepas que Claude sigue trabajando
+- **Pensamiento extendido** — El razonamiento de Claude aparece como embeds con etiqueta spoiler (haz clic para revelar)
+- **Persistencia de sesión** — Continúa conversaciones entre mensajes con `--resume`
+- **Ejecución de skills** — Ejecuta skills de Claude Code con `/skill` con autocompletado, argumentos opcionales y reanudación en hilo
 - **Sesiones concurrentes** — Ejecuta múltiples sesiones en paralelo (límite configurable)
+- **Detener sin borrar** — `/stop` detiene una sesión en curso preservándola para reanudar
+- **Soporte de archivos adjuntos** — Los adjuntos de texto se añaden automáticamente al prompt (hasta 5 archivos, 50 KB cada uno)
+- **Notificaciones de tiempo de espera** — Embed dedicado con segundos transcurridos y guía cuando una sesión expira
+- **Preguntas interactivas** — Cuando Claude llama a `AskUserQuestion`, el bot renderiza Botones de Discord o un Select Menu y reanuda la sesión con tu respuesta
+- **Panel de estado de sesión** — Un embed fijo en vivo en el canal principal muestra qué hilos están procesando vs. esperando entrada; el propietario recibe @mention cuando Claude necesita una respuesta
+- **Coordinación multisesión** — Con `COORDINATION_CHANNEL_ID` configurado, cada sesión difunde eventos de inicio/fin a un canal compartido para que las sesiones concurrentes se mantengan informadas
+
+### Tareas programadas (SchedulerCog)
+- **Tareas periódicas de Claude Code** — Registra tareas vía chat de Discord o API REST; se ejecutan en un intervalo configurable
+- **Respaldado por SQLite** — Las tareas persisten entre reinicios; gestionadas mediante endpoints `/api/tasks`
+- **Programación sin código** — Claude Code puede auto-registrar nuevas tareas con la herramienta Bash durante una sesión; sin reinicios del bot ni cambios de código
+- **Único bucle maestro** — Un bucle `discord.ext.tasks` de 30 segundos despacha todas las tareas, manteniendo baja la sobrecarga
 
 ### Automatización CI/CD
-- **Disparadores webhook** — Activa tareas de Claude Code desde GitHub Actions o cualquier sistema CI/CD
-- **Auto-actualización** — Actualiza automáticamente el bot cuando se publica un paquete upstream
-- **REST API** — Notificaciones push a Discord desde herramientas externas (opcional, requiere aiohttp)
+- **Activadores de webhooks** — Activa tareas de Claude Code desde GitHub Actions o cualquier sistema CI/CD
+- **Actualización automática** — Actualiza automáticamente el bot cuando se publican paquetes upstream
+- **API REST** — Envía notificaciones y gestiona tareas programadas desde herramientas externas (opcional, requiere aiohttp)
 
 ### Seguridad
 - **Sin inyección de shell** — Solo `asyncio.create_subprocess_exec`, nunca `shell=True`
-- **Validación de ID de sesión** — Regex estricto antes de pasar a `--resume`
+- **Validación de ID de sesión** — Regex estricta antes de pasar a `--resume`
 - **Prevención de inyección de flags** — Separador `--` antes de todos los prompts
 - **Aislamiento de secretos** — Token del bot y secretos eliminados del entorno del subproceso
-- **Autorización de usuario** — `allowed_user_ids` restringe quién puede invocar a Claude
+- **Autorización de usuarios** — `allowed_user_ids` restringe quién puede invocar a Claude
+
+## Skills
+
+Ejecuta [skills de Claude Code](https://docs.anthropic.com/en/docs/claude-code) directamente desde Discord mediante el comando de barra `/skill`.
+
+```
+/skill name:goodmorning                      → ejecuta /goodmorning
+/skill name:todoist args:filter "today"      → ejecuta /todoist filter "today"
+/skills                                      → lista todas las skills disponibles
+```
+
+**Características:**
+- **Autocompletado** — Escribe para filtrar; nombres y descripciones son buscables
+- **Argumentos** — Pasa argumentos adicionales mediante el parámetro `args`
+- **Reanudación en hilo** — Usa `/skill` dentro de un hilo de Claude existente para ejecutar la skill en la sesión actual en lugar de crear un nuevo hilo
+- **Recarga en caliente** — Las nuevas skills añadidas a `~/.claude/skills/` se detectan automáticamente (intervalo de actualización de 60s, sin reinicio necesario)
 
 ## Inicio rápido
 
@@ -73,17 +102,17 @@ GitHub PR (auto-merge)  ←  git push  ←  Claude Code  ←──┘
 
 - Python 3.10+
 - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) instalado y autenticado
-- Token de Discord bot con Message Content intent habilitado
+- Token de bot de Discord con Message Content intent habilitado
 - [uv](https://docs.astral.sh/uv/) (recomendado) o pip
 
-### Ejecución independiente
+### Ejecutar de forma autónoma
 
 ```bash
 git clone https://github.com/ebibibi/claude-code-discord-bridge.git
 cd claude-code-discord-bridge
 
 cp .env.example .env
-# Edita .env con tu token de bot y ID de canal
+# Edita .env con tu token de bot y el ID del canal
 
 uv run python -m claude_discord.main
 ```
@@ -97,17 +126,36 @@ uv add git+https://github.com/ebibibi/claude-code-discord-bridge.git
 ```
 
 ```python
+from claude_discord import ClaudeRunner, setup_bridge
+
+runner = ClaudeRunner(command="claude", model="sonnet")
+
+# Una llamada registra todos los Cogs — las nuevas características se incluyen automáticamente
+await setup_bridge(
+    bot,
+    runner,
+    session_db_path="data/sessions.db",
+    claude_channel_id=YOUR_CHANNEL_ID,
+    allowed_user_ids={YOUR_USER_ID},
+)
+```
+
+`setup_bridge()` conecta automáticamente `ClaudeChatCog`, `SkillCommandCog`, `SessionManageCog` y `SchedulerCog`. Cuando se añaden nuevos Cogs a ccdb, aparecen automáticamente — sin cambios de código en el consumidor.
+
+<details>
+<summary>Conexión manual (avanzado)</summary>
+
+```python
 from claude_discord import ClaudeChatCog, ClaudeRunner, SessionRepository
 from claude_discord.database.models import init_db
 
-# Inicializar
 await init_db("data/sessions.db")
 repo = SessionRepository("data/sessions.db")
 runner = ClaudeRunner(command="claude", model="sonnet")
 
-# Agregar a tu bot existente
 await bot.add_cog(ClaudeChatCog(bot, repo, runner))
 ```
+</details>
 
 Actualizar a la última versión:
 
@@ -115,30 +163,348 @@ Actualizar a la última versión:
 uv lock --upgrade-package claude-code-discord-bridge && uv sync
 ```
 
+## Configuración
+
+| Variable | Descripción | Por defecto |
+|----------|-------------|-------------|
+| `DISCORD_BOT_TOKEN` | Token de bot de Discord | (requerido) |
+| `DISCORD_CHANNEL_ID` | ID de canal para chat de Claude | (requerido) |
+| `CLAUDE_COMMAND` | Ruta al Claude Code CLI | `claude` |
+| `CLAUDE_MODEL` | Modelo a usar | `sonnet` |
+| `CLAUDE_PERMISSION_MODE` | Modo de permisos para CLI | `acceptEdits` |
+| `CLAUDE_WORKING_DIR` | Directorio de trabajo para Claude | directorio actual |
+| `MAX_CONCURRENT_SESSIONS` | Máximo de sesiones paralelas | `3` |
+| `SESSION_TIMEOUT_SECONDS` | Tiempo de espera por inactividad | `300` |
+| `DISCORD_OWNER_ID` | ID de usuario de Discord para @mention cuando Claude necesita entrada | (opcional) |
+| `COORDINATION_CHANNEL_ID` | ID de canal para difusión de coordinación multisesión | (opcional) |
+
+## Configuración del bot de Discord
+
+1. Crea una nueva aplicación en el [Portal de desarrolladores de Discord](https://discord.com/developers/applications)
+2. Crea un bot y copia el token
+3. Habilita **Message Content Intent** en Privileged Gateway Intents
+4. Invita al bot a tu servidor con estos permisos:
+   - Send Messages
+   - Create Public Threads
+   - Send Messages in Threads
+   - Add Reactions
+   - Manage Messages (para limpiar reacciones)
+   - Read Message History
+
+## Automatización GitHub + Claude Code
+
+El sistema de activadores de webhooks te permite construir flujos de trabajo CI/CD completamente autónomos donde Claude Code actúa como un agente inteligente — no solo ejecutando scripts, sino entendiendo los cambios de código y tomando decisiones.
+
+### Ejemplo: Sincronización automática de documentación
+
+En cada push a main, Claude Code:
+1. Obtiene los últimos cambios y analiza el diff
+2. Actualiza la documentación en inglés si cambió el código fuente
+3. Traduce al japonés (o cualquier idioma objetivo)
+4. Crea un PR con un resumen bilingüe
+5. Habilita la fusión automática — el PR se fusiona automáticamente cuando pasa CI
+
+**Flujo de trabajo de GitHub Actions:**
+
+```yaml
+# .github/workflows/docs-sync.yml
+name: Documentation Sync
+on:
+  push:
+    branches: [main]
+jobs:
+  trigger:
+    # Omite los commits del propio docs-sync (prevención de bucle infinito)
+    if: "!contains(github.event.head_commit.message, '[docs-sync]')"
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -X POST "${{ secrets.DISCORD_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -d '{"content": "🔄 docs-sync"}'
+```
+
+**Configuración del bot:**
+
+```python
+from claude_discord import WebhookTriggerCog, WebhookTrigger, ClaudeRunner
+
+runner = ClaudeRunner(command="claude", model="sonnet")
+
+triggers = {
+    "🔄 docs-sync": WebhookTrigger(
+        prompt="Analiza cambios, actualiza docs, crea un PR con resumen bilingüe, habilita auto-merge.",
+        working_dir="/home/user/my-project",
+        timeout=600,
+    ),
+    "🚀 deploy": WebhookTrigger(
+        prompt="Despliega al entorno de staging.",
+        timeout=300,
+    ),
+}
+
+await bot.add_cog(WebhookTriggerCog(
+    bot=bot,
+    runner=runner,
+    triggers=triggers,
+    channel_ids={YOUR_CHANNEL_ID},
+))
+```
+
+**Seguridad:** Solo se procesan los mensajes de webhook. `allowed_webhook_ids` opcional para control más estricto. Los prompts se definen en el servidor — los webhooks solo seleccionan qué activador disparar.
+
+### Ejemplo: Auto-aprobación de PRs del propietario
+
+Aprueba y fusiona automáticamente tus propios PRs después de que pase CI:
+
+```yaml
+# .github/workflows/auto-approve.yml
+name: Auto Approve Owner PRs
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  auto-approve:
+    if: github.event.pull_request.user.login == 'your-username'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --approve
+          gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --squash
+```
+
+## Tareas programadas
+
+`SchedulerCog` ejecuta tareas periódicas de Claude Code almacenadas en SQLite. Las tareas se registran en tiempo de ejecución mediante la API REST — sin cambios de código ni reinicios del bot.
+
+### Registrar una tarea (vía API REST)
+
+```bash
+curl -X POST http://localhost:8080/api/tasks \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer your-secret-token" \
+  -d '{
+    "name": "daily-standup",
+    "prompt": "Revisa los issues abiertos de GitHub y publica un resumen breve en Discord.",
+    "interval_seconds": 86400,
+    "channel_id": 123456789
+  }'
+```
+
+### Registrar una tarea (Claude se auto-registra durante una sesión)
+
+Claude Code puede registrar sus propias tareas recurrentes usando la herramienta Bash — sin configuración manual:
+
+```
+# Dentro de una sesión de Claude Code, Claude ejecuta:
+curl -X POST $CCDB_API_URL/api/tasks \
+  -H "Content-Type: application/json" \
+  -d '{"name": "health-check", "prompt": "Ejecuta el conjunto de pruebas e informa los resultados.", "interval_seconds": 3600}'
+```
+
+`CCDB_API_URL` se inyecta automáticamente en el entorno del subproceso de Claude cuando `api_port` está configurado en el `ClaudeRunner`.
+
+## Actualización automática
+
+Actualiza automáticamente el bot cuando se publica un paquete upstream.
+
+```python
+from claude_discord import AutoUpgradeCog, UpgradeConfig
+
+config = UpgradeConfig(
+    package_name="claude-code-discord-bridge",
+    trigger_prefix="🔄 bot-upgrade",
+    working_dir="/home/user/my-bot",
+    restart_command=["sudo", "systemctl", "restart", "my-bot.service"],
+)
+
+await bot.add_cog(AutoUpgradeCog(bot, config))
+```
+
+**Pipeline:** Push upstream → CI webhook → `🔄 bot-upgrade` → `uv lock --upgrade-package` → `uv sync` → reinicio del servicio.
+
+### Drenado elegante (DrainAware)
+
+Antes de reiniciar, AutoUpgradeCog espera a que terminen todas las sesiones activas. Cualquier Cog que implemente una propiedad `active_count` (cumpliendo el protocolo `DrainAware`) se descubre automáticamente — sin necesidad de lambda `drain_check` manual.
+
+Cogs DrainAware incorporados: `ClaudeChatCog`, `WebhookTriggerCog`.
+
+Para hacer tu propio Cog compatible con el drenado, simplemente añade una propiedad `active_count`:
+
+```python
+class MyCog(commands.Cog):
+    @property
+    def active_count(self) -> int:
+        return len(self._running_tasks)
+```
+
+Aún puedes pasar un callable `drain_check` explícito para anular el autodescubrimiento.
+
+### Aprobación de reinicio
+
+Para escenarios de auto-actualización (ej. actualizar el bot desde su propia sesión de Discord), habilita `restart_approval` para prevenir reinicios automáticos:
+
+```python
+config = UpgradeConfig(
+    package_name="claude-code-discord-bridge",
+    trigger_prefix="🔄 bot-upgrade",
+    working_dir="/home/user/my-bot",
+    restart_command=["sudo", "systemctl", "restart", "my-bot.service"],
+    restart_approval=True,
+)
+```
+
+Con `restart_approval=True`, tras actualizar el paquete el bot publica un mensaje solicitando aprobación. Reacciona con ✅ para activar el reinicio. El bot envía recordatorios periódicos hasta que se apruebe.
+
+## API REST
+
+API REST opcional para enviar notificaciones a Discord desde herramientas externas. Requiere aiohttp:
+
+```bash
+uv add "claude-code-discord-bridge[api]"
+```
+
+```python
+from claude_discord import NotificationRepository
+from claude_discord.ext.api_server import ApiServer
+
+repo = NotificationRepository("data/notifications.db")
+await repo.init_db()
+
+api = ApiServer(
+    repo=repo,
+    bot=bot,
+    default_channel_id=YOUR_CHANNEL_ID,
+    host="127.0.0.1",
+    port=8080,
+    api_secret="your-secret-token",  # Autenticación Bearer opcional
+)
+await api.start()
+```
+
+### Endpoints
+
+**Notificaciones**
+
+| Método | Ruta | Descripción |
+|--------|------|-------------|
+| GET | `/api/health` | Verificación de estado |
+| POST | `/api/notify` | Enviar notificación inmediata |
+| POST | `/api/schedule` | Programar notificación para más tarde |
+| GET | `/api/scheduled` | Listar notificaciones pendientes |
+| DELETE | `/api/scheduled/{id}` | Cancelar una notificación programada |
+
+**Tareas programadas** (requiere `SchedulerCog`)
+
+| Método | Ruta | Descripción |
+|--------|------|-------------|
+| POST | `/api/tasks` | Registrar una nueva tarea periódica de Claude Code |
+| GET | `/api/tasks` | Listar todas las tareas registradas |
+| DELETE | `/api/tasks/{id}` | Eliminar una tarea programada |
+| PATCH | `/api/tasks/{id}` | Actualizar tarea (habilitar/deshabilitar, prompt, intervalo) |
+
+### Ejemplos
+
+```bash
+# Verificación de estado
+curl http://localhost:8080/api/health
+
+# Enviar notificación
+curl -X POST http://localhost:8080/api/notify \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer your-secret-token" \
+  -d '{"message": "¡Build exitoso!", "title": "CI/CD"}'
+
+# Programar notificación
+curl -X POST http://localhost:8080/api/schedule \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Hora de revisar los PRs", "scheduled_at": "2026-01-01T09:00:00"}'
+```
+
+## Arquitectura
+
+```
+claude_discord/
+  main.py                  # Punto de entrada autónomo
+  bot.py                   # Clase Discord Bot
+  setup.py                 # setup_bridge() — fábrica de un solo uso para todos los Cogs
+  cogs/
+    claude_chat.py         # Chat interactivo (creación de hilos, manejo de mensajes)
+    skill_command.py       # Comando de barra /skill con autocompletado
+    webhook_trigger.py     # Webhook → ejecución de tarea Claude Code (CI/CD)
+    auto_upgrade.py        # Webhook → actualización del paquete + reinicio
+    scheduler.py           # Tareas periódicas Claude Code (respaldado por SQLite, bucle maestro de 30s)
+    _run_helper.py         # Lógica de ejecución compartida del Claude CLI
+  claude/
+    runner.py              # Gestor de subprocesos Claude CLI
+    parser.py              # Parser de eventos stream-json
+    types.py               # Definiciones de tipos para mensajes SDK
+  database/
+    models.py              # Esquema SQLite
+    repository.py          # Operaciones CRUD de sesiones
+    ask_repo.py            # CRUD de AskUserQuestion pendientes (recuperación tras reinicio)
+    notification_repo.py   # CRUD de notificaciones programadas
+    task_repo.py           # CRUD de tareas programadas (SchedulerCog)
+  coordination/
+    service.py             # CoordinationService — publica eventos de ciclo de vida de sesión en canal compartido
+  discord_ui/
+    status.py              # Gestor de estado de reacciones con emojis (con debounce)
+    chunker.py             # División de mensajes con conciencia de bloques de código y tablas
+    embeds.py              # Constructores de embeds de Discord
+    ask_view.py            # Botones de Discord/Select Menus para AskUserQuestion
+    ask_bus.py             # Enrutamiento de bus para botones AskView persistentes (sobrevive reinicios)
+    thread_dashboard.py    # Embed fijo en vivo que muestra estados de sesión por hilo
+  ext/
+    api_server.py          # Servidor API REST (opcional, requiere aiohttp)
+                           # Incluye endpoints /api/tasks para SchedulerCog
+  utils/
+    logger.py              # Configuración de logging
+```
+
+### Filosofía de diseño
+
+- **Spawn de CLI, no API** — Invocamos `claude -p --output-format stream-json`, obteniendo todas las funciones de Claude Code (CLAUDE.md, skills, herramientas, memoria) gratis
+- **Discord como pegamento** — Discord proporciona la interfaz, el threading, las notificaciones y la infraestructura de webhooks
+- **Framework, no aplicación** — Instala como paquete, añade Cogs a tu bot existente, configura mediante código
+- **Seguridad por simplicidad** — ~2500 líneas de Python auditable, sin ejecución de shell, sin rutas de código arbitrarias
+
 ## Pruebas
 
 ```bash
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-131 pruebas cubriendo parser, chunker, repositorio, runner, streaming, webhook triggers, auto-upgrade y REST API.
+473 pruebas cubriendo parser, chunker, repositorio, runner, streaming, webhook triggers, auto-upgrade, REST API, AskUserQuestion UI, panel de estado de hilos, SchedulerCog y repositorio de tareas.
 
 ## Cómo se construyó este proyecto
 
-**Todo el código fue escrito por [Claude Code](https://docs.anthropic.com/en/docs/claude-code)** — el agente de codificación con IA de Anthropic. El autor humano ([@ebibibi](https://github.com/ebibibi)) proporcionó requisitos y dirección en lenguaje natural, pero no leyó ni editó manualmente el código fuente.
+**Todo este código base fue escrito por [Claude Code](https://docs.anthropic.com/en/docs/claude-code)**, el agente de codificación con IA de Anthropic. El autor humano ([@ebibibi](https://github.com/ebibibi)) proporcionó requisitos y dirección en lenguaje natural, pero no leyó ni editó manualmente el código fuente.
 
 Esto significa:
 
 - **Todo el código fue generado por IA** — arquitectura, implementación, pruebas, documentación
 - **El autor humano no puede garantizar la corrección a nivel de código** — revisa el código fuente si necesitas certeza
-- **Reportes de bugs y PRs son bienvenidos** — Claude Code probablemente será usado para abordarlos
-- **Este es un ejemplo real de software open source escrito por IA** — úsalo como referencia de lo que Claude Code puede construir
+- **Los reportes de bugs y PRs son bienvenidos** — Claude Code probablemente será usado para abordarlos también
+- **Este es un ejemplo real de software de código abierto escrito por IA** — úsalo como referencia de lo que Claude Code puede construir
 
 El proyecto comenzó el 2026-02-18 y continúa evolucionando a través de conversaciones iterativas con Claude Code.
 
-## Ejemplo real
+## Ejemplo del mundo real
 
-**[EbiBot](https://github.com/ebibibi/discord-bot)** — Un bot personal de Discord que usa claude-code-discord-bridge como dependencia. Incluye sincronización automática de documentación (inglés + japonés), notificaciones push, watchdog de Todoist e integración CI/CD con GitHub Actions.
+**[EbiBot](https://github.com/ebibibi/discord-bot)** — Un bot personal de Discord que usa claude-code-discord-bridge como dependencia de paquete. Incluye sincronización automática de documentación (inglés + japonés), notificaciones push, watchdog de Todoist e integración CI/CD con GitHub Actions. Úsalo como referencia para construir tu propio bot sobre este framework.
+
+## Inspirado en
+
+- [OpenClaw](https://github.com/openclaw/openclaw) — Reacciones de estado con emojis, debouncing de mensajes, chunking con conciencia de bloques de código
+- [claude-code-discord-bot](https://github.com/timoconnellaus/claude-code-discord-bot) — Enfoque CLI spawn + stream-json
+- [claude-code-discord](https://github.com/zebbern/claude-code-discord) — Patrones de control de permisos
+- [claude-sandbox-bot](https://github.com/RhysSullivan/claude-sandbox-bot) — Modelo de hilo por conversación
 
 ## Licencia
 

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -9,31 +9,31 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Connectez [Claude Code](https://docs.anthropic.com/en/docs/claude-code) à Discord et GitHub. Un framework qui fait le pont entre Claude Code CLI et Discord pour le **chat interactif, l'automatisation CI/CD et l'intégration des workflows GitHub**.
+Connectez [Claude Code](https://docs.anthropic.com/en/docs/claude-code) à Discord et GitHub. Un framework qui relie Claude Code CLI à Discord pour le **chat interactif, l'automatisation CI/CD et l'intégration des workflows GitHub**.
 
-Claude Code est excellent dans le terminal — mais il peut faire bien plus. Ce pont vous permet d'**utiliser Claude Code dans votre workflow de développement GitHub** : synchroniser automatiquement la documentation, réviser et fusionner les PRs, et exécuter n'importe quelle tâche Claude Code déclenchée par GitHub Actions. Le tout avec Discord comme colle universelle.
+Claude Code est excellent dans le terminal — mais il peut faire bien plus. Ce pont vous permet d'**utiliser Claude Code dans votre workflow de développement GitHub** : synchroniser automatiquement la documentation, réviser et fusionner des PR, et exécuter n'importe quelle tâche Claude Code déclenchée par GitHub Actions. Tout via Discord comme colle universelle.
 
 **[English](../../README.md)** | **[日本語](../ja/README.md)** | **[简体中文](../zh-CN/README.md)** | **[한국어](../ko/README.md)** | **[Español](../es/README.md)** | **[Português](../pt-BR/README.md)**
 
-> **Avertissement :** Ce projet n'est pas affilié, approuvé ou officiellement connecté à Anthropic. « Claude » et « Claude Code » sont des marques déposées d'Anthropic, PBC. Ceci est un outil open source indépendant qui s'interface avec Claude Code CLI.
+> **Avertissement :** Ce projet n'est pas affilié à Anthropic, ni approuvé ou officiellement connecté à Anthropic. "Claude" et "Claude Code" sont des marques déposées d'Anthropic, PBC. Il s'agit d'un outil open source indépendant qui s'interface avec le Claude Code CLI.
 
-> **Entièrement construit par Claude Code.** Ce projet a été conçu, implémenté, testé et documenté par Claude Code lui-même — l'agent de codage IA d'Anthropic. L'auteur humain n'a pas lu le code source. Voir [Comment ce projet a été construit](#comment-ce-projet-a-été-construit) pour les détails.
+> **Entièrement construit par Claude Code.** Ce projet a été conçu, implémenté, testé et documenté par Claude Code lui-même — l'agent de codification IA d'Anthropic. L'auteur humain n'a pas lu le code source. Voir [Comment ce projet a été construit](#comment-ce-projet-a-été-construit) pour plus de détails.
 
 ## Deux façons de l'utiliser
 
 ### 1. Chat interactif (Mobile / Bureau)
 
-Utilisez Claude Code depuis votre téléphone ou n'importe quel appareil avec Discord. Chaque conversation devient un fil avec persistance complète de session.
+Utilisez Claude Code depuis votre téléphone ou n'importe quel appareil avec Discord. Chaque conversation devient un fil avec une persistance de session complète.
 
 ```
 Vous (Discord)  →  Bridge  →  Claude Code CLI
-      ↑                               ↓
-      ←──── sortie stream-json ───────←
+     ↑                              ↓
+     ←──── sortie stream-json ──────←
 ```
 
 ### 2. Automatisation CI/CD (GitHub → Discord → Claude Code → GitHub)
 
-Déclenchez des tâches Claude Code depuis GitHub Actions via des webhooks Discord. Claude Code fonctionne de manière autonome — lecture du code, mise à jour de la documentation, création de PRs et activation de l'auto-merge.
+Déclenchez des tâches Claude Code depuis GitHub Actions via des webhooks Discord. Claude Code s'exécute de manière autonome — lisant le code, mettant à jour les docs, créant des PR et activant la fusion automatique.
 
 ```
 GitHub Actions  →  Discord Webhook  →  Bridge  →  Claude Code CLI
@@ -41,31 +41,60 @@ GitHub Actions  →  Discord Webhook  →  Bridge  →  Claude Code CLI
 GitHub PR (auto-merge)  ←  git push  ←  Claude Code  ←──┘
 ```
 
-**Exemple concret :** À chaque push sur main, Claude Code analyse automatiquement les changements, met à jour la documentation en anglais et japonais, crée une PR avec un résumé bilingue et active l'auto-merge. Aucune intervention humaine requise.
+**Exemple concret :** À chaque push sur main, Claude Code analyse automatiquement les changements, met à jour la documentation en anglais et en japonais, crée une PR avec un résumé bilingue et active la fusion automatique. Aucune intervention humaine requise.
 
 ## Fonctionnalités
 
 ### Chat interactif
-- **Thread = Session** — Chaque tâche a son propre fil Discord, mappé 1:1 à une session Claude Code
+- **Thread = Session** — Chaque tâche obtient son propre fil Discord, mappé 1:1 à une session Claude Code
 - **Statut en temps réel** — Les réactions emoji montrent ce que fait Claude (🧠 réflexion, 🛠️ lecture de fichiers, 💻 édition, 🌐 recherche web)
-- **Texte en streaming** — Le texte intermédiaire apparaît pendant que Claude travaille
-- **Affichage des résultats d'outils** — Les résultats sont affichés en embeds en temps réel
-- **Pensée étendue** — Le raisonnement de Claude apparaît en embeds avec spoiler (clic pour révéler)
-- **Persistance de session** — Continuez les conversations entre messages via `--resume`
-- **Exécution de skills** — Exécutez les skills Claude Code (`/skill goodmorning`) via des commandes slash avec autocomplétion
-- **Sessions concurrentes** — Exécutez plusieurs sessions en parallèle (limite configurable)
+- **Texte en streaming** — Le texte intermédiaire apparaît au fur et à mesure que Claude travaille, pas seulement à la fin
+- **Affichage des résultats d'outils** — Les résultats d'utilisation d'outils affichés sous forme d'embeds en temps réel
+- **Chronométrage des outils en direct** — Les embeds d'outils en cours mettent à jour le temps écoulé toutes les 10s pour les commandes longues (authentification, builds), pour que vous sachiez toujours que Claude travaille encore
+- **Réflexion étendue** — Le raisonnement de Claude apparaît sous forme d'embeds avec balise spoiler (cliquez pour révéler)
+- **Persistance de session** — Continuez les conversations entre les messages via `--resume`
+- **Exécution de skills** — Exécutez des skills Claude Code avec `/skill` avec l'autocomplétion, les arguments optionnels et la reprise dans le fil
+- **Sessions simultanées** — Exécutez plusieurs sessions en parallèle (limite configurable)
+- **Arrêt sans effacement** — `/stop` arrête une session en cours tout en la préservant pour la reprise
+- **Support des pièces jointes** — Les pièces jointes textuelles sont automatiquement ajoutées au prompt (jusqu'à 5 fichiers, 50 Ko chacun)
+- **Notifications de délai d'attente** — Embed dédié avec les secondes écoulées et des conseils actionnables lors de l'expiration d'une session
+- **Questions interactives** — Quand Claude appelle `AskUserQuestion`, le bot affiche des Boutons Discord ou un Select Menu et reprend la session avec votre réponse
+- **Tableau de bord de statut de session** — Un embed épinglé en direct dans le canal principal montre quels fils sont en cours de traitement vs. en attente d'entrée ; le propriétaire est @mentionné quand Claude a besoin d'une réponse
+- **Coordination multi-session** — Avec `COORDINATION_CHANNEL_ID` configuré, chaque session diffuse les événements de début/fin vers un canal partagé pour que les sessions simultanées restent informées les unes des autres
+
+### Tâches planifiées (SchedulerCog)
+- **Tâches périodiques Claude Code** — Enregistrez des tâches via le chat Discord ou l'API REST ; elles s'exécutent selon un intervalle configurable
+- **Basé sur SQLite** — Les tâches persistent entre les redémarrages ; gérées via les endpoints `/api/tasks`
+- **Planification sans code** — Claude Code peut auto-enregistrer de nouvelles tâches avec l'outil Bash pendant une session ; sans redémarrages du bot ni modifications de code
+- **Boucle maîtresse unique** — Une boucle `discord.ext.tasks` de 30 secondes dispatche toutes les tâches, maintenant la surcharge basse
 
 ### Automatisation CI/CD
-- **Déclencheurs webhook** — Déclenchez des tâches Claude Code depuis GitHub Actions ou tout système CI/CD
-- **Mise à jour automatique** — Mettez à jour automatiquement le bot quand un paquet upstream est publié
-- **REST API** — Notifications push vers Discord depuis des outils externes (optionnel, nécessite aiohttp)
+- **Déclencheurs webhooks** — Déclenchez des tâches Claude Code depuis GitHub Actions ou n'importe quel système CI/CD
+- **Mise à jour automatique** — Mettez automatiquement à jour le bot quand les paquets upstream sont publiés
+- **API REST** — Envoyez des notifications et gérez les tâches planifiées depuis des outils externes (optionnel, nécessite aiohttp)
 
 ### Sécurité
-- **Pas d'injection shell** — Uniquement `asyncio.create_subprocess_exec`, jamais `shell=True`
-- **Validation des ID de session** — Regex strict avant de passer à `--resume`
+- **Pas d'injection shell** — Seulement `asyncio.create_subprocess_exec`, jamais `shell=True`
+- **Validation de l'ID de session** — Regex stricte avant de passer à `--resume`
 - **Prévention d'injection de flags** — Séparateur `--` avant tous les prompts
 - **Isolation des secrets** — Token du bot et secrets supprimés de l'environnement du sous-processus
-- **Autorisation utilisateur** — `allowed_user_ids` restreint qui peut invoquer Claude
+- **Autorisation des utilisateurs** — `allowed_user_ids` restreint qui peut invoquer Claude
+
+## Skills
+
+Exécutez des [skills Claude Code](https://docs.anthropic.com/en/docs/claude-code) directement depuis Discord via la commande slash `/skill`.
+
+```
+/skill name:goodmorning                      → exécute /goodmorning
+/skill name:todoist args:filter "today"      → exécute /todoist filter "today"
+/skills                                      → liste toutes les skills disponibles
+```
+
+**Fonctionnalités :**
+- **Autocomplétion** — Tapez pour filtrer ; noms et descriptions sont consultables
+- **Arguments** — Passez des arguments supplémentaires via le paramètre `args`
+- **Reprise dans le fil** — Utilisez `/skill` dans un fil Claude existant pour exécuter la skill dans la session actuelle au lieu de créer un nouveau fil
+- **Rechargement à chaud** — Les nouvelles skills ajoutées à `~/.claude/skills/` sont détectées automatiquement (intervalle de rafraîchissement de 60s, pas de redémarrage nécessaire)
 
 ## Démarrage rapide
 
@@ -73,41 +102,60 @@ GitHub PR (auto-merge)  ←  git push  ←  Claude Code  ←──┘
 
 - Python 3.10+
 - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installé et authentifié
-- Token de bot Discord avec Message Content intent activé
+- Un token de bot Discord avec l'intent Message Content activé
 - [uv](https://docs.astral.sh/uv/) (recommandé) ou pip
 
-### Exécution autonome
+### Exécuter en mode autonome
 
 ```bash
 git clone https://github.com/ebibibi/claude-code-discord-bridge.git
 cd claude-code-discord-bridge
 
 cp .env.example .env
-# Éditez .env avec votre token de bot et ID de canal
+# Éditez .env avec votre token de bot et l'ID du canal
 
 uv run python -m claude_discord.main
 ```
 
-### Installer comme paquet
+### Installer comme un paquet
 
-Si vous avez déjà un bot discord.py en fonctionnement (Discord n'autorise qu'une connexion Gateway par token) :
+Si vous avez déjà un bot discord.py en cours d'exécution (Discord n'autorise qu'une seule connexion Gateway par token) :
 
 ```bash
 uv add git+https://github.com/ebibibi/claude-code-discord-bridge.git
 ```
 
 ```python
+from claude_discord import ClaudeRunner, setup_bridge
+
+runner = ClaudeRunner(command="claude", model="sonnet")
+
+# Un seul appel enregistre tous les Cogs — les nouvelles fonctionnalités sont incluses automatiquement
+await setup_bridge(
+    bot,
+    runner,
+    session_db_path="data/sessions.db",
+    claude_channel_id=YOUR_CHANNEL_ID,
+    allowed_user_ids={YOUR_USER_ID},
+)
+```
+
+`setup_bridge()` connecte automatiquement `ClaudeChatCog`, `SkillCommandCog`, `SessionManageCog` et `SchedulerCog`. Quand de nouveaux Cogs sont ajoutés à ccdb, ils apparaissent automatiquement — sans modifications de code côté consommateur.
+
+<details>
+<summary>Connexion manuelle (avancé)</summary>
+
+```python
 from claude_discord import ClaudeChatCog, ClaudeRunner, SessionRepository
 from claude_discord.database.models import init_db
 
-# Initialiser
 await init_db("data/sessions.db")
 repo = SessionRepository("data/sessions.db")
 runner = ClaudeRunner(command="claude", model="sonnet")
 
-# Ajouter à votre bot existant
 await bot.add_cog(ClaudeChatCog(bot, repo, runner))
 ```
+</details>
 
 Mettre à jour vers la dernière version :
 
@@ -115,30 +163,348 @@ Mettre à jour vers la dernière version :
 uv lock --upgrade-package claude-code-discord-bridge && uv sync
 ```
 
+## Configuration
+
+| Variable | Description | Défaut |
+|----------|-------------|--------|
+| `DISCORD_BOT_TOKEN` | Votre token de bot Discord | (requis) |
+| `DISCORD_CHANNEL_ID` | ID du canal pour le chat Claude | (requis) |
+| `CLAUDE_COMMAND` | Chemin vers le Claude Code CLI | `claude` |
+| `CLAUDE_MODEL` | Modèle à utiliser | `sonnet` |
+| `CLAUDE_PERMISSION_MODE` | Mode de permission pour CLI | `acceptEdits` |
+| `CLAUDE_WORKING_DIR` | Répertoire de travail pour Claude | répertoire courant |
+| `MAX_CONCURRENT_SESSIONS` | Sessions parallèles maximum | `3` |
+| `SESSION_TIMEOUT_SECONDS` | Délai d'inactivité de session | `300` |
+| `DISCORD_OWNER_ID` | ID d'utilisateur Discord pour @mention quand Claude a besoin d'une entrée | (optionnel) |
+| `COORDINATION_CHANNEL_ID` | ID de canal pour les diffusions de coordination multi-session | (optionnel) |
+
+## Configuration du bot Discord
+
+1. Créez une nouvelle application sur le [Portail développeur Discord](https://discord.com/developers/applications)
+2. Créez un bot et copiez le token
+3. Activez **Message Content Intent** sous Privileged Gateway Intents
+4. Invitez le bot sur votre serveur avec ces permissions :
+   - Send Messages
+   - Create Public Threads
+   - Send Messages in Threads
+   - Add Reactions
+   - Manage Messages (pour le nettoyage des réactions)
+   - Read Message History
+
+## Automatisation GitHub + Claude Code
+
+Le système de déclencheurs webhooks vous permet de construire des workflows CI/CD entièrement autonomes où Claude Code agit comme un agent intelligent — pas seulement en exécutant des scripts, mais en comprenant les changements de code et en prenant des décisions.
+
+### Exemple : Synchronisation automatique de documentation
+
+À chaque push sur main, Claude Code :
+1. Récupère les derniers changements et analyse le diff
+2. Met à jour la documentation en anglais si le code source a changé
+3. Traduit en japonais (ou n'importe quelle langue cible)
+4. Crée une PR avec un résumé bilingue
+5. Active la fusion automatique — la PR fusionne automatiquement quand CI passe
+
+**Workflow GitHub Actions :**
+
+```yaml
+# .github/workflows/docs-sync.yml
+name: Documentation Sync
+on:
+  push:
+    branches: [main]
+jobs:
+  trigger:
+    # Ignore les commits de docs-sync lui-même (prévention de boucle infinie)
+    if: "!contains(github.event.head_commit.message, '[docs-sync]')"
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -X POST "${{ secrets.DISCORD_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -d '{"content": "🔄 docs-sync"}'
+```
+
+**Configuration du bot :**
+
+```python
+from claude_discord import WebhookTriggerCog, WebhookTrigger, ClaudeRunner
+
+runner = ClaudeRunner(command="claude", model="sonnet")
+
+triggers = {
+    "🔄 docs-sync": WebhookTrigger(
+        prompt="Analysez les changements, mettez à jour les docs, créez une PR avec résumé bilingue, activez l'auto-merge.",
+        working_dir="/home/user/my-project",
+        timeout=600,
+    ),
+    "🚀 deploy": WebhookTrigger(
+        prompt="Déployez en environnement de staging.",
+        timeout=300,
+    ),
+}
+
+await bot.add_cog(WebhookTriggerCog(
+    bot=bot,
+    runner=runner,
+    triggers=triggers,
+    channel_ids={YOUR_CHANNEL_ID},
+))
+```
+
+**Sécurité :** Seuls les messages webhook sont traités. `allowed_webhook_ids` optionnel pour un contrôle plus strict. Les prompts sont définis côté serveur — les webhooks sélectionnent uniquement quel déclencheur activer.
+
+### Exemple : Auto-approbation des PR du propriétaire
+
+Approuvez et fusionnez automatiquement vos propres PR après que CI passe :
+
+```yaml
+# .github/workflows/auto-approve.yml
+name: Auto Approve Owner PRs
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  auto-approve:
+    if: github.event.pull_request.user.login == 'your-username'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --approve
+          gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --squash
+```
+
+## Tâches planifiées
+
+`SchedulerCog` exécute des tâches Claude Code périodiques stockées dans SQLite. Les tâches sont enregistrées au moment de l'exécution via l'API REST — sans modifications de code ni redémarrages du bot.
+
+### Enregistrer une tâche (via l'API REST)
+
+```bash
+curl -X POST http://localhost:8080/api/tasks \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer your-secret-token" \
+  -d '{
+    "name": "daily-standup",
+    "prompt": "Vérifiez les issues GitHub ouvertes et publiez un bref résumé sur Discord.",
+    "interval_seconds": 86400,
+    "channel_id": 123456789
+  }'
+```
+
+### Enregistrer une tâche (Claude s'auto-enregistre pendant une session)
+
+Claude Code peut enregistrer ses propres tâches récurrentes en utilisant l'outil Bash — sans câblage manuel :
+
+```
+# Dans une session Claude Code, Claude exécute :
+curl -X POST $CCDB_API_URL/api/tasks \
+  -H "Content-Type: application/json" \
+  -d '{"name": "health-check", "prompt": "Exécutez la suite de tests et rapportez les résultats.", "interval_seconds": 3600}'
+```
+
+`CCDB_API_URL` est automatiquement injecté dans l'environnement du sous-processus de Claude quand `api_port` est configuré sur le `ClaudeRunner`.
+
+## Mise à jour automatique
+
+Mettez automatiquement à jour le bot quand un paquet upstream est publié.
+
+```python
+from claude_discord import AutoUpgradeCog, UpgradeConfig
+
+config = UpgradeConfig(
+    package_name="claude-code-discord-bridge",
+    trigger_prefix="🔄 bot-upgrade",
+    working_dir="/home/user/my-bot",
+    restart_command=["sudo", "systemctl", "restart", "my-bot.service"],
+)
+
+await bot.add_cog(AutoUpgradeCog(bot, config))
+```
+
+**Pipeline :** Push upstream → CI webhook → `🔄 bot-upgrade` → `uv lock --upgrade-package` → `uv sync` → redémarrage du service.
+
+### Vidange gracieuse (DrainAware)
+
+Avant de redémarrer, AutoUpgradeCog attend que toutes les sessions actives se terminent. Tout Cog qui implémente une propriété `active_count` (satisfaisant le protocole `DrainAware`) est automatiquement découvert — pas de lambda `drain_check` manuel nécessaire.
+
+Cogs DrainAware intégrés : `ClaudeChatCog`, `WebhookTriggerCog`.
+
+Pour rendre votre propre Cog compatible avec la vidange, ajoutez simplement une propriété `active_count` :
+
+```python
+class MyCog(commands.Cog):
+    @property
+    def active_count(self) -> int:
+        return len(self._running_tasks)
+```
+
+Vous pouvez toujours passer un callable `drain_check` explicite pour remplacer l'autodécouverte.
+
+### Approbation de redémarrage
+
+Pour les scénarios de mise à jour automatique (ex. mettre à jour le bot depuis sa propre session Discord), activez `restart_approval` pour éviter les redémarrages automatiques :
+
+```python
+config = UpgradeConfig(
+    package_name="claude-code-discord-bridge",
+    trigger_prefix="🔄 bot-upgrade",
+    working_dir="/home/user/my-bot",
+    restart_command=["sudo", "systemctl", "restart", "my-bot.service"],
+    restart_approval=True,
+)
+```
+
+Avec `restart_approval=True`, après la mise à jour du paquet le bot publie un message demandant l'approbation. Réagissez avec ✅ pour déclencher le redémarrage. Le bot envoie des rappels périodiques jusqu'à approbation.
+
+## API REST
+
+API REST optionnelle pour envoyer des notifications à Discord depuis des outils externes. Nécessite aiohttp :
+
+```bash
+uv add "claude-code-discord-bridge[api]"
+```
+
+```python
+from claude_discord import NotificationRepository
+from claude_discord.ext.api_server import ApiServer
+
+repo = NotificationRepository("data/notifications.db")
+await repo.init_db()
+
+api = ApiServer(
+    repo=repo,
+    bot=bot,
+    default_channel_id=YOUR_CHANNEL_ID,
+    host="127.0.0.1",
+    port=8080,
+    api_secret="your-secret-token",  # Auth Bearer optionnel
+)
+await api.start()
+```
+
+### Endpoints
+
+**Notifications**
+
+| Méthode | Chemin | Description |
+|---------|--------|-------------|
+| GET | `/api/health` | Vérification de santé |
+| POST | `/api/notify` | Envoyer une notification immédiate |
+| POST | `/api/schedule` | Planifier une notification pour plus tard |
+| GET | `/api/scheduled` | Lister les notifications en attente |
+| DELETE | `/api/scheduled/{id}` | Annuler une notification planifiée |
+
+**Tâches planifiées** (nécessite `SchedulerCog`)
+
+| Méthode | Chemin | Description |
+|---------|--------|-------------|
+| POST | `/api/tasks` | Enregistrer une nouvelle tâche Claude Code périodique |
+| GET | `/api/tasks` | Lister toutes les tâches enregistrées |
+| DELETE | `/api/tasks/{id}` | Supprimer une tâche planifiée |
+| PATCH | `/api/tasks/{id}` | Mettre à jour une tâche (activer/désactiver, prompt, intervalle) |
+
+### Exemples
+
+```bash
+# Vérification de santé
+curl http://localhost:8080/api/health
+
+# Envoyer une notification
+curl -X POST http://localhost:8080/api/notify \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer your-secret-token" \
+  -d '{"message": "Build réussi !", "title": "CI/CD"}'
+
+# Planifier une notification
+curl -X POST http://localhost:8080/api/schedule \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Il est temps de réviser les PR", "scheduled_at": "2026-01-01T09:00:00"}'
+```
+
+## Architecture
+
+```
+claude_discord/
+  main.py                  # Point d'entrée autonome
+  bot.py                   # Classe Discord Bot
+  setup.py                 # setup_bridge() — fabrique à appel unique pour tous les Cogs
+  cogs/
+    claude_chat.py         # Chat interactif (création de fils, traitement des messages)
+    skill_command.py       # Commande slash /skill avec autocomplétion
+    webhook_trigger.py     # Webhook → exécution de tâche Claude Code (CI/CD)
+    auto_upgrade.py        # Webhook → mise à jour du paquet + redémarrage
+    scheduler.py           # Tâches Claude Code périodiques (basé sur SQLite, boucle maîtresse de 30s)
+    _run_helper.py         # Logique d'exécution Claude CLI partagée
+  claude/
+    runner.py              # Gestionnaire de sous-processus Claude CLI
+    parser.py              # Parseur d'événements stream-json
+    types.py               # Définitions de types pour les messages SDK
+  database/
+    models.py              # Schéma SQLite
+    repository.py          # Opérations CRUD de sessions
+    ask_repo.py            # CRUD des AskUserQuestion en attente (récupération après redémarrage)
+    notification_repo.py   # CRUD des notifications planifiées
+    task_repo.py           # CRUD des tâches planifiées (SchedulerCog)
+  coordination/
+    service.py             # CoordinationService — publie les événements du cycle de vie de session sur un canal partagé
+  discord_ui/
+    status.py              # Gestionnaire de statut par réactions emoji (avec debounce)
+    chunker.py             # Division de messages avec conscience des blocs de code et des tableaux
+    embeds.py              # Constructeurs d'embeds Discord
+    ask_view.py            # Boutons Discord/Select Menus pour AskUserQuestion
+    ask_bus.py             # Routage de bus pour les boutons AskView persistants (survit aux redémarrages)
+    thread_dashboard.py    # Embed épinglé en direct montrant les états de session par fil
+  ext/
+    api_server.py          # Serveur API REST (optionnel, nécessite aiohttp)
+                           # Inclut les endpoints /api/tasks pour SchedulerCog
+  utils/
+    logger.py              # Configuration du logging
+```
+
+### Philosophie de conception
+
+- **Spawn CLI, pas API** — Nous invoquons `claude -p --output-format stream-json`, obtenant gratuitement toutes les fonctionnalités de Claude Code (CLAUDE.md, skills, outils, mémoire)
+- **Discord comme colle** — Discord fournit l'interface, le threading, les notifications et l'infrastructure webhook
+- **Framework, pas application** — Installez comme un paquet, ajoutez des Cogs à votre bot existant, configurez via du code
+- **Sécurité par la simplicité** — ~2500 lignes de Python auditable, pas d'exécution shell, pas de chemins de code arbitraires
+
 ## Tests
 
 ```bash
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-131 tests couvrant le parser, le chunker, le repository, le runner, le streaming, les déclencheurs webhook, l'auto-upgrade et l'API REST.
+473 tests couvrant le parseur, le chunker, le dépôt, le runner, le streaming, les déclencheurs webhook, la mise à jour automatique, l'API REST, l'interface AskUserQuestion, le tableau de bord d'état des fils, SchedulerCog et le dépôt de tâches.
 
 ## Comment ce projet a été construit
 
-**L'intégralité du code a été écrite par [Claude Code](https://docs.anthropic.com/en/docs/claude-code)** — l'agent de codage IA d'Anthropic. L'auteur humain ([@ebibibi](https://github.com/ebibibi)) a fourni les exigences et la direction en langage naturel, mais n'a pas lu ou édité manuellement le code source.
+**Tout ce code base a été écrit par [Claude Code](https://docs.anthropic.com/en/docs/claude-code)**, l'agent de codification IA d'Anthropic. L'auteur humain ([@ebibibi](https://github.com/ebibibi)) a fourni des exigences et une direction en langage naturel, mais n'a pas lu ni édité manuellement le code source.
 
 Cela signifie :
 
-- **Tout le code est généré par IA** — architecture, implémentation, tests, documentation
-- **L'auteur humain ne peut pas garantir l'exactitude au niveau du code** — examinez le source si vous avez besoin d'assurance
-- **Les rapports de bugs et les PRs sont les bienvenus** — Claude Code sera probablement utilisé pour les traiter
-- **C'est un exemple concret de logiciel open source écrit par une IA** — utilisez-le comme référence de ce que Claude Code peut construire
+- **Tout le code a été généré par IA** — architecture, implémentation, tests, documentation
+- **L'auteur humain ne peut pas garantir la correction au niveau du code** — révisez le code source si vous avez besoin de certitude
+- **Les rapports de bugs et les PR sont les bienvenus** — Claude Code sera probablement utilisé pour les traiter aussi
+- **C'est un exemple concret de logiciel open source de création IA** — utilisez-le comme référence de ce que Claude Code peut construire
 
-Le projet a démarré le 2026-02-18 et continue d'évoluer à travers des conversations itératives avec Claude Code.
+Le projet a démarré le 2026-02-18 et continue d'évoluer grâce à des conversations itératives avec Claude Code.
 
 ## Exemple concret
 
-**[EbiBot](https://github.com/ebibibi/discord-bot)** — Un bot Discord personnel qui utilise claude-code-discord-bridge comme dépendance. Inclut la synchronisation automatique de documentation (anglais + japonais), les notifications push, le watchdog Todoist et l'intégration CI/CD avec GitHub Actions.
+**[EbiBot](https://github.com/ebibibi/discord-bot)** — Un bot Discord personnel qui utilise claude-code-discord-bridge comme dépendance de paquet. Comprend la synchronisation automatique de documentation (anglais + japonais), les notifications push, le watchdog Todoist et l'intégration CI/CD avec GitHub Actions. Utilisez-le comme référence pour construire votre propre bot sur ce framework.
+
+## Inspiré par
+
+- [OpenClaw](https://github.com/openclaw/openclaw) — Réactions de statut emoji, debouncing des messages, chunking avec conscience des blocs de code
+- [claude-code-discord-bot](https://github.com/timoconnellaus/claude-code-discord-bot) — Approche CLI spawn + stream-json
+- [claude-code-discord](https://github.com/zebbern/claude-code-discord) — Patterns de contrôle des permissions
+- [claude-sandbox-bot](https://github.com/RhysSullivan/claude-sandbox-bot) — Modèle de fil par conversation
 
 ## Licence
 

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -1,7 +1,7 @@
 > **Note:** This is an auto-translated version of the original English documentation.
 > If there are any discrepancies, the [English version](../../README.md) takes precedence.
-> **참고:** 이 문서는 영어 원본 문서의 자동 번역본입니다.
-> 내용이 다를 경우 [영어 버전](../../README.md)이 우선합니다.
+> **참고:** 이것은 영문 원본 문서의 자동 번역본입니다.
+> 내용에 차이가 있을 경우 [영문판](../../README.md)이 우선합니다.
 
 # claude-code-discord-bridge
 
@@ -9,63 +9,92 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-[Claude Code](https://docs.anthropic.com/en/docs/claude-code)를 Discord와 GitHub에 연결합니다. **인터랙티브 채팅, CI/CD 자동화, GitHub 워크플로우 통합**을 위해 Claude Code CLI와 Discord를 브릿지하는 프레임워크입니다.
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code)를 Discord와 GitHub에 연결합니다. Claude Code CLI와 Discord를 연결하는 **인터랙티브 채팅, CI/CD 자동화, GitHub 워크플로 통합**을 위한 프레임워크입니다.
 
-Claude Code는 터미널에서 훌륭하지만 — 더 많은 것이 가능합니다. 이 브릿지를 사용하면 **GitHub 개발 워크플로우에서 Claude Code를 활용**할 수 있습니다: 문서 자동 동기화, PR 리뷰 및 머지, GitHub Actions에서 트리거되는 모든 Claude Code 작업 실행. Discord를 범용 접착제로 사용합니다.
+Claude Code는 터미널에서 훌륭하지만 훨씬 더 많은 것을 할 수 있습니다. 이 브릿지를 통해 **GitHub 개발 워크플로에서 Claude Code를 사용**할 수 있습니다: 문서 자동 동기화, PR 검토 및 병합, GitHub Actions로 트리거되는 모든 Claude Code 작업 실행. Discord를 범용 접착제로 사용합니다.
 
 **[English](../../README.md)** | **[日本語](../ja/README.md)** | **[简体中文](../zh-CN/README.md)** | **[Español](../es/README.md)** | **[Português](../pt-BR/README.md)** | **[Français](../fr/README.md)**
 
-> **면책 조항:** 이 프로젝트는 Anthropic과 제휴하거나 승인받거나 공식적으로 연결되어 있지 않습니다. "Claude"와 "Claude Code"는 Anthropic, PBC의 상표입니다. 이것은 Claude Code CLI와 인터페이스하는 독립적인 오픈소스 도구입니다.
+> **면책 조항:** 이 프로젝트는 Anthropic과 무관하며, Anthropic의 보증이나 공식 연관이 없습니다. "Claude"와 "Claude Code"는 Anthropic, PBC의 상표입니다. 이것은 Claude Code CLI와 인터페이스하는 독립적인 오픈소스 도구입니다.
 
-> **Claude Code로 완전히 구축되었습니다.** 이 프로젝트는 Anthropic의 AI 코딩 에이전트인 Claude Code 자체에 의해 설계, 구현, 테스트 및 문서화되었습니다. 인간 저자는 소스 코드를 읽지 않았습니다. 자세한 내용은 [이 프로젝트가 구축된 방법](#이-프로젝트가-구축된-방법)을 참조하세요.
+> **완전히 Claude Code로 제작.** 이 프로젝트는 Anthropic의 AI 코딩 에이전트인 Claude Code 자체에 의해 설계, 구현, 테스트 및 문서화되었습니다. 인간 저자는 소스 코드를 읽지 않았습니다. 자세한 내용은 [이 프로젝트가 구축된 방법](#이-프로젝트가-구축된-방법)을 참조하세요.
 
 ## 두 가지 사용 방법
 
-### 1. 인터랙티브 채팅 (모바일 / 데스크톱)
+### 1. 인터랙티브 채팅 (모바일 / 데스크탑)
 
-스마트폰이나 Discord가 있는 어떤 기기에서든 Claude Code를 사용하세요. 각 대화는 완전한 세션 지속성을 가진 스레드가 됩니다.
+스마트폰이나 Discord가 있는 모든 기기에서 Claude Code를 사용합니다. 각 대화는 완전한 세션 지속성을 가진 Discord 스레드가 됩니다.
 
 ```
-사용자 (Discord)  →  Bridge  →  Claude Code CLI
-       ↑                                ↓
-       ←──── stream-json 출력 ─────────←
+당신 (Discord)  →  Bridge  →  Claude Code CLI
+      ↑                              ↓
+      ←──── stream-json 출력 ────────←
 ```
 
 ### 2. CI/CD 자동화 (GitHub → Discord → Claude Code → GitHub)
 
-Discord webhook을 통해 GitHub Actions에서 Claude Code 작업을 트리거합니다. Claude Code는 자율적으로 동작합니다 — 코드를 읽고, 문서를 업데이트하고, PR을 생성하고, 자동 머지를 활성화합니다.
+Discord webhook을 통해 GitHub Actions에서 Claude Code 작업을 트리거합니다. Claude Code가 자율적으로 실행됩니다 — 코드 읽기, 문서 업데이트, PR 생성, 자동 병합 활성화.
 
 ```
 GitHub Actions  →  Discord Webhook  →  Bridge  →  Claude Code CLI
                                                          ↓
-GitHub PR (자동 머지)  ←  git push  ←  Claude Code  ←──┘
+GitHub PR (자동 병합)  ←  git push  ←  Claude Code  ←────┘
 ```
 
-**실제 사례:** main에 푸시할 때마다 Claude Code가 자동으로 변경 사항을 분석하고, 영어와 일본어 문서를 업데이트하고, 이중 언어 요약이 포함된 PR을 생성하고, 자동 머지를 활성화합니다. 사람의 개입이 필요 없습니다.
+**실제 사례:** main에 푸시할 때마다 Claude Code가 자동으로 변경 사항을 분석하고, 영어와 일본어 문서를 업데이트하고, 이중 언어 요약이 있는 PR을 만들고, 자동 병합을 활성화합니다. 사람의 개입이 필요하지 않습니다.
 
 ## 기능
 
 ### 인터랙티브 채팅
-- **Thread = Session** — 각 작업이 고유한 Discord 스레드를 가지며, Claude Code 세션과 1:1 매핑
-- **실시간 상태** — 이모지 리액션으로 Claude의 활동 표시 (🧠 생각 중, 🛠️ 파일 읽기, 💻 편집 중, 🌐 웹 검색)
-- **스트리밍 텍스트** — Claude가 작업하는 동안 중간 텍스트가 실시간으로 표시
-- **도구 결과 표시** — 도구 사용 결과가 실시간으로 embed로 표시
-- **확장 사고** — Claude의 추론이 스포일러 태그 embed로 표시 (클릭하여 펼치기)
-- **세션 지속성** — `--resume`을 통한 메시지 간 대화 계속
-- **스킬 실행** — 슬래시 커맨드와 자동 완성으로 Claude Code 스킬 실행 (`/skill goodmorning`)
-- **동시 세션** — 여러 세션을 병렬로 실행 (구성 가능한 제한)
+- **Thread = Session** — 각 작업이 자체 Discord 스레드를 가지며 Claude Code 세션과 1:1로 매핑
+- **실시간 상태** — 이모지 반응으로 Claude가 하는 일 표시 (🧠 생각 중, 🛠️ 파일 읽기, 💻 편집 중, 🌐 웹 검색)
+- **스트리밍 텍스트** — Claude가 작업하는 동안 중간 텍스트가 실시간으로 표시 (끝날 때만이 아님)
+- **도구 결과 표시** — 도구 사용 결과가 embed로 실시간 표시
+- **실시간 도구 타이밍** — 장시간 실행 명령(인증 흐름, 빌드 등)에서 10초마다 경과 시간을 업데이트하여 Claude가 여전히 작동 중임을 알 수 있음
+- **확장 사고** — Claude의 추론이 스포일러 태그 embed로 표시 (클릭하여 공개)
+- **세션 지속성** — `--resume`을 통해 여러 메시지에 걸쳐 대화 계속
+- **스킬 실행** — 자동 완성, 선택적 인수, 스레드 내 재개와 함께 `/skill`로 Claude Code 스킬 실행
+- **동시 세션** — 여러 세션을 병렬로 실행 (설정 가능한 제한)
+- **지우지 않고 중지** — `/stop`으로 실행 중인 세션을 중단하면서 재개를 위해 보존
+- **첨부 파일 지원** — 텍스트 파일 첨부가 프롬프트에 자동 추가 (최대 5개 파일, 각 50 KB)
+- **타임아웃 알림** — 세션 타임아웃 시 경과 시간과 조치 안내가 포함된 전용 embed
+- **인터랙티브 질문** — Claude가 `AskUserQuestion`을 호출하면 Bot이 Discord 버튼 또는 Select Menu를 렌더링하고 답변으로 세션을 재개
+- **세션 상태 대시보드** — 메인 채널의 라이브 고정 embed로 어떤 스레드가 처리 중인지 vs. 입력 대기 중인지 표시; Claude가 답변이 필요할 때 소유자를 @mention
+- **다중 세션 조율** — `COORDINATION_CHANNEL_ID` 설정 시 각 세션이 공유 채널에 시작/종료 이벤트를 브로드캐스트하여 동시 세션이 서로 인식
+
+### 예약 작업 (SchedulerCog)
+- **정기적 Claude Code 작업** — Discord 채팅 또는 REST API를 통해 작업 등록; 설정 가능한 간격으로 실행
+- **SQLite 기반** — 작업이 재시작 후에도 유지; `/api/tasks` 엔드포인트로 관리
+- **코드 없는 스케줄링** — Claude Code가 세션 중 Bash 도구를 통해 새 작업을 자기 등록 가능; Bot 재시작이나 코드 변경 불필요
+- **단일 마스터 루프** — 하나의 30초 `discord.ext.tasks` 루프가 모든 작업을 디스패치하여 오버헤드를 낮게 유지
 
 ### CI/CD 자동화
 - **Webhook 트리거** — GitHub Actions 또는 모든 CI/CD 시스템에서 Claude Code 작업 트리거
-- **자동 업그레이드** — 업스트림 패키지가 릴리스되면 Bot 자동 업데이트
-- **REST API** — 외부 도구에서 Discord로 푸시 알림 (선택 사항, aiohttp 필요)
+- **자동 업그레이드** — 업스트림 패키지가 릴리스될 때 Bot 자동 업데이트
+- **REST API** — 외부 도구에서 알림 푸시 및 예약 작업 관리 (선택적, aiohttp 필요)
 
 ### 보안
-- **Shell 주입 방지** — `asyncio.create_subprocess_exec`만 사용, `shell=True` 절대 사용 안 함
-- **세션 ID 검증** — `--resume`에 전달하기 전 엄격한 정규식으로 검증
-- **플래그 주입 방지** — 모든 프롬프트 앞에 `--` 구분자
-- **시크릿 격리** — Bot 토큰과 시크릿을 서브프로세스 환경에서 제거
-- **사용자 인증** — `allowed_user_ids`로 Claude를 호출할 수 있는 사용자 제한
+- **Shell 인젝션 없음** — `asyncio.create_subprocess_exec`만 사용, `shell=True` 절대 없음
+- **세션 ID 검증** — `--resume`에 전달 전 엄격한 정규식 검증
+- **플래그 인젝션 방지** — 모든 프롬프트 앞에 `--` 구분자
+- **비밀 격리** — Bot 토큰과 비밀이 서브프로세스 환경에서 제거
+- **사용자 권한** — `allowed_user_ids`로 Claude를 호출할 수 있는 사용자 제한
+
+## 스킬
+
+`/skill` 슬래시 명령을 통해 Discord에서 직접 [Claude Code 스킬](https://docs.anthropic.com/en/docs/claude-code)을 실행합니다.
+
+```
+/skill name:goodmorning                      → /goodmorning 실행
+/skill name:todoist args:filter "today"      → /todoist filter "today" 실행
+/skills                                      → 모든 사용 가능한 스킬 나열
+```
+
+**기능:**
+- **자동 완성** — 입력하여 필터; 이름과 설명 모두 검색 가능
+- **인수** — `args` 매개변수를 통해 추가 인수 전달
+- **스레드 내 재개** — 기존 Claude 스레드 내에서 `/skill` 사용 시 새 스레드 대신 현재 세션 내에서 스킬 실행
+- **핫 리로드** — `~/.claude/skills/`에 추가된 새 스킬 자동 인식 (60초 갱신 간격, 재시작 불필요)
 
 ## 빠른 시작
 
@@ -90,24 +119,43 @@ uv run python -m claude_discord.main
 
 ### 패키지로 설치
 
-이미 discord.py Bot을 실행 중인 경우 (Discord는 토큰당 하나의 Gateway 연결만 허용):
+이미 discord.py Bot이 실행 중인 경우 (Discord는 토큰당 하나의 Gateway 연결만 허용):
 
 ```bash
 uv add git+https://github.com/ebibibi/claude-code-discord-bridge.git
 ```
 
 ```python
+from claude_discord import ClaudeRunner, setup_bridge
+
+runner = ClaudeRunner(command="claude", model="sonnet")
+
+# 한 번 호출로 모든 Cog 등록 — 새 기능이 자동으로 포함
+await setup_bridge(
+    bot,
+    runner,
+    session_db_path="data/sessions.db",
+    claude_channel_id=YOUR_CHANNEL_ID,
+    allowed_user_ids={YOUR_USER_ID},
+)
+```
+
+`setup_bridge()`는 `ClaudeChatCog`, `SkillCommandCog`, `SessionManageCog`, `SchedulerCog`를 자동으로 연결합니다. ccdb에 새 Cog가 추가되면 자동으로 포함됩니다 — 소비자 코드 변경 불필요.
+
+<details>
+<summary>수동 연결 (고급)</summary>
+
+```python
 from claude_discord import ClaudeChatCog, ClaudeRunner, SessionRepository
 from claude_discord.database.models import init_db
 
-# 초기화
 await init_db("data/sessions.db")
 repo = SessionRepository("data/sessions.db")
 runner = ClaudeRunner(command="claude", model="sonnet")
 
-# 기존 Bot에 추가
 await bot.add_cog(ClaudeChatCog(bot, repo, runner))
 ```
+</details>
 
 최신 버전으로 업데이트:
 
@@ -126,7 +174,305 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `CLAUDE_PERMISSION_MODE` | CLI 권한 모드 | `acceptEdits` |
 | `CLAUDE_WORKING_DIR` | Claude의 작업 디렉토리 | 현재 디렉토리 |
 | `MAX_CONCURRENT_SESSIONS` | 최대 동시 세션 수 | `3` |
-| `SESSION_TIMEOUT_SECONDS` | 세션 비활성 시간 초과 | `300` |
+| `SESSION_TIMEOUT_SECONDS` | 세션 비활성 타임아웃 | `300` |
+| `DISCORD_OWNER_ID` | Claude가 입력이 필요할 때 @mention할 Discord 사용자 ID | (선택적) |
+| `COORDINATION_CHANNEL_ID` | 다중 세션 조율 브로드캐스트용 채널 ID | (선택적) |
+
+## Discord Bot 설정
+
+1. [Discord Developer Portal](https://discord.com/developers/applications)에서 새 애플리케이션 생성
+2. Bot 생성 후 토큰 복사
+3. Privileged Gateway Intents에서 **Message Content Intent** 활성화
+4. 다음 권한으로 Bot을 서버에 초대:
+   - Send Messages
+   - Create Public Threads
+   - Send Messages in Threads
+   - Add Reactions
+   - Manage Messages (반응 정리용)
+   - Read Message History
+
+## GitHub + Claude Code 자동화
+
+Webhook 트리거 시스템으로 Claude Code가 스크립트만 실행하는 것이 아닌 코드 변경을 이해하고 결정을 내리는 지능형 에이전트로 동작하는 완전 자율 CI/CD 워크플로를 구축할 수 있습니다.
+
+### 예시: 자동화된 문서 동기화
+
+main에 푸시할 때마다 Claude Code가:
+1. 최신 변경 사항을 가져와 diff 분석
+2. 소스 코드가 변경된 경우 영어 문서 업데이트
+3. 일본어 (또는 모든 대상 언어)로 번역
+4. 이중 언어 요약이 있는 PR 생성
+5. 자동 병합 활성화 — CI 통과 시 PR이 자동으로 병합
+
+**GitHub Actions 워크플로:**
+
+```yaml
+# .github/workflows/docs-sync.yml
+name: Documentation Sync
+on:
+  push:
+    branches: [main]
+jobs:
+  trigger:
+    # docs-sync 자체 커밋 건너뛰기 (무한 루프 방지)
+    if: "!contains(github.event.head_commit.message, '[docs-sync]')"
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -X POST "${{ secrets.DISCORD_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -d '{"content": "🔄 docs-sync"}'
+```
+
+**Bot 설정:**
+
+```python
+from claude_discord import WebhookTriggerCog, WebhookTrigger, ClaudeRunner
+
+runner = ClaudeRunner(command="claude", model="sonnet")
+
+triggers = {
+    "🔄 docs-sync": WebhookTrigger(
+        prompt="변경 사항 분석, 문서 업데이트, 이중 언어 요약 PR 생성, 자동 병합 활성화.",
+        working_dir="/home/user/my-project",
+        timeout=600,
+    ),
+    "🚀 deploy": WebhookTrigger(
+        prompt="스테이징 환경에 배포.",
+        timeout=300,
+    ),
+}
+
+await bot.add_cog(WebhookTriggerCog(
+    bot=bot,
+    runner=runner,
+    triggers=triggers,
+    channel_ids={YOUR_CHANNEL_ID},
+))
+```
+
+**보안:** webhook 메시지만 처리됩니다. 더 엄격한 제어를 위한 선택적 `allowed_webhook_ids`. 프롬프트는 서버 측에서 정의 — webhook은 어떤 트리거를 실행할지만 선택합니다.
+
+### 예시: 소유자 PR 자동 승인
+
+CI 통과 후 자신의 PR을 자동으로 승인하고 자동 병합:
+
+```yaml
+# .github/workflows/auto-approve.yml
+name: Auto Approve Owner PRs
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  auto-approve:
+    if: github.event.pull_request.user.login == 'your-username'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --approve
+          gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --squash
+```
+
+## 예약 작업
+
+`SchedulerCog`는 SQLite에 저장된 정기적 Claude Code 작업을 실행합니다. 작업은 런타임에 REST API를 통해 등록됩니다 — 코드 변경이나 Bot 재시작 불필요.
+
+### REST API를 통한 작업 등록
+
+```bash
+curl -X POST http://localhost:8080/api/tasks \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer your-secret-token" \
+  -d '{
+    "name": "daily-standup",
+    "prompt": "열린 GitHub 이슈를 확인하고 Discord에 간략한 요약을 게시하세요.",
+    "interval_seconds": 86400,
+    "channel_id": 123456789
+  }'
+```
+
+### Claude가 세션 중 자기 등록
+
+Claude Code는 세션 중 Bash 도구를 사용하여 자신의 반복 작업을 등록할 수 있습니다 — 사람의 연결 불필요:
+
+```
+# Claude Code 세션 내에서 Claude가 실행:
+curl -X POST $CCDB_API_URL/api/tasks \
+  -H "Content-Type: application/json" \
+  -d '{"name": "health-check", "prompt": "테스트 스위트를 실행하고 결과를 보고하세요.", "interval_seconds": 3600}'
+```
+
+`ClaudeRunner`에 `api_port`가 설정되면 `CCDB_API_URL`이 Claude의 서브프로세스 환경에 자동으로 주입됩니다.
+
+## 자동 업그레이드
+
+업스트림 패키지가 릴리스될 때 Bot을 자동으로 업그레이드합니다.
+
+```python
+from claude_discord import AutoUpgradeCog, UpgradeConfig
+
+config = UpgradeConfig(
+    package_name="claude-code-discord-bridge",
+    trigger_prefix="🔄 bot-upgrade",
+    working_dir="/home/user/my-bot",
+    restart_command=["sudo", "systemctl", "restart", "my-bot.service"],
+)
+
+await bot.add_cog(AutoUpgradeCog(bot, config))
+```
+
+**파이프라인:** 업스트림 푸시 → CI webhook → `🔄 bot-upgrade` → `uv lock --upgrade-package` → `uv sync` → 서비스 재시작.
+
+### 우아한 드레인 (DrainAware)
+
+재시작 전에 AutoUpgradeCog는 모든 활성 세션이 완료될 때까지 기다립니다. `active_count` 속성을 구현하는 모든 Cog (`DrainAware` 프로토콜 충족)가 자동으로 발견됩니다 — 수동 `drain_check` 람다 불필요.
+
+내장 DrainAware Cog: `ClaudeChatCog`, `WebhookTriggerCog`.
+
+자신의 Cog를 드레인 지원으로 만들려면 `active_count` 속성만 추가하면 됩니다:
+
+```python
+class MyCog(commands.Cog):
+    @property
+    def active_count(self) -> int:
+        return len(self._running_tasks)
+```
+
+자동 발견을 재정의하기 위해 명시적 `drain_check` 콜러블을 전달할 수도 있습니다.
+
+### 재시작 승인
+
+자기 업데이트 시나리오 (Bot 자신의 Discord 세션에서 업데이트하는 경우 등)에서 `restart_approval`을 활성화하여 자동 재시작을 방지할 수 있습니다:
+
+```python
+config = UpgradeConfig(
+    package_name="claude-code-discord-bridge",
+    trigger_prefix="🔄 bot-upgrade",
+    working_dir="/home/user/my-bot",
+    restart_command=["sudo", "systemctl", "restart", "my-bot.service"],
+    restart_approval=True,
+)
+```
+
+`restart_approval=True`를 사용하면 패키지 업그레이드 후 Bot이 승인을 요청하는 메시지를 게시합니다. ✅로 반응하여 재시작을 트리거합니다. 승인될 때까지 주기적으로 알림을 보냅니다.
+
+## REST API
+
+외부 도구에서 Discord로 알림을 푸시하기 위한 선택적 REST API. aiohttp 필요:
+
+```bash
+uv add "claude-code-discord-bridge[api]"
+```
+
+```python
+from claude_discord import NotificationRepository
+from claude_discord.ext.api_server import ApiServer
+
+repo = NotificationRepository("data/notifications.db")
+await repo.init_db()
+
+api = ApiServer(
+    repo=repo,
+    bot=bot,
+    default_channel_id=YOUR_CHANNEL_ID,
+    host="127.0.0.1",
+    port=8080,
+    api_secret="your-secret-token",  # 선택적 Bearer 인증
+)
+await api.start()
+```
+
+### 엔드포인트
+
+**알림**
+
+| 메서드 | 경로 | 설명 |
+|--------|------|------|
+| GET | `/api/health` | 헬스 체크 |
+| POST | `/api/notify` | 즉시 알림 전송 |
+| POST | `/api/schedule` | 나중에 알림 예약 |
+| GET | `/api/scheduled` | 대기 중인 알림 나열 |
+| DELETE | `/api/scheduled/{id}` | 예약된 알림 취소 |
+
+**예약 작업** (`SchedulerCog` 필요)
+
+| 메서드 | 경로 | 설명 |
+|--------|------|------|
+| POST | `/api/tasks` | 새로운 정기 Claude Code 작업 등록 |
+| GET | `/api/tasks` | 모든 등록된 작업 나열 |
+| DELETE | `/api/tasks/{id}` | 예약된 작업 제거 |
+| PATCH | `/api/tasks/{id}` | 작업 업데이트 (활성화/비활성화, 프롬프트, 간격) |
+
+### 사용 예시
+
+```bash
+# 헬스 체크
+curl http://localhost:8080/api/health
+
+# 알림 전송
+curl -X POST http://localhost:8080/api/notify \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer your-secret-token" \
+  -d '{"message": "빌드 성공!", "title": "CI/CD"}'
+
+# 알림 예약
+curl -X POST http://localhost:8080/api/schedule \
+  -H "Content-Type: application/json" \
+  -d '{"message": "PR 검토 시간입니다", "scheduled_at": "2026-01-01T09:00:00"}'
+```
+
+## 아키텍처
+
+```
+claude_discord/
+  main.py                  # 독립 실행 진입점
+  bot.py                   # Discord Bot 클래스
+  setup.py                 # setup_bridge() — 모든 Cog를 위한 원클릭 팩토리
+  cogs/
+    claude_chat.py         # 인터랙티브 채팅 (스레드 생성, 메시지 처리)
+    skill_command.py       # /skill 슬래시 명령 (자동 완성)
+    webhook_trigger.py     # Webhook → Claude Code 작업 실행 (CI/CD)
+    auto_upgrade.py        # Webhook → 패키지 업그레이드 + 재시작
+    scheduler.py           # 정기 Claude Code 작업 (SQLite 기반, 30초 마스터 루프)
+    _run_helper.py         # 공유 Claude CLI 실행 로직
+  claude/
+    runner.py              # Claude CLI 서브프로세스 관리자
+    parser.py              # stream-json 이벤트 파서
+    types.py               # SDK 메시지 타입 정의
+  database/
+    models.py              # SQLite 스키마
+    repository.py          # 세션 CRUD 작업
+    ask_repo.py            # 대기 중인 AskUserQuestion CRUD (재시작 복구)
+    notification_repo.py   # 예약 알림 CRUD
+    task_repo.py           # 예약 작업 CRUD (SchedulerCog)
+  coordination/
+    service.py             # CoordinationService — 공유 채널에 세션 라이프사이클 이벤트 게시
+  discord_ui/
+    status.py              # 이모지 반응 상태 관리자 (디바운스)
+    chunker.py             # 코드 펜스 및 테이블 인식 메시지 분할
+    embeds.py              # Discord embed 빌더
+    ask_view.py            # AskUserQuestion용 Discord 버튼/Select Menu
+    ask_bus.py             # 영구 AskView 버튼을 위한 버스 라우팅 (재시작 후에도 유지)
+    thread_dashboard.py    # 스레드별 세션 상태를 표시하는 라이브 고정 embed
+  ext/
+    api_server.py          # REST API 서버 (선택적, aiohttp 필요)
+                           # SchedulerCog용 /api/tasks 엔드포인트 포함
+  utils/
+    logger.py              # 로깅 설정
+```
+
+### 설계 철학
+
+- **CLI 생성, API 아님** — `claude -p --output-format stream-json` 호출로 전체 Claude Code 기능 (CLAUDE.md, 스킬, 도구, 메모리) 무료 사용
+- **Discord를 접착제로** — Discord가 UI, 스레딩, 알림, webhook 인프라 제공
+- **프레임워크, 애플리케이션 아님** — 패키지로 설치하고, 기존 Bot에 Cog 추가, 코드로 설정
+- **단순함에 의한 보안** — 약 2500줄의 감사 가능한 Python, Shell 실행 없음, 임의 코드 경로 없음
 
 ## 테스트
 
@@ -134,24 +480,31 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-131개의 테스트가 파서, 청커, 리포지토리, 러너, 스트리밍, webhook 트리거, 자동 업그레이드 및 REST API를 커버합니다.
+473개 테스트가 파서, 청커, 리포지토리, 러너, 스트리밍, webhook 트리거, 자동 업그레이드, REST API, AskUserQuestion UI, 스레드 상태 대시보드, SchedulerCog 및 작업 리포지토리를 커버합니다.
 
 ## 이 프로젝트가 구축된 방법
 
-**이 전체 코드베이스는 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)** — Anthropic의 AI 코딩 에이전트에 의해 작성되었습니다. 인간 저자([@ebibibi](https://github.com/ebibibi))는 자연어로 요구 사항과 방향을 제공했지만, 소스 코드를 직접 읽거나 편집하지 않았습니다.
+**이 전체 코드베이스는 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)**——Anthropic의 AI 코딩 에이전트에 의해 작성되었습니다. 인간 저자([@ebibibi](https://github.com/ebibibi))는 자연어로 요구 사항과 방향을 제공했지만, 소스 코드를 직접 읽거나 편집하지 않았습니다.
 
 이것은 다음을 의미합니다:
 
 - **모든 코드가 AI 생성** — 아키텍처, 구현, 테스트, 문서
-- **인간 저자는 코드 수준의 정확성을 보장할 수 없습니다** — 확인이 필요하면 소스를 검토하세요
-- **버그 리포트와 PR을 환영합니다** — Claude Code가 이를 처리하는 데 사용될 것입니다
-- **이것은 AI가 작성한 오픈소스 소프트웨어의 실제 사례입니다** — Claude Code가 무엇을 구축할 수 있는지의 참조로 사용하세요
+- **인간 저자는 코드 수준의 정확성을 보장할 수 없음** — 확신이 필요하면 소스를 검토하세요
+- **버그 보고와 PR을 환영합니다** — Claude Code가 이것들도 처리하는 데 사용될 가능성이 높습니다
+- **이것은 AI가 저술한 오픈소스 소프트웨어의 실제 예시** — Claude Code가 무엇을 만들 수 있는지의 참고 자료로 사용하세요
 
-이 프로젝트는 2026-02-18에 시작되어 Claude Code와의 반복적인 대화를 통해 계속 발전하고 있습니다.
+이 프로젝트는 2026-02-18에 시작되었으며 Claude Code와의 반복적인 대화를 통해 계속 발전하고 있습니다.
 
 ## 실제 사례
 
-**[EbiBot](https://github.com/ebibibi/discord-bot)** — claude-code-discord-bridge를 패키지 의존성으로 사용하는 개인 Discord Bot. 자동 문서 동기화 (영어 + 일본어), 푸시 알림, Todoist 감시, GitHub Actions CI/CD 통합을 포함합니다.
+**[EbiBot](https://github.com/ebibibi/discord-bot)** — claude-code-discord-bridge를 패키지 의존성으로 사용하는 개인 Discord Bot. 자동 문서 동기화 (영어 + 일본어), 푸시 알림, Todoist 감시견, GitHub Actions와의 CI/CD 통합을 포함합니다. 이 프레임워크 위에 자신의 Bot을 구축하는 참고 자료로 활용하세요.
+
+## 영감을 준 프로젝트
+
+- [OpenClaw](https://github.com/openclaw/openclaw) — 이모지 상태 반응, 메시지 디바운싱, 펜스 인식 청킹
+- [claude-code-discord-bot](https://github.com/timoconnellaus/claude-code-discord-bot) — CLI 생성 + stream-json 접근
+- [claude-code-discord](https://github.com/zebbern/claude-code-discord) — 권한 제어 패턴
+- [claude-sandbox-bot](https://github.com/RhysSullivan/claude-sandbox-bot) — 대화별 스레드 모델
 
 ## 라이선스
 

--- a/docs/pt-BR/README.md
+++ b/docs/pt-BR/README.md
@@ -9,31 +9,31 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Conecte [Claude Code](https://docs.anthropic.com/en/docs/claude-code) ao Discord e GitHub. Um framework que faz a ponte entre Claude Code CLI e Discord para **chat interativo, automação CI/CD e integração com fluxos de trabalho do GitHub**.
+Conecta o [Claude Code](https://docs.anthropic.com/en/docs/claude-code) ao Discord e GitHub. Um framework que une o Claude Code CLI com o Discord para **chat interativo, automação CI/CD e integração com fluxos de trabalho do GitHub**.
 
-Claude Code é ótimo no terminal — mas pode fazer muito mais. Esta ponte permite **usar Claude Code no seu fluxo de desenvolvimento com GitHub**: sincronizar documentação automaticamente, revisar e mesclar PRs, e executar qualquer tarefa do Claude Code acionada pelo GitHub Actions. Tudo usando Discord como a cola universal.
+O Claude Code é ótimo no terminal — mas pode fazer muito mais. Esta ponte permite que você **use o Claude Code no seu fluxo de desenvolvimento com GitHub**: sincronize documentação automaticamente, revise e mescle PRs, e execute qualquer tarefa do Claude Code acionada pelo GitHub Actions. Tudo através do Discord como cola universal.
 
 **[English](../../README.md)** | **[日本語](../ja/README.md)** | **[简体中文](../zh-CN/README.md)** | **[한국어](../ko/README.md)** | **[Español](../es/README.md)** | **[Français](../fr/README.md)**
 
-> **Aviso:** Este projeto não é afiliado, endossado ou oficialmente conectado à Anthropic. "Claude" e "Claude Code" são marcas registradas da Anthropic, PBC. Esta é uma ferramenta open source independente que interage com o Claude Code CLI.
+> **Aviso:** Este projeto não é afiliado, endossado ou oficialmente conectado à Anthropic. "Claude" e "Claude Code" são marcas registradas da Anthropic, PBC. Esta é uma ferramenta de código aberto independente que se integra ao Claude Code CLI.
 
-> **Construído inteiramente pelo Claude Code.** Este projeto foi projetado, implementado, testado e documentado pelo próprio Claude Code — o agente de codificação com IA da Anthropic. O autor humano não leu o código fonte. Veja [Como este projeto foi construído](#como-este-projeto-foi-construído) para detalhes.
+> **Construído inteiramente pelo Claude Code.** Este projeto foi projetado, implementado, testado e documentado pelo próprio Claude Code — o agente de codificação de IA da Anthropic. O autor humano não leu o código-fonte. Veja [Como este projeto foi construído](#como-este-projeto-foi-construído) para detalhes.
 
 ## Duas formas de usar
 
 ### 1. Chat interativo (Mobile / Desktop)
 
-Use Claude Code do seu celular ou qualquer dispositivo com Discord. Cada conversa se torna uma thread com persistência completa de sessão.
+Use o Claude Code pelo celular ou qualquer dispositivo com Discord. Cada conversa vira um thread com persistência de sessão completa.
 
 ```
 Você (Discord)  →  Bridge  →  Claude Code CLI
-      ↑                               ↓
-      ←──── saída stream-json ────────←
+      ↑                              ↓
+      ←──── saída stream-json ───────←
 ```
 
 ### 2. Automação CI/CD (GitHub → Discord → Claude Code → GitHub)
 
-Acione tarefas do Claude Code a partir do GitHub Actions via webhooks do Discord. Claude Code roda autonomamente — lendo código, atualizando docs, criando PRs e habilitando auto-merge.
+Acione tarefas do Claude Code a partir do GitHub Actions via webhooks do Discord. O Claude Code executa de forma autônoma — lendo código, atualizando docs, criando PRs e habilitando mesclagem automática.
 
 ```
 GitHub Actions  →  Discord Webhook  →  Bridge  →  Claude Code CLI
@@ -41,31 +41,60 @@ GitHub Actions  →  Discord Webhook  →  Bridge  →  Claude Code CLI
 GitHub PR (auto-merge)  ←  git push  ←  Claude Code  ←──┘
 ```
 
-**Exemplo real:** A cada push para main, Claude Code analisa automaticamente as mudanças, atualiza documentação em inglês e japonês, cria um PR com resumo bilíngue e habilita auto-merge. Sem intervenção humana.
+**Exemplo real:** A cada push para main, o Claude Code analisa automaticamente as mudanças, atualiza a documentação em inglês e japonês, cria um PR com resumo bilíngue e habilita mesclagem automática. Sem intervenção humana.
 
 ## Funcionalidades
 
 ### Chat interativo
-- **Thread = Session** — Cada tarefa tem sua própria thread no Discord, mapeada 1:1 para uma sessão do Claude Code
-- **Status em tempo real** — Reações emoji mostram o que Claude está fazendo (🧠 pensando, 🛠️ lendo arquivos, 💻 editando, 🌐 pesquisa web)
-- **Texto em streaming** — Texto intermediário aparece enquanto Claude trabalha
-- **Exibição de resultados de ferramentas** — Resultados mostrados como embeds em tempo real
-- **Pensamento estendido** — O raciocínio de Claude aparece em embeds com spoiler (clique para revelar)
-- **Persistência de sessão** — Continue conversas entre mensagens via `--resume`
-- **Execução de skills** — Execute skills do Claude Code (`/skill goodmorning`) via comandos slash com autocomplete
-- **Sessões concorrentes** — Execute múltiplas sessões em paralelo (limite configurável)
+- **Thread = Session** — Cada tarefa tem seu próprio thread do Discord, mapeado 1:1 para uma sessão do Claude Code
+- **Status em tempo real** — Reações com emoji mostram o que o Claude está fazendo (🧠 pensando, 🛠️ lendo arquivos, 💻 editando, 🌐 pesquisa web)
+- **Texto em streaming** — Texto intermediário aparece enquanto o Claude trabalha, não apenas no final
+- **Exibição de resultados de ferramentas** — Resultados do uso de ferramentas mostrados como embeds em tempo real
+- **Temporização de ferramentas ao vivo** — Embeds de ferramentas em progresso atualizam o tempo decorrido a cada 10s para comandos de longa duração (autenticação, builds), para que você sempre saiba que o Claude ainda está trabalhando
+- **Pensamento estendido** — O raciocínio do Claude aparece como embeds com tag spoiler (clique para revelar)
+- **Persistência de sessão** — Continue conversas entre mensagens com `--resume`
+- **Execução de skills** — Execute skills do Claude Code com `/skill` com autocompletar, argumentos opcionais e retomada em thread
+- **Sessões simultâneas** — Execute múltiplas sessões em paralelo (limite configurável)
+- **Parar sem limpar** — `/stop` interrompe uma sessão em execução preservando-a para retomada
+- **Suporte a anexos** — Anexos de texto são adicionados automaticamente ao prompt (até 5 arquivos, 50 KB cada)
+- **Notificações de timeout** — Embed dedicado com segundos decorridos e orientações quando uma sessão expira
+- **Perguntas interativas** — Quando o Claude chama `AskUserQuestion`, o bot renderiza Botões do Discord ou um Select Menu e retoma a sessão com sua resposta
+- **Painel de status da sessão** — Um embed fixado ao vivo no canal principal mostra quais threads estão processando vs. aguardando entrada; o proprietário é @mencionado quando o Claude precisa de uma resposta
+- **Coordenação multissessão** — Com `COORDINATION_CHANNEL_ID` configurado, cada sessão transmite eventos de início/fim para um canal compartilhado para que sessões simultâneas se mantenham cientes umas das outras
+
+### Tarefas agendadas (SchedulerCog)
+- **Tarefas periódicas do Claude Code** — Registre tarefas via chat do Discord ou API REST; são executadas em um intervalo configurável
+- **Baseado em SQLite** — Tarefas persistem entre reinicializações; gerenciadas via endpoints `/api/tasks`
+- **Agendamento sem código** — O Claude Code pode auto-registrar novas tarefas com a ferramenta Bash durante uma sessão; sem reinicializações do bot ou mudanças de código
+- **Loop mestre único** — Um loop `discord.ext.tasks` de 30 segundos despacha todas as tarefas, mantendo baixa a sobrecarga
 
 ### Automação CI/CD
-- **Gatilhos webhook** — Acione tarefas do Claude Code a partir do GitHub Actions ou qualquer sistema CI/CD
-- **Auto-atualização** — Atualize automaticamente o bot quando pacotes upstream são publicados
-- **REST API** — Notificações push para Discord de ferramentas externas (opcional, requer aiohttp)
+- **Gatilhos de webhook** — Acione tarefas do Claude Code pelo GitHub Actions ou qualquer sistema CI/CD
+- **Atualização automática** — Atualize automaticamente o bot quando pacotes upstream são lançados
+- **API REST** — Envie notificações e gerencie tarefas agendadas de ferramentas externas (opcional, requer aiohttp)
 
 ### Segurança
 - **Sem injeção de shell** — Apenas `asyncio.create_subprocess_exec`, nunca `shell=True`
-- **Validação de ID de sessão** — Regex estrito antes de passar para `--resume`
+- **Validação de ID de sessão** — Regex estrita antes de passar para `--resume`
 - **Prevenção de injeção de flags** — Separador `--` antes de todos os prompts
 - **Isolamento de segredos** — Token do bot e segredos removidos do ambiente do subprocesso
-- **Autorização de usuário** — `allowed_user_ids` restringe quem pode invocar Claude
+- **Autorização de usuários** — `allowed_user_ids` restringe quem pode invocar o Claude
+
+## Skills
+
+Execute [skills do Claude Code](https://docs.anthropic.com/en/docs/claude-code) diretamente do Discord via o comando de barra `/skill`.
+
+```
+/skill name:goodmorning                      → executa /goodmorning
+/skill name:todoist args:filter "today"      → executa /todoist filter "today"
+/skills                                      → lista todas as skills disponíveis
+```
+
+**Funcionalidades:**
+- **Autocompletar** — Digite para filtrar; nomes e descrições são pesquisáveis
+- **Argumentos** — Passe argumentos adicionais via o parâmetro `args`
+- **Retomada em thread** — Use `/skill` dentro de um thread Claude existente para executar a skill na sessão atual em vez de criar um novo thread
+- **Recarga automática** — Novas skills adicionadas a `~/.claude/skills/` são detectadas automaticamente (intervalo de atualização de 60s, sem reinicialização necessária)
 
 ## Início rápido
 
@@ -73,10 +102,10 @@ GitHub PR (auto-merge)  ←  git push  ←  Claude Code  ←──┘
 
 - Python 3.10+
 - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) instalado e autenticado
-- Token de bot Discord com Message Content intent habilitado
+- Token de bot do Discord com Message Content intent habilitado
 - [uv](https://docs.astral.sh/uv/) (recomendado) ou pip
 
-### Execução independente
+### Executar de forma independente
 
 ```bash
 git clone https://github.com/ebibibi/claude-code-discord-bridge.git
@@ -90,30 +119,360 @@ uv run python -m claude_discord.main
 
 ### Instalar como pacote
 
-Se você já tem um bot discord.py rodando (Discord permite apenas uma conexão Gateway por token):
+Se você já tem um bot discord.py rodando (o Discord permite apenas uma conexão Gateway por token):
 
 ```bash
 uv add git+https://github.com/ebibibi/claude-code-discord-bridge.git
 ```
 
 ```python
+from claude_discord import ClaudeRunner, setup_bridge
+
+runner = ClaudeRunner(command="claude", model="sonnet")
+
+# Uma chamada registra todos os Cogs — novos recursos são incluídos automaticamente
+await setup_bridge(
+    bot,
+    runner,
+    session_db_path="data/sessions.db",
+    claude_channel_id=YOUR_CHANNEL_ID,
+    allowed_user_ids={YOUR_USER_ID},
+)
+```
+
+`setup_bridge()` conecta automaticamente `ClaudeChatCog`, `SkillCommandCog`, `SessionManageCog` e `SchedulerCog`. Quando novos Cogs são adicionados ao ccdb, aparecem automaticamente — sem mudanças de código no consumidor.
+
+<details>
+<summary>Conexão manual (avançado)</summary>
+
+```python
 from claude_discord import ClaudeChatCog, ClaudeRunner, SessionRepository
 from claude_discord.database.models import init_db
 
-# Inicializar
 await init_db("data/sessions.db")
 repo = SessionRepository("data/sessions.db")
 runner = ClaudeRunner(command="claude", model="sonnet")
 
-# Adicionar ao bot existente
 await bot.add_cog(ClaudeChatCog(bot, repo, runner))
 ```
+</details>
 
-Atualizar para a última versão:
+Atualizar para a versão mais recente:
 
 ```bash
 uv lock --upgrade-package claude-code-discord-bridge && uv sync
 ```
+
+## Configuração
+
+| Variável | Descrição | Padrão |
+|----------|-----------|--------|
+| `DISCORD_BOT_TOKEN` | Token do bot do Discord | (obrigatório) |
+| `DISCORD_CHANNEL_ID` | ID do canal para chat do Claude | (obrigatório) |
+| `CLAUDE_COMMAND` | Caminho para o Claude Code CLI | `claude` |
+| `CLAUDE_MODEL` | Modelo a usar | `sonnet` |
+| `CLAUDE_PERMISSION_MODE` | Modo de permissão para CLI | `acceptEdits` |
+| `CLAUDE_WORKING_DIR` | Diretório de trabalho para Claude | diretório atual |
+| `MAX_CONCURRENT_SESSIONS` | Máximo de sessões paralelas | `3` |
+| `SESSION_TIMEOUT_SECONDS` | Timeout de inatividade de sessão | `300` |
+| `DISCORD_OWNER_ID` | ID de usuário do Discord para @menção quando Claude precisa de entrada | (opcional) |
+| `COORDINATION_CHANNEL_ID` | ID do canal para broadcasts de coordenação multissessão | (opcional) |
+
+## Configuração do bot do Discord
+
+1. Crie um novo aplicativo no [Portal do desenvolvedor Discord](https://discord.com/developers/applications)
+2. Crie um bot e copie o token
+3. Habilite **Message Content Intent** em Privileged Gateway Intents
+4. Convide o bot para seu servidor com estas permissões:
+   - Send Messages
+   - Create Public Threads
+   - Send Messages in Threads
+   - Add Reactions
+   - Manage Messages (para limpeza de reações)
+   - Read Message History
+
+## Automação GitHub + Claude Code
+
+O sistema de gatilhos de webhook permite criar fluxos de trabalho CI/CD totalmente autônomos onde o Claude Code age como um agente inteligente — não apenas executando scripts, mas entendendo mudanças de código e tomando decisões.
+
+### Exemplo: Sincronização automática de documentação
+
+A cada push para main, o Claude Code:
+1. Busca as últimas mudanças e analisa o diff
+2. Atualiza a documentação em inglês se o código-fonte mudou
+3. Traduz para japonês (ou qualquer idioma alvo)
+4. Cria um PR com resumo bilíngue
+5. Habilita mesclagem automática — PR mescla automaticamente quando CI passa
+
+**Fluxo de trabalho do GitHub Actions:**
+
+```yaml
+# .github/workflows/docs-sync.yml
+name: Documentation Sync
+on:
+  push:
+    branches: [main]
+jobs:
+  trigger:
+    # Ignora commits do próprio docs-sync (prevenção de loop infinito)
+    if: "!contains(github.event.head_commit.message, '[docs-sync]')"
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -X POST "${{ secrets.DISCORD_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -d '{"content": "🔄 docs-sync"}'
+```
+
+**Configuração do bot:**
+
+```python
+from claude_discord import WebhookTriggerCog, WebhookTrigger, ClaudeRunner
+
+runner = ClaudeRunner(command="claude", model="sonnet")
+
+triggers = {
+    "🔄 docs-sync": WebhookTrigger(
+        prompt="Analise mudanças, atualize docs, crie um PR com resumo bilíngue, habilite auto-merge.",
+        working_dir="/home/user/my-project",
+        timeout=600,
+    ),
+    "🚀 deploy": WebhookTrigger(
+        prompt="Faça deploy para o ambiente de staging.",
+        timeout=300,
+    ),
+}
+
+await bot.add_cog(WebhookTriggerCog(
+    bot=bot,
+    runner=runner,
+    triggers=triggers,
+    channel_ids={YOUR_CHANNEL_ID},
+))
+```
+
+**Segurança:** Apenas mensagens de webhook são processadas. `allowed_webhook_ids` opcional para controle mais rigoroso. Prompts são definidos no lado do servidor — webhooks apenas selecionam qual gatilho disparar.
+
+### Exemplo: Auto-aprovação de PRs do proprietário
+
+Aprove e mescle automaticamente seus próprios PRs após CI passar:
+
+```yaml
+# .github/workflows/auto-approve.yml
+name: Auto Approve Owner PRs
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  auto-approve:
+    if: github.event.pull_request.user.login == 'your-username'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --approve
+          gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --squash
+```
+
+## Tarefas agendadas
+
+`SchedulerCog` executa tarefas periódicas do Claude Code armazenadas no SQLite. As tarefas são registradas em tempo de execução via API REST — sem mudanças de código ou reinicializações do bot.
+
+### Registrar uma tarefa (via API REST)
+
+```bash
+curl -X POST http://localhost:8080/api/tasks \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer your-secret-token" \
+  -d '{
+    "name": "daily-standup",
+    "prompt": "Verifique issues abertas do GitHub e publique um breve resumo no Discord.",
+    "interval_seconds": 86400,
+    "channel_id": 123456789
+  }'
+```
+
+### Registrar uma tarefa (Claude auto-registra durante uma sessão)
+
+O Claude Code pode registrar suas próprias tarefas recorrentes usando a ferramenta Bash — sem configuração manual:
+
+```
+# Dentro de uma sessão do Claude Code, o Claude executa:
+curl -X POST $CCDB_API_URL/api/tasks \
+  -H "Content-Type: application/json" \
+  -d '{"name": "health-check", "prompt": "Execute o conjunto de testes e informe os resultados.", "interval_seconds": 3600}'
+```
+
+`CCDB_API_URL` é injetado automaticamente no ambiente do subprocesso do Claude quando `api_port` está configurado no `ClaudeRunner`.
+
+## Atualização automática
+
+Atualize automaticamente o bot quando um pacote upstream é lançado.
+
+```python
+from claude_discord import AutoUpgradeCog, UpgradeConfig
+
+config = UpgradeConfig(
+    package_name="claude-code-discord-bridge",
+    trigger_prefix="🔄 bot-upgrade",
+    working_dir="/home/user/my-bot",
+    restart_command=["sudo", "systemctl", "restart", "my-bot.service"],
+)
+
+await bot.add_cog(AutoUpgradeCog(bot, config))
+```
+
+**Pipeline:** Push upstream → CI webhook → `🔄 bot-upgrade` → `uv lock --upgrade-package` → `uv sync` → reinicialização do serviço.
+
+### Drenagem elegante (DrainAware)
+
+Antes de reiniciar, AutoUpgradeCog espera todas as sessões ativas terminarem. Qualquer Cog que implemente uma propriedade `active_count` (satisfazendo o protocolo `DrainAware`) é descoberto automaticamente — sem necessidade de lambda `drain_check` manual.
+
+Cogs DrainAware embutidos: `ClaudeChatCog`, `WebhookTriggerCog`.
+
+Para tornar seu próprio Cog compatível com drenagem, basta adicionar uma propriedade `active_count`:
+
+```python
+class MyCog(commands.Cog):
+    @property
+    def active_count(self) -> int:
+        return len(self._running_tasks)
+```
+
+Você ainda pode passar um callable `drain_check` explícito para sobrescrever o autodescoberta.
+
+### Aprovação de reinicialização
+
+Para cenários de auto-atualização (ex. atualizar o bot a partir de sua própria sessão do Discord), habilite `restart_approval` para evitar reinicializações automáticas:
+
+```python
+config = UpgradeConfig(
+    package_name="claude-code-discord-bridge",
+    trigger_prefix="🔄 bot-upgrade",
+    working_dir="/home/user/my-bot",
+    restart_command=["sudo", "systemctl", "restart", "my-bot.service"],
+    restart_approval=True,
+)
+```
+
+Com `restart_approval=True`, após atualizar o pacote o bot publica uma mensagem pedindo aprovação. Reaja com ✅ para acionar o reinício. O bot envia lembretes periódicos até aprovação.
+
+## API REST
+
+API REST opcional para enviar notificações ao Discord de ferramentas externas. Requer aiohttp:
+
+```bash
+uv add "claude-code-discord-bridge[api]"
+```
+
+```python
+from claude_discord import NotificationRepository
+from claude_discord.ext.api_server import ApiServer
+
+repo = NotificationRepository("data/notifications.db")
+await repo.init_db()
+
+api = ApiServer(
+    repo=repo,
+    bot=bot,
+    default_channel_id=YOUR_CHANNEL_ID,
+    host="127.0.0.1",
+    port=8080,
+    api_secret="your-secret-token",  # Autenticação Bearer opcional
+)
+await api.start()
+```
+
+### Endpoints
+
+**Notificações**
+
+| Método | Caminho | Descrição |
+|--------|---------|-----------|
+| GET | `/api/health` | Verificação de integridade |
+| POST | `/api/notify` | Enviar notificação imediata |
+| POST | `/api/schedule` | Agendar notificação para mais tarde |
+| GET | `/api/scheduled` | Listar notificações pendentes |
+| DELETE | `/api/scheduled/{id}` | Cancelar uma notificação agendada |
+
+**Tarefas agendadas** (requer `SchedulerCog`)
+
+| Método | Caminho | Descrição |
+|--------|---------|-----------|
+| POST | `/api/tasks` | Registrar uma nova tarefa periódica do Claude Code |
+| GET | `/api/tasks` | Listar todas as tarefas registradas |
+| DELETE | `/api/tasks/{id}` | Remover uma tarefa agendada |
+| PATCH | `/api/tasks/{id}` | Atualizar tarefa (habilitar/desabilitar, prompt, intervalo) |
+
+### Exemplos
+
+```bash
+# Verificação de integridade
+curl http://localhost:8080/api/health
+
+# Enviar notificação
+curl -X POST http://localhost:8080/api/notify \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer your-secret-token" \
+  -d '{"message": "Build bem-sucedido!", "title": "CI/CD"}'
+
+# Agendar notificação
+curl -X POST http://localhost:8080/api/schedule \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Hora de revisar os PRs", "scheduled_at": "2026-01-01T09:00:00"}'
+```
+
+## Arquitetura
+
+```
+claude_discord/
+  main.py                  # Ponto de entrada independente
+  bot.py                   # Classe Discord Bot
+  setup.py                 # setup_bridge() — fábrica de chamada única para todos os Cogs
+  cogs/
+    claude_chat.py         # Chat interativo (criação de threads, tratamento de mensagens)
+    skill_command.py       # Comando de barra /skill com autocompletar
+    webhook_trigger.py     # Webhook → execução de tarefa Claude Code (CI/CD)
+    auto_upgrade.py        # Webhook → atualização de pacote + reinicialização
+    scheduler.py           # Tarefas periódicas Claude Code (baseado em SQLite, loop mestre de 30s)
+    _run_helper.py         # Lógica de execução compartilhada do Claude CLI
+  claude/
+    runner.py              # Gerenciador de subprocesso Claude CLI
+    parser.py              # Parser de eventos stream-json
+    types.py               # Definições de tipo para mensagens SDK
+  database/
+    models.py              # Esquema SQLite
+    repository.py          # Operações CRUD de sessões
+    ask_repo.py            # CRUD de AskUserQuestion pendentes (recuperação após reinicialização)
+    notification_repo.py   # CRUD de notificações agendadas
+    task_repo.py           # CRUD de tarefas agendadas (SchedulerCog)
+  coordination/
+    service.py             # CoordinationService — publica eventos de ciclo de vida de sessão em canal compartilhado
+  discord_ui/
+    status.py              # Gerenciador de status de reações emoji (com debounce)
+    chunker.py             # Divisão de mensagens com consciência de blocos de código e tabelas
+    embeds.py              # Construtores de embeds do Discord
+    ask_view.py            # Botões do Discord/Select Menus para AskUserQuestion
+    ask_bus.py             # Roteamento de bus para botões AskView persistentes (sobrevive reinicializações)
+    thread_dashboard.py    # Embed fixado ao vivo mostrando estados de sessão por thread
+  ext/
+    api_server.py          # Servidor API REST (opcional, requer aiohttp)
+                           # Inclui endpoints /api/tasks para SchedulerCog
+  utils/
+    logger.py              # Configuração de logging
+```
+
+### Filosofia de design
+
+- **Spawn de CLI, não API** — Invocamos `claude -p --output-format stream-json`, obtendo todos os recursos do Claude Code (CLAUDE.md, skills, ferramentas, memória) gratuitamente
+- **Discord como cola** — Discord fornece a interface, threading, notificações e infraestrutura de webhooks
+- **Framework, não aplicação** — Instale como pacote, adicione Cogs ao seu bot existente, configure via código
+- **Segurança pela simplicidade** — ~2500 linhas de Python auditável, sem execução de shell, sem caminhos de código arbitrários
 
 ## Testes
 
@@ -121,24 +480,31 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-131 testes cobrindo parser, chunker, repositório, runner, streaming, webhook triggers, auto-upgrade e REST API.
+473 testes cobrindo parser, chunker, repositório, runner, streaming, webhook triggers, auto-upgrade, API REST, UI do AskUserQuestion, painel de status de threads, SchedulerCog e repositório de tarefas.
 
 ## Como este projeto foi construído
 
-**Todo o código foi escrito pelo [Claude Code](https://docs.anthropic.com/en/docs/claude-code)** — o agente de codificação com IA da Anthropic. O autor humano ([@ebibibi](https://github.com/ebibibi)) forneceu requisitos e direção em linguagem natural, mas não leu ou editou manualmente o código fonte.
+**Todo este código foi escrito pelo [Claude Code](https://docs.anthropic.com/en/docs/claude-code)**, o agente de codificação de IA da Anthropic. O autor humano ([@ebibibi](https://github.com/ebibibi)) forneceu requisitos e direção em linguagem natural, mas não leu ou editou manualmente o código-fonte.
 
 Isso significa:
 
 - **Todo o código foi gerado por IA** — arquitetura, implementação, testes, documentação
-- **O autor humano não pode garantir correção no nível do código** — revise o fonte se precisar de certeza
-- **Relatórios de bugs e PRs são bem-vindos** — Claude Code provavelmente será usado para resolvê-los
-- **Este é um exemplo real de software open source escrito por IA** — use como referência do que Claude Code pode construir
+- **O autor humano não pode garantir a correção no nível de código** — revise o código-fonte se precisar de certeza
+- **Relatórios de bugs e PRs são bem-vindos** — Claude Code provavelmente será usado para abordá-los também
+- **Este é um exemplo real de software open source de autoria de IA** — use como referência do que o Claude Code pode construir
 
-O projeto começou em 2026-02-18 e continua evoluindo através de conversas iterativas com Claude Code.
+O projeto começou em 2026-02-18 e continua evoluindo através de conversas iterativas com o Claude Code.
 
-## Exemplo real
+## Exemplo do mundo real
 
-**[EbiBot](https://github.com/ebibibi/discord-bot)** — Um bot pessoal do Discord que usa claude-code-discord-bridge como dependência. Inclui sincronização automática de documentação (inglês + japonês), notificações push, watchdog do Todoist e integração CI/CD com GitHub Actions.
+**[EbiBot](https://github.com/ebibibi/discord-bot)** — Um bot Discord pessoal que usa claude-code-discord-bridge como dependência de pacote. Inclui sincronização automática de documentação (inglês + japonês), notificações push, watchdog do Todoist e integração CI/CD com GitHub Actions. Use como referência para construir seu próprio bot sobre este framework.
+
+## Inspirado em
+
+- [OpenClaw](https://github.com/openclaw/openclaw) — Reações de status com emoji, debouncing de mensagens, chunking com consciência de blocos de código
+- [claude-code-discord-bot](https://github.com/timoconnellaus/claude-code-discord-bot) — Abordagem CLI spawn + stream-json
+- [claude-code-discord](https://github.com/zebbern/claude-code-discord) — Padrões de controle de permissão
+- [claude-sandbox-bot](https://github.com/RhysSullivan/claude-sandbox-bot) — Modelo de thread por conversa
 
 ## Licença
 

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -1,7 +1,7 @@
 > **Note:** This is an auto-translated version of the original English documentation.
 > If there are any discrepancies, the [English version](../../README.md) takes precedence.
-> **注意：** 这是原始英文文档的自动翻译版本。
-> 如有任何差异，以[英文版](../../README.md)为准。
+> **注意：** 这是英文原版文档的自动翻译版本。
+> 如有差异，以[英文版](../../README.md)为准。
 
 # claude-code-discord-bridge
 
@@ -9,31 +9,31 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-将 [Claude Code](https://docs.anthropic.com/en/docs/claude-code) 连接到 Discord 和 GitHub。一个将 Claude Code CLI 与 Discord 桥接的框架，用于**交互式聊天、CI/CD 自动化和 GitHub 工作流集成**。
+将 [Claude Code](https://docs.anthropic.com/en/docs/claude-code) 连接到 Discord 和 GitHub。这是一个将 Claude Code CLI 与 Discord 桥接的框架，用于**交互式聊天、CI/CD 自动化和 GitHub 工作流集成**。
 
-Claude Code 在终端中表现出色 - 但它能做的远不止这些。这个桥接器让你可以**在 GitHub 开发工作流中使用 Claude Code**：自动同步文档、审查和合并 PR、通过 GitHub Actions 触发任何 Claude Code 任务。所有这一切都通过 Discord 作为通用粘合剂来实现。
+Claude Code 在终端中已经很强大，但它能做的远不止于此。通过这个桥接，你可以**在 GitHub 开发工作流中使用 Claude Code**：自动同步文档、审查和合并 PR、运行由 GitHub Actions 触发的任何 Claude Code 任务。Discord 作为通用粘合剂贯穿其中。
 
 **[English](../../README.md)** | **[日本語](../ja/README.md)** | **[한국어](../ko/README.md)** | **[Español](../es/README.md)** | **[Português](../pt-BR/README.md)** | **[Français](../fr/README.md)**
 
-> **免责声明：** 本项目与 Anthropic 无关，未获得 Anthropic 的认可或官方关联。"Claude"和"Claude Code"是 Anthropic, PBC 的商标。这是一个与 Claude Code CLI 交互的独立开源工具。
+> **免责声明：** 本项目与 Anthropic 无关，未经 Anthropic 背书或官方关联。"Claude"和"Claude Code"是 Anthropic, PBC 的商标。这是一个独立的开源工具，与 Claude Code CLI 交互。
 
-> **完全由 Claude Code 构建。** 本项目由 Anthropic 的 AI 编程代理 Claude Code 自行设计、实现、测试和编写文档。人类作者没有阅读过源代码。详见[本项目的构建方式](#本项目的构建方式)。
+> **完全由 Claude Code 构建。** 本项目由 Anthropic 的 AI 编码代理 Claude Code 本身设计、实现、测试和记录文档。人类作者未阅读源代码。详情请参阅[本项目的构建方式](#本项目的构建方式)。
 
 ## 两种使用方式
 
 ### 1. 交互式聊天（移动端 / 桌面端）
 
-通过手机或任何有 Discord 的设备使用 Claude Code。每个对话成为一个具有完整会话持久性的线程。
+通过手机或任何有 Discord 的设备使用 Claude Code。每次对话都会成为一个具有完整会话持久化的 Discord 线程。
 
 ```
 你 (Discord)  →  Bridge  →  Claude Code CLI
     ↑                              ↓
-    ←──── stream-json 输出 ───────←
+    ←──── stream-json 输出 ────────←
 ```
 
 ### 2. CI/CD 自动化（GitHub → Discord → Claude Code → GitHub）
 
-通过 Discord webhook 从 GitHub Actions 触发 Claude Code 任务。Claude Code 自主运行 - 读取代码、更新文档、创建 PR 并启用自动合并。
+通过 Discord webhook 从 GitHub Actions 触发 Claude Code 任务。Claude Code 自主运行——读取代码、更新文档、创建 PR 并启用自动合并。
 
 ```
 GitHub Actions  →  Discord Webhook  →  Bridge  →  Claude Code CLI
@@ -48,17 +48,30 @@ GitHub PR (自动合并)  ←  git push  ←  Claude Code  ←────┘
 ### 交互式聊天
 - **Thread = Session** — 每个任务有自己的 Discord 线程，与 Claude Code 会话 1:1 映射
 - **实时状态** — 表情符号反应显示 Claude 的状态（🧠 思考中、🛠️ 读取文件、💻 编辑中、🌐 网页搜索）
-- **流式文本** — Claude 工作时中间文本实时显示
+- **流式文本** — Claude 工作时中间文本实时显示，而非只在结束时显示
 - **工具结果显示** — 工具使用结果以 embed 形式实时显示
+- **实时工具计时** — 长时间运行的命令（如认证流程、构建）每 10 秒更新已用时间，让你随时知道 Claude 仍在工作
 - **扩展思考** — Claude 的推理以剧透标签 embed 显示（点击展开）
 - **会话持久化** — 通过 `--resume` 跨消息继续对话
-- **技能执行** — 通过斜杠命令和自动补全执行 Claude Code 技能（`/skill goodmorning`）
+- **技能执行** — 通过 `/skill` 斜杠命令执行 Claude Code 技能，支持自动补全、可选参数和线程内恢复
 - **并发会话** — 并行运行多个会话（可配置上限）
+- **停止而不清除** — `/stop` 暂停运行中的会话，同时保留以便后续恢复
+- **附件支持** — 文本类型文件附件自动附加到提示（最多 5 个文件，每个 50 KB）
+- **超时通知** — 会话超时时显示包含已用秒数和操作指南的专用 embed
+- **交互式问题** — 当 Claude 调用 `AskUserQuestion` 时，Bot 渲染 Discord 按钮或 Select Menu，并用你的回答恢复会话
+- **会话状态仪表盘** — 主频道中的 live 固定 embed 显示哪些线程正在处理 vs. 等待输入；当 Claude 需要回复时 @mention 所有者
+- **多会话协调** — 设置 `COORDINATION_CHANNEL_ID` 后，每个会话将开始/结束事件广播到共享频道，让并发会话互相感知
+
+### 定时任务（SchedulerCog）
+- **定期 Claude Code 任务** — 通过 Discord 聊天或 REST API 注册任务；按可配置的间隔运行
+- **SQLite 支持** — 任务在重启后持久保留；通过 `/api/tasks` 端点管理
+- **零代码调度** — Claude Code 可在会话中通过 Bash 工具自行注册新任务；无需重启 Bot 或更改代码
+- **单一主循环** — 一个 30 秒的 `discord.ext.tasks` 循环调度所有任务，保持低开销
 
 ### CI/CD 自动化
 - **Webhook 触发** — 从 GitHub Actions 或任何 CI/CD 系统触发 Claude Code 任务
 - **自动升级** — 上游包发布时自动更新 Bot
-- **REST API** — 从外部工具向 Discord 推送通知（可选，需要 aiohttp）
+- **REST API** — 从外部工具推送通知并管理定时任务（可选，需要 aiohttp）
 
 ### 安全性
 - **无 Shell 注入** — 仅使用 `asyncio.create_subprocess_exec`，从不使用 `shell=True`
@@ -66,6 +79,22 @@ GitHub PR (自动合并)  ←  git push  ←  Claude Code  ←────┘
 - **标志注入防护** — 所有提示前使用 `--` 分隔符
 - **密钥隔离** — Bot 令牌和密钥从子进程环境中移除
 - **用户授权** — `allowed_user_ids` 限制可调用 Claude 的用户
+
+## 技能
+
+通过 `/skill` 斜杠命令直接从 Discord 运行 [Claude Code 技能](https://docs.anthropic.com/en/docs/claude-code)。
+
+```
+/skill name:goodmorning                      → 运行 /goodmorning
+/skill name:todoist args:filter "today"      → 运行 /todoist filter "today"
+/skills                                      → 列出所有可用技能
+```
+
+**功能：**
+- **自动补全** — 输入以过滤；名称和描述均可搜索
+- **参数** — 通过 `args` 参数传递额外参数
+- **线程内恢复** — 在已有 Claude 线程中使用 `/skill` 可在当前会话中运行技能，而非创建新线程
+- **热重载** — 添加到 `~/.claude/skills/` 的新技能自动生效（60 秒刷新间隔，无需重启）
 
 ## 快速开始
 
@@ -97,17 +126,36 @@ uv add git+https://github.com/ebibibi/claude-code-discord-bridge.git
 ```
 
 ```python
+from claude_discord import ClaudeRunner, setup_bridge
+
+runner = ClaudeRunner(command="claude", model="sonnet")
+
+# 一次调用注册所有 Cog — 新功能自动包含
+await setup_bridge(
+    bot,
+    runner,
+    session_db_path="data/sessions.db",
+    claude_channel_id=YOUR_CHANNEL_ID,
+    allowed_user_ids={YOUR_USER_ID},
+)
+```
+
+`setup_bridge()` 自动接入 `ClaudeChatCog`、`SkillCommandCog`、`SessionManageCog` 和 `SchedulerCog`。向 ccdb 添加新 Cog 时会自动包含——无需更改消费者代码。
+
+<details>
+<summary>手动接入（高级用法）</summary>
+
+```python
 from claude_discord import ClaudeChatCog, ClaudeRunner, SessionRepository
 from claude_discord.database.models import init_db
 
-# 初始化
 await init_db("data/sessions.db")
 repo = SessionRepository("data/sessions.db")
 runner = ClaudeRunner(command="claude", model="sonnet")
 
-# 添加到现有 Bot
 await bot.add_cog(ClaudeChatCog(bot, repo, runner))
 ```
+</details>
 
 更新到最新版本：
 
@@ -127,6 +175,8 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `CLAUDE_WORKING_DIR` | Claude 的工作目录 | 当前目录 |
 | `MAX_CONCURRENT_SESSIONS` | 最大并发会话数 | `3` |
 | `SESSION_TIMEOUT_SECONDS` | 会话非活动超时 | `300` |
+| `DISCORD_OWNER_ID` | Claude 需要输入时 @mention 的 Discord 用户 ID | （可选） |
+| `COORDINATION_CHANNEL_ID` | 多会话协调广播的频道 ID | （可选） |
 
 ## Discord Bot 设置
 
@@ -141,30 +191,320 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
    - Manage Messages（用于清理反应）
    - Read Message History
 
+## GitHub + Claude Code 自动化
+
+Webhook 触发系统让你能构建完全自主的 CI/CD 工作流，其中 Claude Code 作为智能代理运行——不只是执行脚本，而是理解代码变更并做出决策。
+
+### 示例：自动文档同步
+
+每次推送到 main，Claude Code：
+1. 拉取最新变更并分析 diff
+2. 如果源代码变更，更新英文文档
+3. 翻译到日文（或任何目标语言）
+4. 创建双语摘要的 PR
+5. 启用自动合并——CI 通过后 PR 自动合并
+
+**GitHub Actions 工作流：**
+
+```yaml
+# .github/workflows/docs-sync.yml
+name: Documentation Sync
+on:
+  push:
+    branches: [main]
+jobs:
+  trigger:
+    # 跳过 docs-sync 自身的提交（防止无限循环）
+    if: "!contains(github.event.head_commit.message, '[docs-sync]')"
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -X POST "${{ secrets.DISCORD_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -d '{"content": "🔄 docs-sync"}'
+```
+
+**Bot 配置：**
+
+```python
+from claude_discord import WebhookTriggerCog, WebhookTrigger, ClaudeRunner
+
+runner = ClaudeRunner(command="claude", model="sonnet")
+
+triggers = {
+    "🔄 docs-sync": WebhookTrigger(
+        prompt="分析变更，更新文档，创建双语摘要的 PR，启用自动合并。",
+        working_dir="/home/user/my-project",
+        timeout=600,
+    ),
+    "🚀 deploy": WebhookTrigger(
+        prompt="部署到预发布环境。",
+        timeout=300,
+    ),
+}
+
+await bot.add_cog(WebhookTriggerCog(
+    bot=bot,
+    runner=runner,
+    triggers=triggers,
+    channel_ids={YOUR_CHANNEL_ID},
+))
+```
+
+**安全性：** 仅处理 webhook 消息。可选 `allowed_webhook_ids` 实现更严格控制。提示在服务器端定义——webhook 只选择触发哪个触发器。
+
+### 示例：自动批准所有者 PR
+
+CI 通过后自动批准并自动合并自己的 PR：
+
+```yaml
+# .github/workflows/auto-approve.yml
+name: Auto Approve Owner PRs
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  auto-approve:
+    if: github.event.pull_request.user.login == 'your-username'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --approve
+          gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --squash
+```
+
+## 定时任务
+
+`SchedulerCog` 运行存储在 SQLite 中的定期 Claude Code 任务。任务在运行时通过 REST API 注册——无需更改代码或重启 Bot。
+
+### 通过 REST API 注册任务
+
+```bash
+curl -X POST http://localhost:8080/api/tasks \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer your-secret-token" \
+  -d '{
+    "name": "daily-standup",
+    "prompt": "检查开放的 GitHub issue 并向 Discord 发布简要摘要。",
+    "interval_seconds": 86400,
+    "channel_id": 123456789
+  }'
+```
+
+### Claude 在会话中自行注册任务
+
+Claude Code 可以在会话中使用 Bash 工具注册自己的定期任务——无需人工接入：
+
+```
+# 在 Claude Code 会话内，Claude 运行：
+curl -X POST $CCDB_API_URL/api/tasks \
+  -H "Content-Type: application/json" \
+  -d '{"name": "health-check", "prompt": "运行测试套件并报告结果。", "interval_seconds": 3600}'
+```
+
+当 `ClaudeRunner` 设置了 `api_port` 时，`CCDB_API_URL` 会自动注入到 Claude 的子进程环境中。
+
+## 自动升级
+
+上游包发布时自动升级 Bot。
+
+```python
+from claude_discord import AutoUpgradeCog, UpgradeConfig
+
+config = UpgradeConfig(
+    package_name="claude-code-discord-bridge",
+    trigger_prefix="🔄 bot-upgrade",
+    working_dir="/home/user/my-bot",
+    restart_command=["sudo", "systemctl", "restart", "my-bot.service"],
+)
+
+await bot.add_cog(AutoUpgradeCog(bot, config))
+```
+
+**流程：** 上游推送 → CI webhook → `🔄 bot-upgrade` → `uv lock --upgrade-package` → `uv sync` → 服务重启。
+
+### 优雅排空（DrainAware）
+
+重启前，AutoUpgradeCog 等待所有活跃会话完成。任何实现了 `active_count` 属性（满足 `DrainAware` 协议）的 Cog 都会被自动发现——无需手动传入 `drain_check` lambda。
+
+内置 DrainAware Cog：`ClaudeChatCog`、`WebhookTriggerCog`。
+
+要让你自己的 Cog 支持排空，只需添加 `active_count` 属性：
+
+```python
+class MyCog(commands.Cog):
+    @property
+    def active_count(self) -> int:
+        return len(self._running_tasks)
+```
+
+你仍可传入显式的 `drain_check` 可调用对象来覆盖自动发现。
+
+### 重启批准
+
+对于自更新场景（如从 Bot 自身的 Discord 会话中更新），启用 `restart_approval` 可防止自动重启：
+
+```python
+config = UpgradeConfig(
+    package_name="claude-code-discord-bridge",
+    trigger_prefix="🔄 bot-upgrade",
+    working_dir="/home/user/my-bot",
+    restart_command=["sudo", "systemctl", "restart", "my-bot.service"],
+    restart_approval=True,
+)
+```
+
+启用 `restart_approval=True` 后，升级包后 Bot 会发布一条请求批准的消息。用 ✅ 反应触发重启。Bot 会定期发送提醒直到批准。
+
+## REST API
+
+用于从外部工具向 Discord 推送通知的可选 REST API。需要 aiohttp：
+
+```bash
+uv add "claude-code-discord-bridge[api]"
+```
+
+```python
+from claude_discord import NotificationRepository
+from claude_discord.ext.api_server import ApiServer
+
+repo = NotificationRepository("data/notifications.db")
+await repo.init_db()
+
+api = ApiServer(
+    repo=repo,
+    bot=bot,
+    default_channel_id=YOUR_CHANNEL_ID,
+    host="127.0.0.1",
+    port=8080,
+    api_secret="your-secret-token",  # 可选 Bearer 认证
+)
+await api.start()
+```
+
+### 端点
+
+**通知**
+
+| 方法 | 路径 | 描述 |
+|------|------|------|
+| GET | `/api/health` | 健康检查 |
+| POST | `/api/notify` | 发送即时通知 |
+| POST | `/api/schedule` | 安排稍后发送通知 |
+| GET | `/api/scheduled` | 列出待处理通知 |
+| DELETE | `/api/scheduled/{id}` | 取消定时通知 |
+
+**定时任务**（需要 `SchedulerCog`）
+
+| 方法 | 路径 | 描述 |
+|------|------|------|
+| POST | `/api/tasks` | 注册新的定期 Claude Code 任务 |
+| GET | `/api/tasks` | 列出所有已注册任务 |
+| DELETE | `/api/tasks/{id}` | 删除定时任务 |
+| PATCH | `/api/tasks/{id}` | 更新任务（启用/禁用、提示、间隔） |
+
+### 使用示例
+
+```bash
+# 健康检查
+curl http://localhost:8080/api/health
+
+# 发送通知
+curl -X POST http://localhost:8080/api/notify \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer your-secret-token" \
+  -d '{"message": "构建成功！", "title": "CI/CD"}'
+
+# 安排通知
+curl -X POST http://localhost:8080/api/schedule \
+  -H "Content-Type: application/json" \
+  -d '{"message": "是时候审查 PR 了", "scheduled_at": "2026-01-01T09:00:00"}'
+```
+
+## 架构
+
+```
+claude_discord/
+  main.py                  # 独立入口点
+  bot.py                   # Discord Bot 类
+  setup.py                 # setup_bridge() — 所有 Cog 的一键工厂
+  cogs/
+    claude_chat.py         # 交互式聊天（线程创建、消息处理）
+    skill_command.py       # /skill 斜杠命令（自动补全）
+    webhook_trigger.py     # Webhook → Claude Code 任务执行（CI/CD）
+    auto_upgrade.py        # Webhook → 包升级 + 重启
+    scheduler.py           # 定期 Claude Code 任务（SQLite 支持，30 秒主循环）
+    _run_helper.py         # 共享 Claude CLI 执行逻辑
+  claude/
+    runner.py              # Claude CLI 子进程管理器
+    parser.py              # stream-json 事件解析器
+    types.py               # SDK 消息类型定义
+  database/
+    models.py              # SQLite 模式
+    repository.py          # 会话 CRUD 操作
+    ask_repo.py            # 待处理 AskUserQuestion CRUD（重启恢复）
+    notification_repo.py   # 定时通知 CRUD
+    task_repo.py           # 定时任务 CRUD（SchedulerCog）
+  coordination/
+    service.py             # CoordinationService — 向共享频道发布会话生命周期事件
+  discord_ui/
+    status.py              # 表情符号反应状态管理器（防抖）
+    chunker.py             # 支持代码围栏和表格的消息分割
+    embeds.py              # Discord embed 构建器
+    ask_view.py            # AskUserQuestion 的 Discord 按钮/Select Menu
+    ask_bus.py             # 持久化 AskView 按钮的总线路由（重启后仍存活）
+    thread_dashboard.py    # 显示每个线程会话状态的 live 固定 embed
+  ext/
+    api_server.py          # REST API 服务器（可选，需要 aiohttp）
+                           # 包含 SchedulerCog 的 /api/tasks 端点
+  utils/
+    logger.py              # 日志配置
+```
+
+### 设计理念
+
+- **CLI 生成，而非 API** — 调用 `claude -p --output-format stream-json`，免费获得完整的 Claude Code 功能（CLAUDE.md、技能、工具、记忆）
+- **Discord 作为粘合剂** — Discord 提供 UI、线程、通知和 webhook 基础设施
+- **框架，而非应用** — 作为包安装，向现有 Bot 添加 Cog，通过代码配置
+- **简单即安全** — 约 2500 行可审计的 Python，无 Shell 执行，无任意代码路径
+
 ## 测试
 
 ```bash
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-131 个测试覆盖解析器、分块器、仓库、运行器、流式传输、webhook 触发、自动升级和 REST API。
+473 个测试覆盖解析器、分块器、仓库、运行器、流式传输、webhook 触发器、自动升级、REST API、AskUserQuestion UI、线程状态仪表盘、SchedulerCog 和任务仓库。
 
 ## 本项目的构建方式
 
-**整个代码库由 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)** — Anthropic 的 AI 编程代理编写。人类作者（[@ebibibi](https://github.com/ebibibi)）以自然语言提供需求和方向，但没有手动阅读或编辑源代码。
+**整个代码库由 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)**——Anthropic 的 AI 编码代理——编写。人类作者（[@ebibibi](https://github.com/ebibibi)）用自然语言提供了需求和方向，但未手动阅读或编辑源代码。
 
 这意味着：
 
-- **所有代码由 AI 生成** — 架构、实现、测试、文档
-- **人类作者无法保证代码级别的正确性** — 如需确认请查看源代码
+- **所有代码均由 AI 生成** — 架构、实现、测试、文档
+- **人类作者无法在代码层面保证正确性** — 如需确保请审查源代码
 - **欢迎 Bug 报告和 PR** — Claude Code 可能也会被用来处理它们
-- **这是 AI 编写的开源软件的真实案例** — 用作 Claude Code 能力的参考
+- **这是 AI 创作开源软件的实际案例** — 可作为 Claude Code 能构建什么的参考
 
-本项目始于 2026-02-18，通过与 Claude Code 的迭代对话持续演进。
+本项目于 2026-02-18 启动，并通过与 Claude Code 的迭代对话持续演进。
 
 ## 实际案例
 
-**[EbiBot](https://github.com/ebibibi/discord-bot)** — 使用 claude-code-discord-bridge 作为包依赖的个人 Discord Bot。包括自动文档同步（英文 + 日文）、推送通知、Todoist 看门狗和 GitHub Actions CI/CD 集成。
+**[EbiBot](https://github.com/ebibibi/discord-bot)** — 一个将 claude-code-discord-bridge 作为包依赖的个人 Discord Bot。包含自动文档同步（英文 + 日文）、推送通知、Todoist 看门狗和 GitHub Actions 的 CI/CD 集成。可作为在此框架上构建自己 Bot 的参考。
+
+## 灵感来源
+
+- [OpenClaw](https://github.com/openclaw/openclaw) — 表情符号状态反应、消息防抖、围栏感知分块
+- [claude-code-discord-bot](https://github.com/timoconnellaus/claude-code-discord-bot) — CLI 生成 + stream-json 方法
+- [claude-code-discord](https://github.com/zebbern/claude-code-discord) — 权限控制模式
+- [claude-sandbox-bot](https://github.com/RhysSullivan/claude-sandbox-bot) — 每对话一个线程模型
 
 ## 许可证
 


### PR DESCRIPTION
## Summary
- Updated English README with v1.2.0 features: `setup_bridge()` factory function, `SchedulerCog` periodic tasks section, `/api/tasks` REST endpoints, updated architecture tree, and corrected test count (400+ → 473)
- Fully rebuilt zh-CN, ko, es, pt-BR, and fr translations from scratch to match current README (they were 145–171 lines vs the 480-line English source)
- Updated Japanese translation with the same incremental additions

## 概要
- 英語 README に v1.2.0 の新機能を追記: `setup_bridge()` ファクトリ関数、`SchedulerCog` 定期タスクセクション、`/api/tasks` REST エンドポイント、アーキテクチャツリーの更新、テスト数の修正（400+ → 473）
- zh-CN・ko・es・pt-BR・fr の翻訳を現在の英語 README に合わせて完全再構築（旧版は 145–171 行で最新 480 行の英語版と大きく乖離していた）
- 日本語翻訳に同様の追記を適用

## Changed files
- `README.md`
- `docs/ja/README.md`
- `docs/zh-CN/README.md`
- `docs/ko/README.md`
- `docs/es/README.md`
- `docs/pt-BR/README.md`
- `docs/fr/README.md`

## Languages updated
ja, zh-CN, ko, es, pt-BR, fr

---
🤖 Auto-generated by [docs-sync](https://github.com/ebibibi/claude-code-discord-bridge)
