### PR TITLE
feat: add /model-show and /model-set for runtime model switching

### DIFF
--- a/claude_discord/claude/runner.py
+++ b/claude_discord/claude/runner.py
@@ -98,16 +98,19 @@ class ClaudeRunner:
         finally:
             await self._cleanup()
 
-    def clone(self, thread_id: int | None = None) -> ClaudeRunner:
+    def clone(self, thread_id: int | None = None, model: str | None = None) -> ClaudeRunner:
         """Create a fresh runner with the same configuration but no active process.
 
         Args:
             thread_id: Discord thread ID to inject as DISCORD_THREAD_ID env var.
                        Overrides the instance-level thread_id if provided.
+            model: Optional model override for this clone. When provided, the clone
+                   uses this model instead of self.model. Useful for per-session
+                   model switching without mutating the shared base runner.
         """
         return ClaudeRunner(
             command=self.command,
-            model=self.model,
+            model=model if model is not None else self.model,
             permission_mode=self.permission_mode,
             working_dir=self.working_dir,
             timeout_seconds=self.timeout_seconds,

--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -161,6 +161,7 @@ async def setup_bridge(
         ask_repo=ask_repo,
         lounge_repo=lounge_repo,
         resume_repo=resume_repo,
+        settings_repo=settings_repo,
     )
     await bot.add_cog(chat_cog)
     logger.info("Registered ClaudeChatCog")

--- a/tests/test_model_command.py
+++ b/tests/test_model_command.py
@@ -1,0 +1,204 @@
+"""Tests for /model command group in SessionManageCog.
+
+TDD: Write tests first, then implement.
+
+Commands:
+- /model show  — display current global model (+ per-thread model if in thread)
+- /model set   — update global default model in settings_repo
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from claude_discord.cogs.session_manage import (
+    SETTING_CLAUDE_MODEL,
+    SessionManageCog,
+)
+from claude_discord.database.repository import SessionRecord
+
+
+def _make_record(
+    thread_id: int = 100,
+    session_id: str = "abc-123",
+    model: str | None = "sonnet",
+) -> SessionRecord:
+    return SessionRecord(
+        thread_id=thread_id,
+        session_id=session_id,
+        working_dir="/home/user",
+        model=model,
+        origin="discord",
+        summary=None,
+        created_at="2026-02-22 10:00:00",
+        last_used_at="2026-02-22 11:00:00",
+    )
+
+
+def _make_thread_interaction(thread_id: int = 12345) -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = thread_id
+    interaction.channel = thread
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+def _make_channel_interaction() -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = MagicMock(spec=discord.TextChannel)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+def _make_cog(
+    default_model: str = "sonnet",
+    settings_model: str | None = None,
+) -> SessionManageCog:
+    from claude_discord.cogs.session_manage import SessionManageCog
+
+    bot = MagicMock()
+    bot.channel_id = 999
+
+    repo = MagicMock()
+    repo.get = AsyncMock(return_value=None)
+    repo.list_all = AsyncMock(return_value=[])
+
+    settings_repo = MagicMock()
+    settings_repo.get = AsyncMock(return_value=settings_model)
+    settings_repo.set = AsyncMock()
+
+    runner = MagicMock()
+    runner.model = default_model
+
+    return SessionManageCog(
+        bot=bot,
+        repo=repo,
+        settings_repo=settings_repo,
+        runner=runner,
+    )
+
+
+class TestModelShow:
+    async def test_show_global_model_in_channel(self):
+        """In a channel (not thread), show the global model."""
+        cog = _make_cog(default_model="sonnet", settings_model=None)
+        interaction = _make_channel_interaction()
+        await cog.model_show.callback(cog, interaction)
+        call_args = interaction.response.send_message.call_args
+        embed = call_args.kwargs.get("embed")
+        assert embed is not None
+        # Global model should appear in the embed
+        assert "sonnet" in embed.description.lower() or any(
+            "sonnet" in str(f.value).lower() for f in embed.fields
+        )
+
+    async def test_show_settings_model_overrides_runner(self):
+        """settings_repo model takes precedence over runner.model."""
+        cog = _make_cog(default_model="sonnet", settings_model="opus")
+        interaction = _make_channel_interaction()
+        await cog.model_show.callback(cog, interaction)
+        call_args = interaction.response.send_message.call_args
+        embed = call_args.kwargs.get("embed")
+        assert embed is not None
+        text = embed.description + " ".join(str(f.value) for f in embed.fields)
+        assert "opus" in text.lower()
+
+    async def test_show_thread_model_from_session(self):
+        """In a thread with a session, also show the per-thread model."""
+        cog = _make_cog(default_model="sonnet", settings_model=None)
+        record = _make_record(thread_id=12345, model="haiku")
+        cog.repo.get = AsyncMock(return_value=record)
+
+        interaction = _make_thread_interaction(thread_id=12345)
+        await cog.model_show.callback(cog, interaction)
+        call_args = interaction.response.send_message.call_args
+        embed = call_args.kwargs.get("embed")
+        assert embed is not None
+        text = embed.description + " ".join(str(f.value) for f in embed.fields)
+        assert "haiku" in text.lower()
+
+    async def test_show_no_session_in_thread(self):
+        """In a thread with no session, only show global model."""
+        cog = _make_cog(default_model="sonnet", settings_model=None)
+        cog.repo.get = AsyncMock(return_value=None)
+
+        interaction = _make_thread_interaction(thread_id=12345)
+        await cog.model_show.callback(cog, interaction)
+        # Should succeed without error
+        assert interaction.response.send_message.called
+
+    async def test_show_no_settings_repo(self):
+        """Graceful fallback when settings_repo is None."""
+        from claude_discord.cogs.session_manage import SessionManageCog
+
+        bot = MagicMock()
+        repo = MagicMock()
+        repo.get = AsyncMock(return_value=None)
+        runner = MagicMock()
+        runner.model = "sonnet"
+
+        cog = SessionManageCog(bot=bot, repo=repo, runner=runner)
+        interaction = _make_channel_interaction()
+        await cog.model_show.callback(cog, interaction)
+        assert interaction.response.send_message.called
+
+
+class TestModelSet:
+    async def test_set_valid_model(self):
+        """Setting a valid model stores it in settings_repo."""
+        cog = _make_cog()
+        interaction = _make_channel_interaction()
+        await cog.model_set.callback(cog, interaction, model="opus")
+        cog.settings_repo.set.assert_awaited_once_with(SETTING_CLAUDE_MODEL, "opus")
+
+    async def test_set_model_sends_confirmation(self):
+        """Setting a model sends a confirmation embed."""
+        cog = _make_cog()
+        interaction = _make_channel_interaction()
+        await cog.model_set.callback(cog, interaction, model="haiku")
+        call_args = interaction.response.send_message.call_args
+        embed = call_args.kwargs.get("embed")
+        assert embed is not None
+        assert "haiku" in embed.description.lower() or any(
+            "haiku" in str(f.value).lower() for f in embed.fields
+        )
+
+    async def test_set_invalid_model_rejected(self):
+        """Setting an unsupported model shows an error, does not save."""
+        cog = _make_cog()
+        interaction = _make_channel_interaction()
+        await cog.model_set.callback(cog, interaction, model="gpt-4")
+        # settings_repo.set should NOT be called for invalid models
+        cog.settings_repo.set.assert_not_awaited()
+        call_args = interaction.response.send_message.call_args
+        assert call_args.kwargs.get("ephemeral") is True
+
+    async def test_set_model_no_settings_repo(self):
+        """When settings_repo is None, set sends ephemeral error."""
+        from claude_discord.cogs.session_manage import SessionManageCog
+
+        bot = MagicMock()
+        repo = MagicMock()
+        repo.get = AsyncMock(return_value=None)
+        runner = MagicMock()
+        runner.model = "sonnet"
+
+        cog = SessionManageCog(bot=bot, repo=repo, runner=runner)
+        interaction = _make_channel_interaction()
+        await cog.model_set.callback(cog, interaction, model="opus")
+        call_args = interaction.response.send_message.call_args
+        assert call_args.kwargs.get("ephemeral") is True
+
+    @pytest.mark.parametrize("model", ["haiku", "sonnet", "opus"])
+    async def test_all_valid_models_accepted(self, model: str):
+        """All documented model names should be accepted."""
+        cog = _make_cog()
+        interaction = _make_channel_interaction()
+        await cog.model_set.callback(cog, interaction, model=model)
+        cog.settings_repo.set.assert_awaited_once_with(SETTING_CLAUDE_MODEL, model)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -338,3 +338,16 @@ class TestSignalKillSuppression:
         error_events = [e for e in events if e.error]
         assert len(error_events) == 1
         assert "1" in error_events[0].error
+
+    def test_clone_with_model_override(self) -> None:
+        """clone() with model= overrides the runner's model for that clone."""
+        runner = ClaudeRunner(model="sonnet")
+        cloned = runner.clone(model="opus")
+        assert cloned.model == "opus"
+        assert runner.model == "sonnet"  # original unchanged
+
+    def test_clone_without_model_override_preserves_model(self) -> None:
+        """clone() without model= keeps the original model."""
+        runner = ClaudeRunner(model="haiku")
+        cloned = runner.clone()
+        assert cloned.model == "haiku"


### PR DESCRIPTION
## Summary

- `/model-show` — displays the current global model, runner default, and (if in a thread) the model used by that thread's last session
- `/model-set <model>` — persists a global model override in `settings_repo` (`haiku` / `sonnet` / `opus`); all new sessions pick it up immediately
- **Zero-Config**: `setup_bridge()` automatically wires `settings_repo` into `ClaudeChatCog` — no consumer code changes needed

## Implementation

- `ClaudeRunner.clone(model=...)` — optional model override per-clone without mutating the shared base runner
- `ClaudeChatCog._get_current_model()` — reads `claude_model` key from `settings_repo` before each clone; falls back to `runner.model`
- `SessionManageCog` — new `runner` param + lazy resolver via `bot.get_cog("ClaudeChatCog")`; new `SETTING_CLAUDE_MODEL` constant
- `setup.py` — wires `settings_repo` into `ClaudeChatCog`

## Test plan

- [x] 13 new tests in `tests/test_model_command.py`
- [x] `ClaudeRunner.clone(model=...)` unit tests
- [x] `/model-show` with settings override, runner default, per-thread session model, no-session-repo fallback
- [x] `/model-set` valid/invalid model, no-settings-repo error, all 3 model names accepted
- [x] Full suite: 638 tests passing
- [x] `ruff check` + `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)