### PR TITLE
refactor: remove dead code — has_waiter, update_question_idx, post_session_start

### DIFF
--- a/claude_discord/coordination/service.py
+++ b/claude_discord/coordination/service.py
@@ -15,12 +15,8 @@ Claude side (see ~/.claude/skills/coordination-channel/):
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
 
 import discord
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 
@@ -47,15 +43,6 @@ class CoordinationService:
         if channel is None:
             logger.warning("Coordination channel %d not found in bot cache", self._channel_id)
         return channel  # type: ignore[return-value]
-
-    async def post_session_start(self, thread: discord.Thread, prompt_preview: str) -> None:
-        """Post a session-started notice to the coordination channel."""
-        channel = self._get_channel()
-        if channel is None:
-            return
-        preview = prompt_preview[:80].replace("\n", " ")
-        content = f"🔵 **{thread.name}** セッション開始 | {preview}"
-        await self._safe_send(channel, content)
 
     async def post_session_end(self, thread: discord.Thread) -> None:
         """Post a session-ended notice to the coordination channel."""

--- a/claude_discord/database/ask_repo.py
+++ b/claude_discord/database/ask_repo.py
@@ -82,15 +82,6 @@ class PendingAskRepository:
             created_at=row[4],
         )
 
-    async def update_question_idx(self, thread_id: int, question_idx: int) -> None:
-        """Advance the current question index (called when moving to next question)."""
-        async with aiosqlite.connect(self._db_path) as db:
-            await db.execute(
-                "UPDATE pending_asks SET question_idx = ? WHERE thread_id = ?",
-                (question_idx, thread_id),
-            )
-            await db.commit()
-
     async def delete(self, thread_id: int) -> None:
         """Remove the pending ask for *thread_id* (called after answer received)."""
         async with aiosqlite.connect(self._db_path) as db:

--- a/claude_discord/discord_ui/ask_bus.py
+++ b/claude_discord/discord_ui/ask_bus.py
@@ -59,10 +59,6 @@ class AskAnswerBus:
         self._waiters.pop(thread_id, None)
         logger.debug("AskAnswerBus: unregistered waiter for thread %d", thread_id)
 
-    def has_waiter(self, thread_id: int) -> bool:
-        """Return True if a coroutine is currently waiting for this thread."""
-        return thread_id in self._waiters
-
 
 # Module-level singleton — import this everywhere.
 ask_bus = AskAnswerBus()


### PR DESCRIPTION
## Summary

Dead code analysis using `vulture`, `ruff`, and `coverage`. Removed 3 methods with zero callers confirmed by exhaustive grep across all source and test files.

| Removed | File | Reason |
|---------|------|--------|
| `AskAnswerBus.has_waiter()` | `discord_ui/ask_bus.py` | Never called; contributed to ask_bus.py's 46% coverage hole |
| `PendingAskRepository.update_question_idx()` | `database/ask_repo.py` | Designed for multi-question Ask flow never completed |
| `CoordinationService.post_session_start()` | `coordination/service.py` | Production caller removed when AI Lounge replaced it |

Also removed: empty `TYPE_CHECKING` block + unused `TYPE_CHECKING` import in `service.py`.

6 tests for `post_session_start` removed from `test_coordination.py` (testing deleted functionality).

## What was NOT touched

30+ vulture findings were confirmed as false positives:
- discord.py event handlers / slash commands (dynamic dispatch)
- Cog lifecycle hooks (`cog_load`, `cog_unload`, `_before_master_loop`)
- `row_factory` — aiosqlite Connection attribute
- `created_at` — dataclass fields used in SQL queries
- `ApiServer` class — imported by discord-bot consumer

## Test result

`499 passed` (down from 505 — the 6 deleted tests accounted for the difference, zero failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)