### PR TITLE
feat: add workflow_dispatch to docs-sync for manual triggering

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -3,10 +3,12 @@ name: Documentation Sync
 on:
   push:
     branches: [main]
+  workflow_dispatch: {}
 
 jobs:
   trigger-docs-sync:
     # Skip if the commit is from docs-sync itself (infinite loop prevention)
+    # For workflow_dispatch, head_commit is null so the contains() checks are skipped safely
     if: >-
       !contains(github.event.head_commit.message, '[docs-sync]') &&
       !contains(github.event.head_commit.message, 'docs-sync/')


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger to `docs-sync.yml` so the workflow can be run manually
- Useful for triggering docs-sync after stale PRs are closed or for debugging

## Why needed

When old docs-sync PRs are blocking new runs, there was no way to manually trigger without pushing a commit. This fix enables `gh workflow run docs-sync.yml` for on-demand execution.

The `if:` condition safely handles `workflow_dispatch` context where `head_commit` is null — `contains(null, ...)` evaluates to `false` in GitHub Actions expression syntax, so the job runs normally.

## Test plan

- [x] After merge: `gh workflow run docs-sync.yml --repo ebibibi/claude-code-discord-bridge` should trigger docs-sync