### PR TITLE
[docs-sync] Update multilingual READMEs — UpgradeApprovalView button, 682 tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ If the bot restarts mid-session, interrupted Claude sessions are automatically r
 - **Auto-upgrade** — Automatically update the bot when upstream packages are released
 - **DrainAware restart** — Waits for active sessions to finish before restarting
 - **Auto-resume marking** — Active sessions are automatically marked for resume on any shutdown (upgrade restart via `AutoUpgradeCog`, or any other shutdown via `ClaudeChatCog.cog_unload()`); they pick up where they left off after the bot comes back online
-- **Restart approval** — Optional gate to confirm upgrades before applying
+- **Restart approval** — Optional gate to confirm upgrades; approve via ✅ reaction in the upgrade thread or via button posted to the parent channel
 - **Manual upgrade trigger** — `/upgrade` slash command lets authorised users trigger the upgrade pipeline directly from Discord (opt-in via `slash_command_enabled=True`)
 
 ### Session Management
@@ -463,7 +463,7 @@ config = UpgradeConfig(
     trigger_prefix="🔄 bot-upgrade",
     working_dir="/home/user/my-bot",
     restart_command=["sudo", "systemctl", "restart", "my-bot.service"],
-    restart_approval=True,       # React with ✅ to confirm restart
+    restart_approval=True,       # React ✅ in thread, or click button in channel
     slash_command_enabled=True,  # Enable /upgrade slash command (opt-in, default False)
 )
 
@@ -604,7 +604,7 @@ claude_discord/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-674+ tests covering parser, chunker, repository, runner, streaming, webhook triggers, auto-upgrade (including `/upgrade` slash command), REST API, AskUserQuestion UI, thread dashboard, scheduled tasks, session sync, AI Lounge, startup resume, model switching, and compact detection.
+682+ tests covering parser, chunker, repository, runner, streaming, webhook triggers, auto-upgrade (including `/upgrade` slash command and approval button), REST API, AskUserQuestion UI, thread dashboard, scheduled tasks, session sync, AI Lounge, startup resume, model switching, and compact detection.
 
 ---
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -170,7 +170,7 @@ Bot の再起動中にセッションが中断された場合、Bot が再起動
 - **自動アップグレード** — 上流パッケージリリース時に Bot を自動更新
 - **DrainAware 再起動** — 再起動前にアクティブセッションの完了を待機
 - **自動リジューム登録** — アップグレード再起動（`AutoUpgradeCog`）または任意のシャットダウン（`ClaudeChatCog.cog_unload()`）でアクティブセッションを自動登録。Bot 再起動後に中断した作業を自動的に再開
-- **再起動承認** — アップグレード適用前の確認ゲート（オプション）
+- **再起動承認** — アップグレード適用前の確認ゲート（オプション）。アップグレードスレッドへの ✅ リアクション、または親チャンネルに投稿されるボタンのどちらでも承認可能
 - **手動アップグレードトリガー** — `/upgrade` スラッシュコマンドで Discord から直接アップグレードパイプラインを実行（`slash_command_enabled=True` でオプトイン）
 
 ### セッション管理
@@ -401,7 +401,7 @@ config = UpgradeConfig(
     trigger_prefix="🔄 bot-upgrade",
     working_dir="/home/user/my-bot",
     restart_command=["sudo", "systemctl", "restart", "my-bot.service"],
-    restart_approval=True,       # 再起動確認に ✅ リアクション
+    restart_approval=True,       # スレッドの ✅ リアクション、またはチャンネルのボタンで承認
     slash_command_enabled=True,  # /upgrade スラッシュコマンドを有効化（オプトイン、デフォルト False）
 )
 
@@ -542,7 +542,7 @@ claude_discord/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-674 件以上のテストがパーサー、チャンカー、リポジトリ、ランナー、ストリーミング、Webhook トリガー、自動アップグレード（`/upgrade` スラッシュコマンド含む）、REST API、AskUserQuestion UI、スレッドダッシュボード、スケジュールタスク、セッション同期、AI Lounge、スタートアップリジューム、モデル切り替え、コンパクト検出をカバーしています。
+682 件以上のテストがパーサー、チャンカー、リポジトリ、ランナー、ストリーミング、Webhook トリガー、自動アップグレード（`/upgrade` スラッシュコマンドおよび承認ボタン含む）、REST API、AskUserQuestion UI、スレッドダッシュボード、スケジュールタスク、セッション同期、AI Lounge、スタートアップリジューム、モデル切り替え、コンパクト検出をカバーしています。
 
 ---
 


### PR DESCRIPTION
## Summary
- Added `UpgradeApprovalView` to `AutoUpgradeCog`: restart approval now accepts both ✅ reaction in the upgrade thread AND a button posted to the parent channel (no need to scroll up to find the thread)
- Updated test count from 674+ to 682+ (8 new tests for `UpgradeApprovalView` and button-based approval integration)

## 概要
- `AutoUpgradeCog` に `UpgradeApprovalView` を追加: 再起動承認がアップグレードスレッドの ✅ リアクションと親チャンネルに投稿されるボタンの両方で可能になりました（スレッドまで遡らずに承認可能）
- テスト数を 674+ から 682+ に更新（`UpgradeApprovalView` とボタン承認の統合テスト 8 件追加）

## Changed files
- `README.md`
- `docs/ja/README.md`

---
🤖 Auto-generated by [docs-sync](https://github.com/ebibibi/claude-code-discord-bridge)
