### PR TITLE
chore: release v1.3.0 — AI Lounge, startup resume, /api/spawn, auto-worktree cleanup, and resilience improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-02-22
+
+### Added
+- **AI Lounge** (`LoungeChannel`) — shared Discord channel where concurrent Claude Code sessions announce themselves; hooks and concurrency notice injected automatically into every session's system prompt (#102, #107)
+- **Startup resume** — bot restart auto-resumes interrupted sessions via `on_ready`; `pending_resumes` DB table tracks sessions that need resumption (#115)
+- **`POST /api/spawn`** — programmatic Claude Code session creation from external callers (GitHub Actions, schedulers, other Claude sessions) without a Discord message trigger (#113)
+- **`DISCORD_THREAD_ID` env injection** — subprocess env includes `DISCORD_THREAD_ID` so Claude can self-register for resume via `mark-resume` endpoint without knowing its session ID (#116)
+- **Auto-mark on upgrade restart** — `AutoUpgradeCog` marks active sessions for resume before applying a package upgrade restart, so sessions survive bot upgrades (#126)
+- **Auto-mark on any shutdown** — `cog_unload()` marks active sessions for resume on any bot shutdown (not just upgrades), ensuring no session is lost on `systemctl restart` (#128)
+- **Automatic worktree cleanup** — `WorktreeCleanupCog` removes stale git worktrees left by finished sessions on a configurable interval (#124)
+- **Stop button always at bottom** — Stop button is re-posted to the thread after each assistant message so it stays reachable without scrolling (#119)
+- **`BridgeComponents.apply_to_api_server()`** — convenience method to wire `CoordinationChannel` and `SessionRegistry` into the REST API server; also auto-wired in `setup_bridge()` (#103)
+- **`session_registry` in scheduler tasks** — `SchedulerCog` passes `session_registry` into spawned tasks so Claude can detect concurrent sessions before starting (#99)
+
+### Changed
+- **Layered architecture refactor** — large-scale internal refactor introducing `RunConfig` (immutable per-run config) and `EventProcessor` (stateful stream processor), replacing ad-hoc kwargs threading through the runner stack (#110)
+- **Dead code removal** — eliminated unreachable branches and unused symbols identified by vulture, ruff, and coverage analysis (#104)
+- **README rewrite** — README now leads with the concurrent multi-session development use case as the primary value proposition (#100)
+
+### Fixed
+- `session_start_embed` sent exactly once regardless of how many `SYSTEM` events arrive (#105)
+- docs-sync webhook sent from `auto-approve.yml` after PR merge (was missing) (#106)
+- Duplicate result text guarded by flag instead of fragile string comparison (#109)
+- `spawn_session` made non-blocking via `asyncio.create_task` to avoid blocking the event loop (#117)
+- `ServerDisconnectedError` from aiohttp on bot shutdown now handled gracefully (#120)
+- Pre-commit hook exits with a clear error message when `uv` is not installed (#121)
+- `asyncio.TimeoutError` in `auto_upgrade` now caught correctly on Python 3.10 (#123)
+- `asyncio.TimeoutError` in `runner` and `ask_handler` now caught correctly on Python 3.10 (#130)
+
 ## [1.2.0] - 2026-02-20
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-code-discord-bridge"
-version = "1.2.0"
+version = "1.3.0"
 description = "Connect Claude Code to Discord and GitHub — interactive chat, CI/CD automation, and workflow integration"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

- Bump version `1.2.0` → `1.3.0`
- Update `CHANGELOG.md` with all changes since v1.2.0

## Changes in this release

### Added
- **AI Lounge** — shared Discord channel for cross-session awareness; injected into every session's system prompt (#102, #107)
- **Startup resume** — bot restart auto-resumes interrupted sessions via `on_ready` (#115)
- **`POST /api/spawn`** — programmatic Claude Code session creation from external callers (#113)
- **`DISCORD_THREAD_ID` env injection** — subprocess knows its thread ID for self-registration (#116)
- **Auto-mark on upgrade restart** — sessions survive bot package upgrades (#126)
- **Auto-mark on any shutdown** — sessions survive `systemctl restart` via `cog_unload()` (#128)
- **Automatic worktree cleanup** — `WorktreeCleanupCog` removes stale git worktrees (#124)
- **Stop button always at bottom** — re-posted after each assistant message (#119)
- **`BridgeComponents.apply_to_api_server()`** — convenience wiring method (#103)
- **`session_registry` in scheduler tasks** — concurrency awareness for scheduled tasks (#99)

### Changed
- Layered architecture refactor: `RunConfig` + `EventProcessor` (#110)
- Dead code removal (#104)
- README rewrite leading with concurrent multi-session use case (#100)

### Fixed
- 8 bug fixes including Python 3.10 `asyncio.TimeoutError` compat, `ServerDisconnectedError`, duplicate start embeds, non-blocking spawn, duplicate result text guard

## Test plan
- [ ] CI passes (ruff + pytest on 3.10/3.11/3.12)
- [ ] CHANGELOG entry is accurate
- [ ] Version in `pyproject.toml` is `1.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)