### PR TITLE
feat: inject DISCORD_THREAD_ID into env + auto-resolve session_id in /api/mark-resume

### DIFF
--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -401,7 +401,7 @@ class ClaudeChatCog(commands.Cog):
             status = StatusManager(user_message)
             await status.set_thinking()
 
-            runner = self.runner.clone()
+            runner = self.runner.clone(thread_id=thread.id)
             self._active_runners[thread.id] = runner
 
             stop_view = StopView(runner)

--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -59,6 +59,7 @@ class BridgeComponents:
             api_server.lounge_repo = self.lounge_repo
         if self.resume_repo is not None:
             api_server.resume_repo = self.resume_repo
+        api_server.session_repo = self.session_repo
 
 
 async def setup_bridge(


### PR DESCRIPTION
## Summary

- Injects `DISCORD_THREAD_ID` into Claude Code subprocess env so sessions know which thread they belong to
- Auto-resolves `session_id` from the sessions table in `POST /api/mark-resume` when not provided

## Usage (from within a Claude Code session)

Before restarting the bot, Claude Code can now simply call:

```bash
curl -s -X POST "$CCDB_API_URL/api/mark-resume" \
  -H "Content-Type: application/json" \
  -d "{\"thread_id\": $DISCORD_THREAD_ID, \"reason\": \"self_restart\"}"
```

- `$DISCORD_THREAD_ID` is injected automatically (no manual lookup)
- `session_id` is auto-resolved from the sessions table (no `--resume` session ID needed)

## Changes

| File | Change |
|------|--------|
| `claude/runner.py` | Add `thread_id` param; inject `DISCORD_THREAD_ID` in `_build_env()` |
| `cogs/claude_chat.py` | Pass `thread_id=thread.id` to `runner.clone()` |
| `ext/api_server.py` | Add `session_repo` param; auto-resolve `session_id` in `mark_resume()` |
| `setup.py` | Wire `session_repo` to api_server in `apply_to_api_server()` |

## Test plan

- [x] All 560 existing tests pass
- [x] `ruff format` + `ruff check` clean
- [ ] E2E: verify `$DISCORD_THREAD_ID` is set in subprocess env, call `/api/mark-resume` without session_id, confirm it resolves correctly

Closes #114 (follow-up ergonomics improvement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)