### PR TITLE
feat: keep Stop button at the bottom of the thread

### DIFF
--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -410,6 +410,7 @@ class ClaudeChatCog(commands.Cog):
 
             stop_view = StopView(runner)
             stop_msg = await thread.send("-# ⏺ Session running", view=stop_view)
+            stop_view.set_message(stop_msg)
 
             try:
                 await run_claude_with_config(
@@ -423,10 +424,11 @@ class ClaudeChatCog(commands.Cog):
                         registry=self._registry,
                         ask_repo=self._ask_repo,
                         lounge_repo=self._lounge_repo,
+                        stop_view=stop_view,
                     )
                 )
             finally:
-                await stop_view.disable(stop_msg)
+                await stop_view.disable()
                 self._active_runners.pop(thread.id, None)
 
                 # Announce session end to coordination channel (no-op if unconfigured)

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -273,6 +273,7 @@ class EventProcessor:
             self._state.partial_text = ""
             self._state.accumulated_text = event.text
             self._assistant_text_sent = True
+            await self._bump_stop()
 
     async def _handle_tool_use(self, event: StreamEvent) -> None:
         """Post tool use embed and start the live timer."""
@@ -293,3 +294,10 @@ class EventProcessor:
 
         timer = LiveToolTimer(msg, event.tool_use)
         self._state.active_timers[event.tool_use.tool_id] = timer.start()
+
+        await self._bump_stop()
+
+    async def _bump_stop(self) -> None:
+        """Move the Stop button to the bottom of the thread if configured."""
+        if self._config.stop_view:
+            await self._config.stop_view.bump(self._config.thread)

--- a/claude_discord/cogs/run_config.py
+++ b/claude_discord/cogs/run_config.py
@@ -9,6 +9,7 @@ added without changing every caller).
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import discord
 
@@ -18,6 +19,9 @@ from ..database.ask_repo import PendingAskRepository
 from ..database.lounge_repo import LoungeRepository
 from ..database.repository import SessionRepository
 from ..discord_ui.status import StatusManager
+
+if TYPE_CHECKING:
+    from ..discord_ui.views import StopView
 
 
 @dataclass
@@ -39,6 +43,8 @@ class RunConfig:
                   notice is prepended to the prompt.
         ask_repo: Repository for persisting AskUserQuestion state across restarts.
         lounge_repo: Repository for AI Lounge context injection.
+        stop_view: StopView instance to bump after each major message, keeping
+                   the Stop button at the bottom of the thread.
     """
 
     thread: discord.Thread
@@ -50,6 +56,7 @@ class RunConfig:
     registry: SessionRegistry | None = None
     ask_repo: PendingAskRepository | None = None
     lounge_repo: LoungeRepository | None = None
+    stop_view: StopView | None = None
 
     # Prevent accidental field mutation — RunConfig is a value object.
     # Use dataclasses.replace() to create modified copies.

--- a/claude_discord/discord_ui/views.py
+++ b/claude_discord/discord_ui/views.py
@@ -20,13 +20,40 @@ class StopView(discord.ui.View):
     like pressing Escape in Claude Code) and posts a stopped_embed.
 
     After the session ends — either via the button or naturally — call
-    ``disable(message)`` to deactivate the button on the status message.
+    ``disable()`` to deactivate the button on the status message.
+
+    Call ``bump(thread)`` after each major Discord message to keep the Stop
+    button at the bottom of the thread (most recently visible position).
     """
 
     def __init__(self, runner: ClaudeRunner) -> None:
         super().__init__(timeout=None)
         self._runner = runner
         self._stopped = False
+        self._message: discord.Message | None = None
+
+    def set_message(self, message: discord.Message) -> None:
+        """Store the message this view is attached to."""
+        self._message = message
+
+    async def bump(self, thread: discord.Thread) -> None:
+        """Re-post the Stop button as the latest message in the thread.
+
+        Deletes the old stop message and sends a new one at the bottom so the
+        button stays accessible as Claude sends new messages above it.
+        No-op if the session has already been stopped.
+        """
+        if self._stopped:
+            return
+
+        old_message = self._message
+        with contextlib.suppress(discord.HTTPException):
+            new_message = await thread.send("-# ⏺ Session running", view=self)
+            self._message = new_message
+
+        if old_message:
+            with contextlib.suppress(discord.HTTPException):
+                await old_message.delete()
 
     @discord.ui.button(label="⏹ Stop", style=discord.ButtonStyle.danger)
     async def stop_button(
@@ -47,19 +74,22 @@ class StopView(discord.ui.View):
         with contextlib.suppress(Exception):
             await interaction.followup.send(embed=stopped_embed())
 
-    async def disable(self, message: discord.Message) -> None:
+    async def disable(self, message: discord.Message | None = None) -> None:
         """Disable the button after the session ends naturally.
 
+        Uses the stored message reference if ``message`` is not provided.
         No-op if the stop button was already clicked.
         """
         if self._stopped:
             return
 
+        target = message or self._message
         self._stopped = True
         for child in self.children:
             if isinstance(child, discord.ui.Button):
                 child.disabled = True
         self.stop()
 
-        with contextlib.suppress(discord.HTTPException):
-            await message.edit(view=self)
+        if target:
+            with contextlib.suppress(discord.HTTPException):
+                await target.edit(view=self)


### PR DESCRIPTION
## Summary

- **Problem**: The Stop button was posted once at session start, then buried as Claude sent tool embeds, text responses, and other messages below it.
- Added `StopView.bump(thread)` that deletes the old stop message and re-posts it at the bottom after each major Discord send (tool use and finalized text response).
- Added `StopView.set_message()` and made `disable()` optionally take no argument (uses stored reference).
- `RunConfig` gains an optional `stop_view` field; `EventProcessor` calls `_bump_stop()` at the right moments.

## Test plan

- [ ] Run `pytest tests/test_views.py` — 16 tests pass (7 new: bump, disable-without-args)
- [ ] Run `pytest tests/` — all 567 tests pass
- [ ] Start a session in Discord that uses multiple tools and verify the Stop button re-appears below each tool embed / response
- [ ] Verify pressing Stop still interrupts the session correctly
- [ ] Verify session completing naturally disables the (bottom-most) Stop button