### PR TITLE
fix: make spawn_session non-blocking (asyncio.create_task)

### DIFF
--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import discord
@@ -539,6 +540,8 @@ class TestOnReady:
 
         with patch.object(cog, "_run_claude", side_effect=fake_run_claude):
             await cog.on_ready()
+            # create_task schedules the coroutine; yield to the event loop so it runs.
+            await asyncio.sleep(0)
 
         assert call_order == ["delete", "run_claude"], (
             "delete() must be called before _run_claude to prevent double-resume"
@@ -552,8 +555,12 @@ class TestOnReady:
         from claude_discord.database.resume_repo import PendingResume, PendingResumeRepository
 
         entry = PendingResume(
-            id=1, thread_id=100, session_id=None, reason="self_restart",
-            resume_prompt=None, created_at="2026-02-21 20:00:00",
+            id=1,
+            thread_id=100,
+            session_id=None,
+            reason="self_restart",
+            resume_prompt=None,
+            created_at="2026-02-21 20:00:00",
         )
         resume_repo = MagicMock(spec=PendingResumeRepository)
         resume_repo.get_pending = AsyncMock(return_value=[entry])


### PR DESCRIPTION
## Summary

- `spawn_session()` was `await`ing `_run_claude()` directly, causing `POST /api/spawn` to **block until Claude finished** (potentially hours)
- `spawn.py` would hang for the entire duration, making the calling session unresponsive
- Same issue existed in `on_ready()` resume logic

## Fix

Wrap both `_run_claude()` calls in `asyncio.create_task()`:

```python
# Before (blocking)
await self._run_claude(seed_message, thread, prompt, session_id=session_id)
return thread

# After (non-blocking)
asyncio.create_task(
    self._run_claude(seed_message, thread, prompt, session_id=session_id)
)
return thread
```

`POST /api/spawn` now returns **immediately** after creating the Discord thread. Both sessions can run in parallel.

## Test plan

- [x] All 560 existing tests pass
- [x] Updated `TestOnReady::test_on_ready_deletes_before_spawning` to yield to event loop with `asyncio.sleep(0)` so `create_task`'d coroutines run before assertions
- [ ] Manual: spawn a thread → verify calling session continues without blocking