### PR TITLE
feat: automatic session worktree cleanup

### DIFF
--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -425,6 +425,7 @@ class ClaudeChatCog(commands.Cog):
                         ask_repo=self._ask_repo,
                         lounge_repo=self._lounge_repo,
                         stop_view=stop_view,
+                        worktree_manager=getattr(self.bot, "worktree_manager", None),
                     )
                 )
             finally:

--- a/claude_discord/cogs/run_config.py
+++ b/claude_discord/cogs/run_config.py
@@ -22,6 +22,7 @@ from ..discord_ui.status import StatusManager
 
 if TYPE_CHECKING:
     from ..discord_ui.views import StopView
+    from ..worktree import WorktreeManager
 
 
 @dataclass
@@ -45,6 +46,9 @@ class RunConfig:
         lounge_repo: Repository for AI Lounge context injection.
         stop_view: StopView instance to bump after each major message, keeping
                    the Stop button at the bottom of the thread.
+        worktree_manager: WorktreeManager for automatic session worktree cleanup.
+                          When provided, the worktree for this thread is removed
+                          (if clean) after the session ends.
     """
 
     thread: discord.Thread
@@ -57,6 +61,7 @@ class RunConfig:
     ask_repo: PendingAskRepository | None = None
     lounge_repo: LoungeRepository | None = None
     stop_view: StopView | None = None
+    worktree_manager: WorktreeManager | None = None
 
     # Prevent accidental field mutation — RunConfig is a value object.
     # Use dataclasses.replace() to create modified copies.

--- a/claude_discord/cogs/session_manage.py
+++ b/claude_discord/cogs/session_manage.py
@@ -19,8 +19,9 @@ from discord.ext import commands
 
 from ..database.repository import SessionRepository
 from ..database.settings_repo import SettingsRepository
-from ..discord_ui.embeds import COLOR_INFO, COLOR_SUCCESS
+from ..discord_ui.embeds import COLOR_INFO, COLOR_SUCCESS, COLOR_TOOL
 from ..session_sync import CliSession, extract_recent_messages, scan_cli_sessions
+from ..worktree import WorktreeManager
 
 if TYPE_CHECKING:
     from ..bot import ClaudeDiscordBot
@@ -437,3 +438,163 @@ class SessionManageCog(commands.Cog):
                 chunk = candidate
         if chunk:
             await thread.send(chunk)
+
+    # ------------------------------------------------------------------
+    # Worktree commands
+    # ------------------------------------------------------------------
+
+    def _get_worktree_manager(self) -> WorktreeManager | None:
+        """Return the WorktreeManager from the bot, if configured."""
+        return getattr(self.bot, "worktree_manager", None)
+
+    @app_commands.command(
+        name="worktree-list",
+        description="List all active Claude Code session worktrees",
+    )
+    async def worktree_list(self, interaction: discord.Interaction) -> None:
+        """Show all session worktrees (branch ``session/\\d+``) and their status."""
+        wm = self._get_worktree_manager()
+        if wm is None:
+            await interaction.response.send_message(
+                "❌ Worktree manager is not configured.", ephemeral=True
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True)
+
+        import asyncio
+
+        worktrees = await asyncio.to_thread(wm.find_session_worktrees)
+
+        if not worktrees:
+            await interaction.followup.send(
+                embed=discord.Embed(
+                    title="🌲 Session Worktrees",
+                    description="No session worktrees found.",
+                    color=COLOR_INFO,
+                )
+            )
+            return
+
+        from ..worktree import _is_clean  # noqa: PLC0415
+
+        embed = discord.Embed(
+            title=f"🌲 Session Worktrees ({len(worktrees)})",
+            color=COLOR_INFO,
+        )
+        for wt in worktrees:
+            clean = await asyncio.to_thread(_is_clean, wt.path)
+            status = "✅ clean" if clean else "⚠️ dirty"
+            name = f"`wt-{wt.thread_id}`"
+            value = f"Branch: `{wt.branch}`\nRepo: `{wt.main_repo or 'unknown'}`\nStatus: {status}"
+            embed.add_field(name=name, value=value, inline=False)
+
+        await interaction.followup.send(embed=embed)
+
+    @app_commands.command(
+        name="worktree-cleanup",
+        description="Remove clean orphaned session worktrees",
+    )
+    @app_commands.describe(
+        dry_run="Preview what would be removed without actually removing anything",
+    )
+    async def worktree_cleanup(
+        self,
+        interaction: discord.Interaction,
+        dry_run: bool = False,
+    ) -> None:
+        """Remove session worktrees that have no active session and are clean."""
+        wm = self._get_worktree_manager()
+        if wm is None:
+            await interaction.response.send_message(
+                "❌ Worktree manager is not configured.", ephemeral=True
+            )
+            return
+
+        await interaction.response.defer()
+
+        import asyncio
+
+        # Determine active thread IDs from the session registry
+        active_ids: set[int] = set()
+        if hasattr(self.bot, "session_registry"):
+            active_ids = {s.thread_id for s in self.bot.session_registry.list_active()}
+
+        if dry_run:
+            # Just list what would be removed
+            worktrees = await asyncio.to_thread(wm.find_session_worktrees)
+            from ..worktree import _is_clean  # noqa: PLC0415
+
+            candidates = []
+            skipped = []
+            for wt in worktrees:
+                if wt.thread_id in active_ids:
+                    skipped.append((wt, "session is active"))
+                    continue
+                clean = await asyncio.to_thread(_is_clean, wt.path)
+                if clean:
+                    candidates.append(wt)
+                else:
+                    skipped.append((wt, "dirty"))
+
+            embed = discord.Embed(
+                title="🌲 Worktree Cleanup — Dry Run",
+                color=COLOR_INFO,
+            )
+            if candidates:
+                embed.add_field(
+                    name=f"Would remove ({len(candidates)})",
+                    value="\n".join(f"`{wt.path}`" for wt in candidates) or "—",
+                    inline=False,
+                )
+            if skipped:
+                embed.add_field(
+                    name=f"Would skip ({len(skipped)})",
+                    value="\n".join(f"`{wt.path}` — {reason}" for wt, reason in skipped) or "—",
+                    inline=False,
+                )
+            if not candidates and not skipped:
+                embed.description = "No session worktrees found."
+            embed.set_footer(text="Re-run without dry_run=True to actually remove.")
+            await interaction.followup.send(embed=embed)
+            return
+
+        results = await asyncio.to_thread(wm.cleanup_orphaned, active_ids)
+
+        removed = [r for r in results if r.removed]
+        dirty = [r for r in results if not r.removed and "uncommitted changes" in r.reason]
+        other_skipped = [
+            r
+            for r in results
+            if not r.removed
+            and "uncommitted changes" not in r.reason
+            and r.reason != "session is still active"
+        ]
+
+        color = COLOR_SUCCESS if removed else COLOR_INFO
+        if dirty:
+            color = COLOR_TOOL
+
+        embed = discord.Embed(
+            title="🌲 Worktree Cleanup Complete",
+            color=color,
+        )
+        embed.add_field(
+            name=f"✅ Removed ({len(removed)})",
+            value="\n".join(f"`{r.path}`" for r in removed) or "—",
+            inline=False,
+        )
+        if dirty:
+            embed.add_field(
+                name=f"⚠️ Dirty — not removed ({len(dirty)})",
+                value="\n".join(f"`{r.path}`" for r in dirty) or "—",
+                inline=False,
+            )
+        if other_skipped:
+            embed.add_field(
+                name=f"ℹ️ Skipped ({len(other_skipped)})",
+                value="\n".join(f"`{r.path}` — {r.reason}" for r in other_skipped) or "—",
+                inline=False,
+            )
+
+        await interaction.followup.send(embed=embed)

--- a/claude_discord/cogs/skill_command.py
+++ b/claude_discord/cogs/skill_command.py
@@ -207,6 +207,7 @@ class SkillCommandCog(commands.Cog):
                     prompt=prompt,
                     session_id=session_id,
                     registry=self._registry,
+                    worktree_manager=getattr(self.bot, "worktree_manager", None),
                 )
             )
             return
@@ -236,5 +237,6 @@ class SkillCommandCog(commands.Cog):
                 prompt=prompt,
                 session_id=None,
                 registry=self._registry,
+                worktree_manager=getattr(self.bot, "worktree_manager", None),
             )
         )

--- a/claude_discord/worktree.py
+++ b/claude_discord/worktree.py
@@ -1,0 +1,283 @@
+"""Git worktree lifecycle management for Claude Code sessions.
+
+Each Claude Code session may create a git worktree (wt-{thread_id}) to work
+in isolation from other concurrent sessions.  These worktrees accumulate over
+time because Claude has no built-in mechanism to remove them.
+
+This module provides WorktreeManager to:
+  - Identify session worktrees (branches matching ``session/\\d+``)
+  - Clean up worktrees safely (never remove if uncommitted changes exist)
+  - Distinguish session worktrees from manually-created feature worktrees
+
+Cleanup is triggered at three points:
+  1. Session end — remove wt-{thread_id} if it's clean (see _run_helper.py)
+  2. Bot startup — remove all orphaned clean session worktrees
+  3. Manual — via /worktree-list and /worktree-cleanup Discord commands
+
+Safety invariant: a worktree with uncommitted changes is NEVER auto-removed.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Branch pattern created by the concurrency notice template:
+# git worktree add ../wt-{thread_id} -b session/{thread_id}
+_SESSION_BRANCH_RE = re.compile(r"^session/(\d+)$")
+_SESSION_WORKTREE_PATH_RE = re.compile(r"wt-(\d+)$")
+
+
+@dataclass(frozen=True)
+class WorktreeInfo:
+    """Snapshot of a single git worktree."""
+
+    path: str
+    branch: str  # e.g. "session/1474394070012137593" or "feat/foo"
+    commit: str
+    main_repo: str  # absolute path of the main git repository
+
+    # Derived fields computed in __post_init__
+    thread_id: int | None = field(default=None, init=False)
+    is_session_worktree: bool = field(default=False, init=False)
+
+    def __post_init__(self) -> None:
+        m = _SESSION_BRANCH_RE.match(self.branch)
+        # frozen=True requires object.__setattr__ for post-init assignment
+        object.__setattr__(self, "thread_id", int(m.group(1)) if m else None)
+        object.__setattr__(self, "is_session_worktree", m is not None)
+
+
+@dataclass(frozen=True)
+class CleanupResult:
+    """Result of a single worktree cleanup attempt."""
+
+    path: str
+    thread_id: int | None
+    removed: bool
+    reason: str  # human-readable explanation
+
+
+def _run(args: list[str], cwd: str | None = None) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess and return the result (never raises on non-zero exit)."""
+    return subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+
+
+def _find_main_repo(worktree_path: str) -> str | None:
+    """Return the absolute path of the main git repo for a worktree.
+
+    Inside a worktree, ``.git`` is a *file* (not a directory) containing::
+
+        gitdir: /path/to/main-repo/.git/worktrees/<name>
+
+    We parse that file to locate the main repo's ``.git`` directory, then
+    return its parent.
+    """
+    git_file = Path(worktree_path) / ".git"
+    if not git_file.is_file():
+        return None
+    try:
+        content = git_file.read_text().strip()
+    except OSError:
+        return None
+
+    if not content.startswith("gitdir:"):
+        return None
+
+    # gitdir: /home/ebi/some-repo/.git/worktrees/wt-xxx
+    gitdir_value = content[len("gitdir:") :].strip()
+    # Navigate up: .git/worktrees/<name> → .git → repo
+    git_common = Path(gitdir_value)
+    # Remove ".git/worktrees/<name>" suffix to get the main repo root
+    # Expected: git_common ends with .git/worktrees/<name>
+    if git_common.parent.name == "worktrees" and git_common.parent.parent.name == ".git":
+        main_repo = str(git_common.parent.parent.parent)
+        return main_repo
+
+    # Fallback: ask git itself
+    result = _run(
+        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"], cwd=worktree_path
+    )
+    if result.returncode == 0:
+        git_common_dir = result.stdout.strip()
+        return str(Path(git_common_dir).parent)
+    return None
+
+
+def _is_clean(worktree_path: str) -> bool:
+    """Return True if the worktree has no uncommitted changes."""
+    result = _run(["git", "status", "--porcelain"], cwd=worktree_path)
+    if result.returncode != 0:
+        # Can't determine status — treat as dirty to be safe
+        return False
+    return result.stdout.strip() == ""
+
+
+def _get_branch(worktree_path: str) -> str:
+    """Return the current branch name, or empty string on error."""
+    result = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=worktree_path)
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def _get_commit(worktree_path: str) -> str:
+    """Return the short commit hash, or empty string on error."""
+    result = _run(["git", "rev-parse", "--short", "HEAD"], cwd=worktree_path)
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+class WorktreeManager:
+    """Manages Claude Code session git worktrees.
+
+    Scans ``base_dir`` for directories matching ``wt-{digits}`` and
+    determines whether they are session worktrees (branch ``session/{digits}``).
+
+    Args:
+        base_dir: Directory to scan for session worktrees.
+                  Typically the parent of all repos (e.g. ``/home/ebi``).
+    """
+
+    def __init__(self, base_dir: str = "/home/ebi") -> None:
+        self._base_dir = base_dir
+
+    def find_session_worktrees(self) -> list[WorktreeInfo]:
+        """Return all session worktrees (branch matching ``session/\\d+``).
+
+        Scans ``base_dir`` for directories whose basename matches ``wt-\\d+``,
+        then filters to those with a ``session/{id}`` branch.
+        """
+        results: list[WorktreeInfo] = []
+        base = Path(self._base_dir)
+
+        try:
+            entries = list(base.iterdir())
+        except OSError as exc:
+            logger.error("Cannot scan base_dir %s: %s", self._base_dir, exc)
+            return results
+
+        for entry in entries:
+            if not entry.is_dir():
+                continue
+            if not _SESSION_WORKTREE_PATH_RE.search(entry.name):
+                continue
+            if not (entry / ".git").exists():
+                continue
+
+            path = str(entry)
+            branch = _get_branch(path)
+            commit = _get_commit(path)
+            main_repo = _find_main_repo(path) or ""
+
+            info = WorktreeInfo(path=path, branch=branch, commit=commit, main_repo=main_repo)
+            if info.is_session_worktree:
+                results.append(info)
+
+        return results
+
+    def cleanup_for_thread(self, thread_id: int) -> CleanupResult:
+        """Remove the worktree for ``thread_id`` if it is clean.
+
+        The worktree path is expected to be ``{base_dir}/wt-{thread_id}``.
+        If the path does not exist this is a no-op (returns removed=False).
+
+        Returns:
+            CleanupResult describing what happened.
+        """
+        path = str(Path(self._base_dir) / f"wt-{thread_id}")
+        if not Path(path).is_dir():
+            return CleanupResult(
+                path=path,
+                thread_id=thread_id,
+                removed=False,
+                reason="worktree directory does not exist",
+            )
+
+        return self._try_remove(path, thread_id)
+
+    def cleanup_orphaned(self, active_thread_ids: set[int]) -> list[CleanupResult]:
+        """Remove clean session worktrees whose sessions are no longer active.
+
+        Call this at bot startup (``active_thread_ids=set()``) to sweep up
+        leftover worktrees from previous runs, or periodically with the current
+        active session IDs to keep things tidy.
+
+        Args:
+            active_thread_ids: Thread IDs that are currently running. Worktrees
+                               for these sessions are skipped.
+
+        Returns:
+            List of CleanupResult for every worktree that was examined.
+        """
+        results: list[CleanupResult] = []
+        for info in self.find_session_worktrees():
+            if info.thread_id in active_thread_ids:
+                results.append(
+                    CleanupResult(
+                        path=info.path,
+                        thread_id=info.thread_id,
+                        removed=False,
+                        reason="session is still active",
+                    )
+                )
+                continue
+
+            result = self._try_remove(info.path, info.thread_id)
+            results.append(result)
+
+        return results
+
+    def _try_remove(self, path: str, thread_id: int | None) -> CleanupResult:
+        """Check cleanliness and remove the worktree if safe."""
+        if not _is_clean(path):
+            logger.warning(
+                "Skipping worktree removal (dirty): %s (thread_id=%s)",
+                path,
+                thread_id,
+            )
+            return CleanupResult(
+                path=path,
+                thread_id=thread_id,
+                removed=False,
+                reason="worktree has uncommitted changes — skipped to prevent data loss",
+            )
+
+        main_repo = _find_main_repo(path)
+        if not main_repo:
+            logger.warning("Cannot determine main repo for worktree %s", path)
+            return CleanupResult(
+                path=path,
+                thread_id=thread_id,
+                removed=False,
+                reason="cannot determine main git repository",
+            )
+
+        result = _run(["git", "worktree", "remove", path], cwd=main_repo)
+        if result.returncode == 0:
+            logger.info("Removed session worktree: %s (thread_id=%s)", path, thread_id)
+            return CleanupResult(path=path, thread_id=thread_id, removed=True, reason="clean")
+        else:
+            stderr = result.stderr.strip()
+            logger.warning(
+                "Failed to remove worktree %s: %s",
+                path,
+                stderr,
+            )
+            return CleanupResult(
+                path=path,
+                thread_id=thread_id,
+                removed=False,
+                reason=f"git worktree remove failed: {stderr}",
+            )

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -1,0 +1,271 @@
+"""Tests for WorktreeManager and related helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from claude_discord.worktree import (
+    WorktreeInfo,
+    WorktreeManager,
+    _find_main_repo,
+    _is_clean,
+)
+
+# ---------------------------------------------------------------------------
+# WorktreeInfo — derived field computation
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeInfo:
+    def test_session_branch_parsed(self) -> None:
+        wt = WorktreeInfo(
+            path="/home/ebi/wt-12345",
+            branch="session/12345",
+            commit="abc1234",
+            main_repo="/home/ebi/some-repo",
+        )
+        assert wt.is_session_worktree is True
+        assert wt.thread_id == 12345
+
+    def test_non_session_branch(self) -> None:
+        wt = WorktreeInfo(
+            path="/home/ebi/wt-feat-foo",
+            branch="feat/my-feature",
+            commit="abc1234",
+            main_repo="/home/ebi/some-repo",
+        )
+        assert wt.is_session_worktree is False
+        assert wt.thread_id is None
+
+    def test_main_branch_not_session(self) -> None:
+        wt = WorktreeInfo(
+            path="/home/ebi/some-repo",
+            branch="main",
+            commit="abc1234",
+            main_repo="/home/ebi/some-repo",
+        )
+        assert wt.is_session_worktree is False
+        assert wt.thread_id is None
+
+    def test_frozen(self) -> None:
+        wt = WorktreeInfo(
+            path="/home/ebi/wt-99",
+            branch="session/99",
+            commit="aaa",
+            main_repo="/home/ebi/repo",
+        )
+        import dataclasses
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            wt.path = "/other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# _find_main_repo
+# ---------------------------------------------------------------------------
+
+
+class TestFindMainRepo:
+    def test_parses_gitdir_file(self, tmp_path: Path) -> None:
+        """A .git file with a standard gitdir: line should resolve the main repo."""
+        worktree_dir = tmp_path / "wt-999"
+        worktree_dir.mkdir()
+        main_git = tmp_path / "main-repo" / ".git" / "worktrees" / "wt-999"
+        main_git.mkdir(parents=True)
+
+        git_file = worktree_dir / ".git"
+        git_file.write_text(f"gitdir: {main_git}\n")
+
+        result = _find_main_repo(str(worktree_dir))
+        assert result == str(tmp_path / "main-repo")
+
+    def test_missing_git_file_returns_none(self, tmp_path: Path) -> None:
+        d = tmp_path / "not-a-worktree"
+        d.mkdir()
+        assert _find_main_repo(str(d)) is None
+
+    def test_non_gitdir_content_returns_none(self, tmp_path: Path) -> None:
+        d = tmp_path / "weird"
+        d.mkdir()
+        (d / ".git").write_text("not a gitdir line\n")
+        assert _find_main_repo(str(d)) is None
+
+
+# ---------------------------------------------------------------------------
+# _is_clean (subprocess mock)
+# ---------------------------------------------------------------------------
+
+
+class TestIsClean:
+    def test_clean_worktree(self) -> None:
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        with patch("claude_discord.worktree._run", return_value=mock_result):
+            assert _is_clean("/some/path") is True
+
+    def test_dirty_worktree(self) -> None:
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = " M some_file.py\n"
+        with patch("claude_discord.worktree._run", return_value=mock_result):
+            assert _is_clean("/some/path") is False
+
+    def test_git_error_treated_as_dirty(self) -> None:
+        mock_result = MagicMock()
+        mock_result.returncode = 128
+        mock_result.stdout = ""
+        with patch("claude_discord.worktree._run", return_value=mock_result):
+            assert _is_clean("/some/path") is False
+
+
+# ---------------------------------------------------------------------------
+# WorktreeManager.find_session_worktrees
+# ---------------------------------------------------------------------------
+
+
+class TestFindSessionWorktrees:
+    def test_finds_session_worktrees(self, tmp_path: Path) -> None:
+        """Only wt-{digits} directories with session/{digits} branches should be returned."""
+        # Create a fake session worktree directory
+        session_wt = tmp_path / "wt-12345"
+        session_wt.mkdir()
+        (session_wt / ".git").write_text("gitdir: /fake/repo/.git/worktrees/wt-12345\n")
+
+        # Non-session worktree (feature branch) — should be excluded
+        feature_wt = tmp_path / "wt-feat"
+        feature_wt.mkdir()
+        (feature_wt / ".git").write_text("gitdir: /fake/repo/.git/worktrees/wt-feat\n")
+
+        # Not a worktree (no .git file)
+        plain_dir = tmp_path / "wt-notgit"
+        plain_dir.mkdir()
+
+        with (
+            patch("claude_discord.worktree._get_branch") as mock_branch,
+            patch("claude_discord.worktree._get_commit", return_value="abc1234"),
+            patch("claude_discord.worktree._find_main_repo", return_value="/fake/repo"),
+        ):
+            # Return session branch for wt-12345, feature branch for wt-feat
+            def branch_side_effect(path: str) -> str:
+                if "wt-12345" in path:
+                    return "session/12345"
+                return "feat/my-feature"
+
+            mock_branch.side_effect = branch_side_effect
+
+            wm = WorktreeManager(base_dir=str(tmp_path))
+            worktrees = wm.find_session_worktrees()
+
+        assert len(worktrees) == 1
+        assert worktrees[0].thread_id == 12345
+        assert worktrees[0].is_session_worktree is True
+
+    def test_empty_when_no_session_worktrees(self, tmp_path: Path) -> None:
+        wm = WorktreeManager(base_dir=str(tmp_path))
+        assert wm.find_session_worktrees() == []
+
+
+# ---------------------------------------------------------------------------
+# WorktreeManager.cleanup_for_thread
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupForThread:
+    def test_removes_clean_worktree(self, tmp_path: Path) -> None:
+        wt_path = tmp_path / "wt-999"
+        wt_path.mkdir()
+        (wt_path / ".git").write_text("gitdir: /repo/.git/worktrees/wt-999\n")
+
+        with (
+            patch("claude_discord.worktree._is_clean", return_value=True),
+            patch("claude_discord.worktree._find_main_repo", return_value="/repo"),
+            patch("claude_discord.worktree._run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            wm = WorktreeManager(base_dir=str(tmp_path))
+            result = wm.cleanup_for_thread(999)
+
+        assert result.removed is True
+        assert result.thread_id == 999
+
+    def test_skips_dirty_worktree(self, tmp_path: Path) -> None:
+        wt_path = tmp_path / "wt-999"
+        wt_path.mkdir()
+        (wt_path / ".git").write_text("gitdir: /repo/.git/worktrees/wt-999\n")
+
+        with patch("claude_discord.worktree._is_clean", return_value=False):
+            wm = WorktreeManager(base_dir=str(tmp_path))
+            result = wm.cleanup_for_thread(999)
+
+        assert result.removed is False
+        assert "uncommitted changes" in result.reason
+
+    def test_noop_when_worktree_missing(self, tmp_path: Path) -> None:
+        wm = WorktreeManager(base_dir=str(tmp_path))
+        result = wm.cleanup_for_thread(42)
+        assert result.removed is False
+        assert "does not exist" in result.reason
+
+    def test_handles_git_remove_failure(self, tmp_path: Path) -> None:
+        wt_path = tmp_path / "wt-123"
+        wt_path.mkdir()
+        (wt_path / ".git").write_text("gitdir: /repo/.git/worktrees/wt-123\n")
+
+        with (
+            patch("claude_discord.worktree._is_clean", return_value=True),
+            patch("claude_discord.worktree._find_main_repo", return_value="/repo"),
+            patch("claude_discord.worktree._run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=128, stderr="locked worktree")
+            wm = WorktreeManager(base_dir=str(tmp_path))
+            result = wm.cleanup_for_thread(123)
+
+        assert result.removed is False
+        assert "git worktree remove failed" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# WorktreeManager.cleanup_orphaned
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupOrphaned:
+    def test_skips_active_sessions(self, tmp_path: Path) -> None:
+        wt_path = tmp_path / "wt-555"
+        wt_path.mkdir()
+        (wt_path / ".git").write_text("gitdir: /repo/.git/worktrees/wt-555\n")
+
+        with (
+            patch("claude_discord.worktree._get_branch", return_value="session/555"),
+            patch("claude_discord.worktree._get_commit", return_value="abc"),
+            patch("claude_discord.worktree._find_main_repo", return_value="/repo"),
+        ):
+            wm = WorktreeManager(base_dir=str(tmp_path))
+            results = wm.cleanup_orphaned(active_thread_ids={555})
+
+        assert len(results) == 1
+        assert results[0].removed is False
+        assert "active" in results[0].reason
+
+    def test_removes_orphaned_clean_worktree(self, tmp_path: Path) -> None:
+        wt_path = tmp_path / "wt-777"
+        wt_path.mkdir()
+        (wt_path / ".git").write_text("gitdir: /repo/.git/worktrees/wt-777\n")
+
+        with (
+            patch("claude_discord.worktree._get_branch", return_value="session/777"),
+            patch("claude_discord.worktree._get_commit", return_value="abc"),
+            patch("claude_discord.worktree._find_main_repo", return_value="/repo"),
+            patch("claude_discord.worktree._is_clean", return_value=True),
+            patch("claude_discord.worktree._run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            wm = WorktreeManager(base_dir=str(tmp_path))
+            results = wm.cleanup_orphaned(active_thread_ids=set())
+
+        assert len(results) == 1
+        assert results[0].removed is True


### PR DESCRIPTION
## Summary

- **Problem**: Each Claude Code session may create a git worktree (`wt-{thread_id}`) for isolation, but nothing cleans them up — they accumulate indefinitely (see current state: 4+ orphaned session worktrees)
- **Solution**: Three-tier cleanup strategy with a strict safety invariant: dirty worktrees are **never** auto-removed

## Three-tier cleanup

| Tier | When | How |
|------|------|-----|
| **Immediate** | Session ends | `_run_helper.py` removes `wt-{thread_id}` if clean |
| **Startup** | Bot boots | `bot.on_ready()` sweeps all orphaned clean session worktrees |
| **Manual** | On demand | `/worktree-list` and `/worktree-cleanup [dry_run]` Discord commands |

## Session worktree identification

Uses branch name pattern `session/\d+` (not path name) to distinguish session worktrees from manually-created feature branches — the pattern is set by `concurrency.py`'s template, so it's reliable.

## Safety

- Worktrees with uncommitted changes → **never auto-removed**, Discord warning posted instead
- `git worktree remove` failure → logged, skipped gracefully
- `_find_main_repo()` reads the `.git` file to determine which repo to run `git worktree remove` against

## Configuration

Opt-in via env var or `setup_bridge()` parameter — no change to existing deployments:
```
WORKTREE_BASE_DIR=/home/ebi  # directory to scan for wt-{digits} dirs
```

## Test plan

- [x] 18 unit tests covering `WorktreeInfo`, `_find_main_repo`, `_is_clean`, `WorktreeManager.find_session_worktrees`, `cleanup_for_thread`, `cleanup_orphaned`
- [x] Full test suite: 590 passed
- [ ] Manual: verify existing orphaned worktrees are cleaned on next bot restart