### PR TITLE
[docs-sync] Update multilingual READMEs — /upgrade slash command, 674 tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ If the bot restarts mid-session, interrupted Claude sessions are automatically r
 - **DrainAware restart** — Waits for active sessions to finish before restarting
 - **Auto-resume marking** — Active sessions are automatically marked for resume on any shutdown (upgrade restart via `AutoUpgradeCog`, or any other shutdown via `ClaudeChatCog.cog_unload()`); they pick up where they left off after the bot comes back online
 - **Restart approval** — Optional gate to confirm upgrades before applying
+- **Manual upgrade trigger** — `/upgrade` slash command lets authorised users trigger the upgrade pipeline directly from Discord (opt-in via `slash_command_enabled=True`)
 
 ### Session Management
 - **Session sync** — Import CLI sessions as Discord threads (`/sync-sessions`)
@@ -462,11 +463,16 @@ config = UpgradeConfig(
     trigger_prefix="🔄 bot-upgrade",
     working_dir="/home/user/my-bot",
     restart_command=["sudo", "systemctl", "restart", "my-bot.service"],
-    restart_approval=True,  # React with ✅ to confirm restart
+    restart_approval=True,       # React with ✅ to confirm restart
+    slash_command_enabled=True,  # Enable /upgrade slash command (opt-in, default False)
 )
 
 await bot.add_cog(AutoUpgradeCog(bot, config))
 ```
+
+#### Manual Trigger via `/upgrade`
+
+When `slash_command_enabled=True`, any authorised user can run `/upgrade` directly in Discord to trigger the same upgrade pipeline — no webhook required. The command respects `upgrade_approval` and `restart_approval` gates, creates a progress thread, and gracefully handles concurrent runs (replies ephemerally if an upgrade is already in progress).
 
 Before restarting, `AutoUpgradeCog`:
 
@@ -598,7 +604,7 @@ claude_discord/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-666+ tests covering parser, chunker, repository, runner, streaming, webhook triggers, auto-upgrade, REST API, AskUserQuestion UI, thread dashboard, scheduled tasks, session sync, AI Lounge, startup resume, model switching, and compact detection.
+674+ tests covering parser, chunker, repository, runner, streaming, webhook triggers, auto-upgrade (including `/upgrade` slash command), REST API, AskUserQuestion UI, thread dashboard, scheduled tasks, session sync, AI Lounge, startup resume, model switching, and compact detection.
 
 ---
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -171,6 +171,7 @@ Bot の再起動中にセッションが中断された場合、Bot が再起動
 - **DrainAware 再起動** — 再起動前にアクティブセッションの完了を待機
 - **自動リジューム登録** — アップグレード再起動（`AutoUpgradeCog`）または任意のシャットダウン（`ClaudeChatCog.cog_unload()`）でアクティブセッションを自動登録。Bot 再起動後に中断した作業を自動的に再開
 - **再起動承認** — アップグレード適用前の確認ゲート（オプション）
+- **手動アップグレードトリガー** — `/upgrade` スラッシュコマンドで Discord から直接アップグレードパイプラインを実行（`slash_command_enabled=True` でオプトイン）
 
 ### セッション管理
 - **セッション同期** — CLI セッションを Discord スレッドにインポート（`/sync-sessions`）
@@ -400,11 +401,16 @@ config = UpgradeConfig(
     trigger_prefix="🔄 bot-upgrade",
     working_dir="/home/user/my-bot",
     restart_command=["sudo", "systemctl", "restart", "my-bot.service"],
-    restart_approval=True,  # 再起動確認に ✅ リアクション
+    restart_approval=True,       # 再起動確認に ✅ リアクション
+    slash_command_enabled=True,  # /upgrade スラッシュコマンドを有効化（オプトイン、デフォルト False）
 )
 
 await bot.add_cog(AutoUpgradeCog(bot, config))
 ```
+
+#### `/upgrade` スラッシュコマンドによる手動トリガー
+
+`slash_command_enabled=True` の場合、認可されたユーザーが Discord から `/upgrade` を実行することで、Webhook なしで同じアップグレードパイプラインをトリガーできます。`upgrade_approval` および `restart_approval` のゲートが適用され、進捗スレッドが作成されます。すでにアップグレードが実行中の場合はエフェメラルで通知します。
 
 再起動前に `AutoUpgradeCog` は以下の手順を実行します:
 
@@ -536,7 +542,7 @@ claude_discord/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-666 件以上のテストがパーサー、チャンカー、リポジトリ、ランナー、ストリーミング、Webhook トリガー、自動アップグレード、REST API、AskUserQuestion UI、スレッドダッシュボード、スケジュールタスク、セッション同期、AI Lounge、スタートアップリジューム、モデル切り替え、コンパクト検出をカバーしています。
+674 件以上のテストがパーサー、チャンカー、リポジトリ、ランナー、ストリーミング、Webhook トリガー、自動アップグレード（`/upgrade` スラッシュコマンド含む）、REST API、AskUserQuestion UI、スレッドダッシュボード、スケジュールタスク、セッション同期、AI Lounge、スタートアップリジューム、モデル切り替え、コンパクト検出をカバーしています。
 
 ---
 


### PR DESCRIPTION
## Summary
- Documented the new `/upgrade` slash command added to `AutoUpgradeCog` (opt-in via `slash_command_enabled=True` in `UpgradeConfig`)
- Updated `UpgradeConfig` code examples to show the new `slash_command_enabled` option
- Updated test count from 666+ to 674+ to reflect the new slash command test suite

## 概要
- `AutoUpgradeCog` に追加された `/upgrade` スラッシュコマンドをドキュメント化（`UpgradeConfig` の `slash_command_enabled=True` でオプトイン）
- `UpgradeConfig` のコード例に `slash_command_enabled` オプションを追加
- テスト数を 666+ から 674+ に更新（スラッシュコマンドのテストスイートが追加されたため）

## Changed files
- `README.md`
- `docs/ja/README.md`

---
🤖 Auto-generated by [docs-sync](https://github.com/ebibibi/claude-code-discord-bridge)
