### PR TITLE
feat: notify users when hard stall detected

### DIFF
--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -449,7 +449,13 @@ class ClaudeChatCog(commands.Cog):
                     thread=thread,
                 )
 
-            status = StatusManager(user_message)
+            async def _notify_stall() -> None:
+                await thread.send(
+                    "-# \u26a0\ufe0f No activity for 30s — could be extended thinking "
+                    "or context compression. Will resume automatically."
+                )
+
+            status = StatusManager(user_message, on_hard_stall=_notify_stall)
             await status.set_thinking()
 
             runner = self.runner.clone(thread_id=thread.id)

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,92 @@
+"""Unit tests for StatusManager stall notification feature."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from claude_discord.claude.types import ToolCategory
+from claude_discord.discord_ui.status import (
+    STALL_HARD_SECONDS,
+    StatusManager,
+)
+
+
+def _make_message() -> MagicMock:
+    """Create a mock Discord message with guild.me for reactions."""
+    msg = MagicMock()
+    msg.add_reaction = AsyncMock()
+    msg.remove_reaction = AsyncMock()
+    msg.guild = MagicMock()
+    msg.guild.me = MagicMock()
+    return msg
+
+
+class TestHardStallCallback:
+    """Tests for the on_hard_stall callback feature."""
+
+    @pytest.mark.asyncio
+    async def test_callback_fires_on_hard_stall(self) -> None:
+        callback = AsyncMock()
+        msg = _make_message()
+        sm = StatusManager(msg, on_hard_stall=callback)
+        await sm.set_thinking()
+        loop = asyncio.get_running_loop()
+        sm._last_activity = loop.time() - STALL_HARD_SECONDS - 1
+        await asyncio.sleep(2.5)
+        callback.assert_awaited_once()
+        await sm.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_callback_fires_only_once_per_stall(self) -> None:
+        callback = AsyncMock()
+        msg = _make_message()
+        sm = StatusManager(msg, on_hard_stall=callback)
+        await sm.set_thinking()
+        loop = asyncio.get_running_loop()
+        sm._last_activity = loop.time() - STALL_HARD_SECONDS - 1
+        await asyncio.sleep(5)
+        callback.assert_awaited_once()
+        await sm.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_callback_resets_after_activity(self) -> None:
+        callback = AsyncMock()
+        msg = _make_message()
+        sm = StatusManager(msg, on_hard_stall=callback)
+        await sm.set_thinking()
+        loop = asyncio.get_running_loop()
+        sm._last_activity = loop.time() - STALL_HARD_SECONDS - 1
+        await asyncio.sleep(2.5)
+        assert callback.await_count == 1
+        await sm.set_tool(ToolCategory.READ)
+        sm._last_activity = loop.time() - STALL_HARD_SECONDS - 1
+        await asyncio.sleep(2.5)
+        assert callback.await_count == 2
+        await sm.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_no_callback_when_not_provided(self) -> None:
+        msg = _make_message()
+        sm = StatusManager(msg)
+        await sm.set_thinking()
+        loop = asyncio.get_running_loop()
+        sm._last_activity = loop.time() - STALL_HARD_SECONDS - 1
+        await asyncio.sleep(2.5)
+        await sm.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_callback_exception_does_not_crash_monitor(self) -> None:
+        callback = AsyncMock(side_effect=Exception("Discord API error"))
+        msg = _make_message()
+        sm = StatusManager(msg, on_hard_stall=callback)
+        await sm.set_thinking()
+        loop = asyncio.get_running_loop()
+        sm._last_activity = loop.time() - STALL_HARD_SECONDS - 1
+        await asyncio.sleep(2.5)
+        callback.assert_awaited_once()
+        assert sm._stall_task is not None
+        assert not sm._stall_task.done()
+        await sm.cleanup()


### PR DESCRIPTION
## Summary

- **Problem**: When Claude is inactive for 30+ seconds, StatusManager shows ⚠️ emoji on the user's message but posts NO message to the thread. Users see ⚠️ and don't know what's happening — is it broken? Should they retry?
- **Solution**: Add an `on_hard_stall` callback to `StatusManager` that fires once when hard stall is detected. `ClaudeChatCog` wires this to post a small `-#` notice in the thread explaining the stall (extended thinking, context compression, etc.)
- **Behavior**: Callback fires once per stall period. When activity resumes and another stall occurs, the callback fires again. Exceptions in the callback are suppressed so the stall monitor keeps running.

## Changes

- `claude_discord/discord_ui/status.py` — Added `on_hard_stall` callback parameter, `_hard_stall_notified` flag, reset on activity, fire-once logic in `_stall_monitor()`
- `claude_discord/cogs/claude_chat.py` — Wired `_notify_stall` closure that posts a thread message
- `tests/test_status.py` — 5 new tests covering: callback fires, fires only once, resets after activity, no-op when not provided, exception resilience

## Test plan

- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [x] `uv run pytest tests/ -v --cov=claude_discord` — 629 tests pass, 80% coverage
- [ ] Manual test: send a message, observe ⚠️ emoji + thread notice after 30s of inactivity
- [ ] Manual test: verify notice appears only once per stall (not repeated every 2s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)