### PR TITLE
feat: auto-wire ApiServer repos in setup_bridge() — zero consumer changes needed

### DIFF
--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -117,9 +117,15 @@ class TestBuildEnv:
         assert env["CCDB_API_URL"] == "http://127.0.0.1:8099"
 
     def test_no_ccdb_api_url_when_api_port_not_set(self) -> None:
-        runner = ClaudeRunner()
-        env = runner._build_env()
-        assert "CCDB_API_URL" not in env
+        # Remove CCDB_API_URL from the process env so it isn't inherited
+        original = os.environ.pop("CCDB_API_URL", None)
+        try:
+            runner = ClaudeRunner()
+            env = runner._build_env()
+            assert "CCDB_API_URL" not in env
+        finally:
+            if original is not None:
+                os.environ["CCDB_API_URL"] = original
 
     def test_injects_ccdb_api_secret_when_set(self) -> None:
         runner = ClaudeRunner(api_port=8099, api_secret="my-secret")

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -114,3 +114,128 @@ async def test_setup_bridge_skips_skill_cog_without_channel_id(tmp_path: object)
 
     cog_names = [call.args[0].__class__.__name__ for call in bot.add_cog.call_args_list]
     assert "SkillCommandCog" not in cog_names
+
+
+# ---------------------------------------------------------------------------
+# apply_to_api_server()
+# ---------------------------------------------------------------------------
+
+
+def _make_api_server() -> MagicMock:
+    server = MagicMock()
+    server.task_repo = None
+    server.lounge_repo = None
+    server.port = 8099
+    return server
+
+
+def test_apply_to_api_server_wires_task_and_lounge_repos(tmp_path: object) -> None:
+    """apply_to_api_server should set task_repo and lounge_repo on the ApiServer."""
+    from claude_discord.database.lounge_repo import LoungeRepository
+    from claude_discord.database.repository import SessionRepository
+    from claude_discord.database.task_repo import TaskRepository
+
+    session_repo = MagicMock(spec=SessionRepository)
+    task_repo = MagicMock(spec=TaskRepository)
+    lounge_repo = MagicMock(spec=LoungeRepository)
+
+    components = BridgeComponents(
+        session_repo=session_repo,
+        task_repo=task_repo,
+        lounge_repo=lounge_repo,
+    )
+    api_server = _make_api_server()
+
+    components.apply_to_api_server(api_server)
+
+    assert api_server.task_repo is task_repo
+    assert api_server.lounge_repo is lounge_repo
+
+
+def test_apply_to_api_server_skips_none_repos() -> None:
+    """apply_to_api_server should not overwrite existing repos with None."""
+    from claude_discord.database.repository import SessionRepository
+
+    session_repo = MagicMock(spec=SessionRepository)
+    components = BridgeComponents(
+        session_repo=session_repo,
+        task_repo=None,
+        lounge_repo=None,
+    )
+    api_server = _make_api_server()
+    existing_task_repo = MagicMock()
+    api_server.task_repo = existing_task_repo
+
+    components.apply_to_api_server(api_server)
+
+    # None repos must not overwrite existing values
+    assert api_server.task_repo is existing_task_repo
+
+
+def test_apply_to_api_server_is_idempotent() -> None:
+    """apply_to_api_server called twice should leave the same repo references."""
+    from claude_discord.database.lounge_repo import LoungeRepository
+    from claude_discord.database.repository import SessionRepository
+    from claude_discord.database.task_repo import TaskRepository
+
+    session_repo = MagicMock(spec=SessionRepository)
+    task_repo = MagicMock(spec=TaskRepository)
+    lounge_repo = MagicMock(spec=LoungeRepository)
+
+    components = BridgeComponents(
+        session_repo=session_repo,
+        task_repo=task_repo,
+        lounge_repo=lounge_repo,
+    )
+    api_server = _make_api_server()
+
+    components.apply_to_api_server(api_server)
+    components.apply_to_api_server(api_server)
+
+    assert api_server.task_repo is task_repo
+    assert api_server.lounge_repo is lounge_repo
+
+
+@pytest.mark.asyncio
+async def test_setup_bridge_auto_wires_api_server(tmp_path: object) -> None:
+    """setup_bridge(api_server=...) should auto-wire repos and set runner.api_port."""
+    bot = _make_bot()
+    runner = _make_runner()
+    runner.api_port = None  # Not set yet
+    api_server = _make_api_server()
+
+    result = await setup_bridge(
+        bot,
+        runner,
+        api_server=api_server,
+        session_db_path=str(tmp_path / "sessions.db"),  # type: ignore[operator]
+        enable_scheduler=True,
+        task_db_path=str(tmp_path / "tasks.db"),  # type: ignore[operator]
+    )
+
+    # Repos should be wired automatically
+    assert api_server.task_repo is result.task_repo
+    assert api_server.lounge_repo is result.lounge_repo
+    # runner.api_port should be set from api_server.port
+    assert runner.api_port == api_server.port
+
+
+@pytest.mark.asyncio
+async def test_setup_bridge_preserves_existing_runner_api_port(tmp_path: object) -> None:
+    """setup_bridge should not overwrite runner.api_port if already set."""
+    bot = _make_bot()
+    runner = _make_runner()
+    runner.api_port = 9999  # Already set
+    api_server = _make_api_server()
+    api_server.port = 8099
+
+    await setup_bridge(
+        bot,
+        runner,
+        api_server=api_server,
+        session_db_path=str(tmp_path / "sessions.db"),  # type: ignore[operator]
+        enable_scheduler=False,
+    )
+
+    # Should NOT overwrite the existing value
+    assert runner.api_port == 9999


### PR DESCRIPTION
## Problem

When adding a new feature (e.g. AI Lounge), consumers had to manually wire new repos:

```python
# discord-bot/src/main.py — had to add this for EVERY new repo
if components.task_repo:   api_server.task_repo = components.task_repo
if components.lounge_repo: api_server.lounge_repo = components.lounge_repo
```

This caused the bugs fixed in the previous session:
- `lounge_repo` was missing from `ApiServer` → `POST /api/lounge` returned 503
- `ClaudeRunner.api_port` was missing → `CCDB_API_URL` undefined in Claude sessions

## Solution

**`BridgeComponents.apply_to_api_server(api_server)`** — one method that wires all repos.

**`setup_bridge(... api_server=api_server)`** — pass ApiServer once, everything is wired automatically, including `runner.api_port`.

### Before

```python
components = await setup_bridge(bot, runner, ...)
if components.task_repo:   api_server.task_repo = components.task_repo
if components.lounge_repo: api_server.lounge_repo = components.lounge_repo
# ↑ forget one line and a whole feature silently fails
```

### After

```python
await setup_bridge(bot, runner, api_server=api_server, ...)
# Done. All repos wired. runner.api_port set. No consumer changes needed for future features.
```

## What changes when a NEW repo is added to ccdb

| Change location | Before | After |
|-----------------|--------|-------|
| `setup.py` (ccdb) | `BridgeComponents` field + manual wiring | `BridgeComponents` field + `apply_to_api_server` line |
| `discord-bot/src/main.py` | **Add wiring code** | **Nothing** |

## Tests

- `test_apply_to_api_server_wires_task_and_lounge_repos`
- `test_apply_to_api_server_skips_none_repos`
- `test_apply_to_api_server_is_idempotent`
- `test_setup_bridge_auto_wires_api_server`
- `test_setup_bridge_preserves_existing_runner_api_port`
- Fix `test_no_ccdb_api_url_when_api_port_not_set` to isolate from host env

505 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)