### PR TITLE
[docs-sync] Update architecture docs for EventProcessor/RunConfig refactoring

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,8 @@ uv run ruff format claude_discord/
 ## Adding a New Cog
 
 1. Create `claude_discord/cogs/your_cog.py`
-2. Use `_run_helper.run_claude_in_thread()` for Claude CLI execution
+2. Use `_run_helper.run_claude_with_config(RunConfig(...))` for Claude CLI execution
+   (The legacy `run_claude_in_thread()` shim is still available but prefer `run_claude_with_config`)
 3. Export from `claude_discord/cogs/__init__.py`
 4. Add to `claude_discord/__init__.py` public API
 5. Write tests in `tests/test_your_cog.py`

--- a/README.md
+++ b/README.md
@@ -412,7 +412,9 @@ claude_discord/
     scheduler.py           # Periodic Claude Code task executor
     webhook_trigger.py     # Webhook → Claude Code task execution (CI/CD)
     auto_upgrade.py        # Webhook → package upgrade + drain-aware restart
-    _run_helper.py         # Shared Claude CLI execution logic
+    event_processor.py     # EventProcessor — state machine for stream-json events
+    run_config.py          # RunConfig dataclass — bundles all CLI execution params
+    _run_helper.py         # Thin orchestration layer (run_claude_with_config + shim)
   claude/
     runner.py              # Claude CLI subprocess manager
     parser.py              # stream-json event parser
@@ -431,6 +433,9 @@ claude_discord/
     chunker.py             # Fence- and table-aware message splitting
     embeds.py              # Discord embed builders
     ask_view.py            # Buttons/Select Menus for AskUserQuestion
+    ask_handler.py         # collect_ask_answers() — AskUserQuestion UI + DB lifecycle
+    streaming_manager.py   # StreamingMessageManager — debounced in-place message edits
+    tool_timer.py          # LiveToolTimer — elapsed time counter for long-running tools
     thread_dashboard.py    # Live pinned embed showing session states
   session_sync.py          # CLI session discovery and import
   ext/

--- a/docs/ja/CONTRIBUTING.md
+++ b/docs/ja/CONTRIBUTING.md
@@ -90,7 +90,8 @@ uv run ruff format claude_discord/
 ## 新しい Cog の追加
 
 1. `claude_discord/cogs/your_cog.py` を作成
-2. Claude CLI 実行には `_run_helper.run_claude_in_thread()` を使用
+2. Claude CLI 実行には `_run_helper.run_claude_with_config(RunConfig(...))` を使用
+   （旧 `run_claude_in_thread()` shim も引き続き使えるが、新規コードは `run_claude_with_config` を優先）
 3. `claude_discord/cogs/__init__.py` からエクスポート
 4. `claude_discord/__init__.py` のパブリック API に追加
 5. `tests/test_your_cog.py` にテストを書く

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -352,7 +352,9 @@ claude_discord/
     skill_command.py       # /skill スラッシュコマンド（オートコンプリート付き）
     webhook_trigger.py     # Webhook → Claude Code タスク実行（CI/CD）
     auto_upgrade.py        # Webhook → パッケージアップグレード + 再起動
-    _run_helper.py         # 共有 Claude CLI 実行ロジック
+    event_processor.py     # EventProcessor — stream-json イベントのステートマシン
+    run_config.py          # RunConfig データクラス — CLI 実行パラメーターをまとめる
+    _run_helper.py         # 薄いオーケストレーション層（run_claude_with_config + 後方互換 shim）
   claude/
     runner.py              # Claude CLI subprocess マネージャー
     parser.py              # stream-json イベントパーサー
@@ -361,6 +363,9 @@ claude_discord/
     models.py              # SQLite スキーマ
     repository.py          # セッション CRUD 操作
     notification_repo.py   # スケジュール通知 CRUD
+    task_repo.py           # スケジュールタスク CRUD
+    ask_repo.py            # 保留中 AskUserQuestion CRUD
+    settings_repo.py       # ギルドごとの設定
   coordination/
     service.py             # CoordinationService — セッションライフサイクルイベントを共有チャンネルに投稿
   discord_ui/
@@ -368,6 +373,9 @@ claude_discord/
     chunker.py             # フェンス・テーブル対応メッセージ分割
     embeds.py              # Discord embed ビルダー
     ask_view.py            # AskUserQuestion 用 Discord ボタン / Select Menu
+    ask_handler.py         # collect_ask_answers() — AskUserQuestion UI + DB ライフサイクル
+    streaming_manager.py   # StreamingMessageManager — デバウンス付きインプレース編集
+    tool_timer.py          # LiveToolTimer — 長時間ツール実行の経過時間カウンター
     thread_dashboard.py    # スレッドごとのセッション状態を表示する live ピン留め embed
   ext/
     api_server.py          # REST API サーバー（オプション、aiohttp が必要）


### PR DESCRIPTION
## Summary
- Updated architecture diagrams in README.md and CONTRIBUTING.md to reflect the major `_run_helper.py` refactoring: extracted `EventProcessor`, `RunConfig`, `StreamingMessageManager`, `LiveToolTimer`, and `AskHandler` into dedicated modules
- Updated "Adding a New Cog" guide in CONTRIBUTING.md to recommend `run_claude_with_config(RunConfig(...))` over the legacy `run_claude_in_thread()` shim

## 概要
- `_run_helper.py` のリファクタリングに合わせて README.md と CONTRIBUTING.md のアーキテクチャ図を更新: `EventProcessor`、`RunConfig`、`StreamingMessageManager`、`LiveToolTimer`、`AskHandler` が独立モジュールとして抽出された
- CONTRIBUTING.md の「新しい Cog の追加」ガイドを更新し、旧 `run_claude_in_thread()` shim より `run_claude_with_config(RunConfig(...))` を推奨するよう修正

## Changed files
- `README.md`
- `CONTRIBUTING.md`
- `docs/ja/README.md`
- `docs/ja/CONTRIBUTING.md`

---
🤖 Auto-generated by [docs-sync](https://github.com/ebibibi/claude-code-discord-bridge)
