### PR TITLE
[docs-sync] Update Japanese CONTRIBUTING.md with make setup docs

### DIFF
--- a/docs/ja/CONTRIBUTING.md
+++ b/docs/ja/CONTRIBUTING.md
@@ -43,7 +43,13 @@ main（常にリリース可能）
 git clone https://github.com/ebibibi/claude-code-discord-bridge.git
 cd claude-code-discord-bridge
 uv sync --dev
+make setup   # git hooks を登録（クローン後に一度だけ実行）
 ```
+
+> **`make setup` は必須です** — 新しくクローンするたびに実行してください。`.githooks/` の pre-commit hook を有効化し、ステージされた Python ファイルの自動フォーマットと lint を行います。
+> 実行しないと hook が動作せず、不正なコードがローカルで通過してしまいます（CI では検出されますが、予期せぬビルド失敗に驚くことになります）。
+>
+> `make check-setup` をいつでも実行して、環境が正常かどうか確認できます。
 
 ## テストの実行
 


### PR DESCRIPTION
## Summary
- Added `make setup` command to the Development Setup section of CONTRIBUTING.md, aligning with the new mandatory git hooks registration step
- Added explanatory note about why `make setup` is required (enables pre-commit hook for auto-format/lint) and mention of `make check-setup` for environment verification

## 概要
- CONTRIBUTING.md の「開発環境のセットアップ」セクションに `make setup` コマンドを追加（git hooks 登録を必須化した変更に対応）
- `make setup` が必要な理由（pre-commit hook の有効化による自動フォーマット/lint）と `make check-setup` による環境確認方法を説明するノートを追加

## Changed files
- `docs/ja/CONTRIBUTING.md`

---
🤖 Auto-generated by [docs-sync](https://github.com/ebibibi/claude-code-discord-bridge)
