### PR TITLE
feat: auto-mark active sessions for resume before bot upgrade restart

### DIFF
--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -147,6 +147,11 @@ async def setup_bridge(
     resume_repo = PendingResumeRepository(session_db_path)
     logger.info("Session DB initialized: %s", session_db_path)
 
+    # Attach repos to bot so generic cogs (e.g. AutoUpgradeCog) can discover them
+    # without a hard import dependency on ccdb internals.
+    bot.session_repo = session_repo  # type: ignore[attr-defined]
+    bot.resume_repo = resume_repo  # type: ignore[attr-defined]
+
     # --- ClaudeChatCog ---
     chat_cog = ClaudeChatCog(
         bot,  # type: ignore[arg-type]  # consumers pass their own Bot subclass

--- a/tests/test_auto_upgrade.py
+++ b/tests/test_auto_upgrade.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
@@ -603,7 +602,7 @@ class TestRestartApproval:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                raise asyncio.TimeoutError  # Python 3.10 asyncio variant
+                raise TimeoutError  # Python 3.10 asyncio variant
             event = MagicMock()
             event.message_id = 99999
             event.emoji = "✅"
@@ -713,3 +712,194 @@ class TestActiveSessionCount:
 
         del cog._active_runners[1]
         assert cog.active_session_count == 1
+
+
+class TestMarkSessionsForResume:
+    """Tests for _collect_active_thread_ids and _mark_sessions_for_resume."""
+
+    def _make_cog_with_restart(self, bot: MagicMock) -> AutoUpgradeCog:
+        config = UpgradeConfig(
+            package_name="pkg",
+            restart_command=["sudo", "systemctl", "restart", "bot.service"],
+            working_dir="/tmp",
+        )
+        return AutoUpgradeCog(bot=bot, config=config)
+
+    def test_collect_active_thread_ids_empty(self) -> None:
+        """Returns empty frozenset when no cog has _active_runners."""
+        bot = MagicMock(spec=commands.Bot)
+        bot.cogs.values.return_value = []
+        cog = self._make_cog_with_restart(bot)
+        assert cog._collect_active_thread_ids() == frozenset()
+
+    def test_collect_active_thread_ids_from_cog(self) -> None:
+        """Collects thread IDs from cogs that have _active_runners."""
+        bot = MagicMock(spec=commands.Bot)
+        cog = self._make_cog_with_restart(bot)
+
+        class FakeChatCog:
+            _active_runners = {111: MagicMock(), 222: MagicMock()}
+
+        fake_chat = FakeChatCog()
+        bot.cogs.values.return_value = [fake_chat, cog]
+
+        result = cog._collect_active_thread_ids()
+        assert result == frozenset({111, 222})
+
+    def test_collect_active_thread_ids_excludes_self(self) -> None:
+        """Does not include threads from the cog itself (it has no _active_runners)."""
+        bot = MagicMock(spec=commands.Bot)
+        cog = self._make_cog_with_restart(bot)
+        # Manually give the cog an _active_runners to verify self-exclusion
+        cog._active_runners = {999: MagicMock()}  # type: ignore[attr-defined]
+        bot.cogs.values.return_value = [cog]
+
+        # self is excluded
+        result = cog._collect_active_thread_ids()
+        assert 999 not in result
+
+    @pytest.mark.asyncio
+    async def test_mark_sessions_no_op_when_empty(self) -> None:
+        """No API calls when thread_ids is empty."""
+        bot = MagicMock(spec=commands.Bot)
+        bot.resume_repo = AsyncMock()
+        cog = self._make_cog_with_restart(bot)
+        thread = MagicMock(spec=discord.Thread)
+        thread.send = AsyncMock()
+
+        await cog._mark_sessions_for_resume(frozenset(), thread)
+
+        bot.resume_repo.mark.assert_not_called()
+        thread.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mark_sessions_no_op_when_no_resume_repo(self) -> None:
+        """No-op when bot.resume_repo is not set."""
+        bot = MagicMock(spec=commands.Bot)
+        del bot.resume_repo  # ensure attribute is absent
+        cog = self._make_cog_with_restart(bot)
+        thread = MagicMock(spec=discord.Thread)
+        thread.send = AsyncMock()
+
+        await cog._mark_sessions_for_resume(frozenset({111}), thread)
+
+        thread.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mark_sessions_calls_mark_for_each_thread(self) -> None:
+        """Calls resume_repo.mark() for each active thread."""
+        bot = MagicMock(spec=commands.Bot)
+        resume_repo = MagicMock()
+        resume_repo.mark = AsyncMock(return_value=1)
+        bot.resume_repo = resume_repo
+
+        # No session_repo → session_id will be None
+        del bot.session_repo
+
+        cog = self._make_cog_with_restart(bot)
+        thread = MagicMock(spec=discord.Thread)
+        thread.send = AsyncMock()
+
+        await cog._mark_sessions_for_resume(frozenset({111, 222}), thread)
+
+        assert resume_repo.mark.call_count == 2
+        called_thread_ids = {call.args[0] for call in resume_repo.mark.call_args_list}
+        assert called_thread_ids == {111, 222}
+
+        # Should post a Discord message reporting the count
+        thread.send.assert_called_once()
+        assert "2" in thread.send.call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_mark_sessions_resolves_session_id_from_repo(self) -> None:
+        """Looks up session_id from session_repo when available."""
+        bot = MagicMock(spec=commands.Bot)
+
+        resume_repo = MagicMock()
+        resume_repo.mark = AsyncMock(return_value=1)
+        bot.resume_repo = resume_repo
+
+        session_record = MagicMock()
+        session_record.session_id = "abc-123"
+        session_repo = MagicMock()
+        session_repo.get = AsyncMock(return_value=session_record)
+        bot.session_repo = session_repo
+
+        cog = self._make_cog_with_restart(bot)
+        thread = MagicMock(spec=discord.Thread)
+        thread.send = AsyncMock()
+
+        await cog._mark_sessions_for_resume(frozenset({111}), thread)
+
+        session_repo.get.assert_awaited_once_with(111)
+        resume_repo.mark.assert_awaited_once()
+        call_kwargs = resume_repo.mark.call_args.kwargs
+        assert call_kwargs["session_id"] == "abc-123"
+        assert call_kwargs["reason"] == "bot_upgrade"
+
+    @pytest.mark.asyncio
+    async def test_mark_sessions_handles_mark_failure_gracefully(self) -> None:
+        """Continues marking other threads even if one fails."""
+        bot = MagicMock(spec=commands.Bot)
+        resume_repo = MagicMock()
+        resume_repo.mark = AsyncMock(side_effect=[RuntimeError("db error"), 2])
+        bot.resume_repo = resume_repo
+        del bot.session_repo
+
+        cog = self._make_cog_with_restart(bot)
+        thread = MagicMock(spec=discord.Thread)
+        thread.send = AsyncMock()
+
+        # Should not raise; one thread fails, one succeeds
+        await cog._mark_sessions_for_resume(frozenset({111, 222}), thread)
+
+        assert resume_repo.mark.call_count == 2
+        # Only 1 succeeded, so Discord message says "1"
+        thread.send.assert_called_once()
+        assert "1" in thread.send.call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_upgrade_marks_active_sessions_before_restart(self) -> None:
+        """Integration: active sessions are marked for resume during upgrade."""
+        bot = MagicMock(spec=commands.Bot)
+        bot.user = MagicMock()
+        bot.user.id = 0
+
+        resume_repo = MagicMock()
+        resume_repo.mark = AsyncMock(return_value=1)
+        bot.resume_repo = resume_repo
+        del bot.session_repo
+
+        class FakeChatCog:
+            _active_runners = {555: MagicMock()}
+
+        bot.cogs.values.return_value = [FakeChatCog()]
+
+        config = UpgradeConfig(
+            package_name="pkg",
+            trigger_prefix="🔄 upgrade",
+            working_dir="/tmp",
+            restart_command=["sudo", "systemctl", "restart", "bot.service"],
+        )
+        cog = AutoUpgradeCog(bot=bot, config=config)
+
+        trigger_msg = _make_message(content="🔄 upgrade")
+
+        with (
+            patch(_PATCH_EXEC, new_callable=AsyncMock) as mock_exec,
+            patch(_PATCH_WAIT, new_callable=AsyncMock) as mock_wait,
+            patch(_PATCH_SLEEP, new_callable=AsyncMock),
+        ):
+            proc = _make_process(returncode=0, stdout=b"ok")
+            mock_exec.return_value = proc
+            mock_wait.return_value = (b"ok", b"")
+
+            # Drain check: return True immediately (no active sessions during drain)
+            cog._drain_check = lambda: True
+
+            await cog._run_upgrade(trigger_msg)
+
+        # resume_repo.mark should have been called for thread 555
+        resume_repo.mark.assert_awaited_once()
+        assert resume_repo.mark.call_args.args[0] == 555
+        assert resume_repo.mark.call_args.kwargs["reason"] == "bot_upgrade"


### PR DESCRIPTION
## Summary

- **Root cause of #125**: When `AutoUpgradeCog` triggers a bot restart, active Claude sessions were not saved to `pending_resumes`. So `on_ready` found nothing to resume, and sessions only continued if the user manually sent a new message.

- `_collect_active_thread_ids()`: snapshots `_active_runners` from all cogs (duck-typed) **before** drain, capturing sessions that are mid-run at upgrade time
- `_mark_sessions_for_resume()`: called **after** drain but **just before** the restart command; looks up `session_id` from `bot.session_repo` for `--resume` continuity; no-op when `bot.resume_repo` is not configured
- `setup.py`: attaches `session_repo` and `resume_repo` to `bot` so generic cogs can discover them via `getattr(bot, "session_repo", None)` without coupling to ccdb internals

**Why mark after drain, not before:**
Drain ensures sessions finish their current Claude turn naturally. Marking just before restart keeps the `pending_resumes` row well within the 5-minute TTL (restart typically takes <10s). Sessions that completed naturally still get the post-restart "check for remaining work" prompt, enabling multi-turn autonomous workflows to continue across bot upgrades.

## Test plan

- [x] 9 new unit tests in `TestMarkSessionsForResume` covering: empty case, no `resume_repo`, per-thread marking, `session_id` resolution, error tolerance, and end-to-end integration through `_run_upgrade()`
- [x] All 39 existing `test_auto_upgrade.py` tests still pass
- [x] ruff/pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)