### PR TITLE
[docs-sync] Update multilingual READMEs — /upgrade thread support, 685 tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ await bot.add_cog(AutoUpgradeCog(bot, config))
 
 #### Manual Trigger via `/upgrade`
 
-When `slash_command_enabled=True`, any authorised user can run `/upgrade` directly in Discord to trigger the same upgrade pipeline — no webhook required. The command respects `upgrade_approval` and `restart_approval` gates, creates a progress thread, and gracefully handles concurrent runs (replies ephemerally if an upgrade is already in progress).
+When `slash_command_enabled=True`, any authorised user can run `/upgrade` directly in Discord to trigger the same upgrade pipeline — no webhook required. The command works from both text channels and threads (running it inside a thread creates the upgrade thread in the parent channel). It respects `upgrade_approval` and `restart_approval` gates, creates a progress thread, and gracefully handles concurrent runs (replies ephemerally if an upgrade is already in progress).
 
 Before restarting, `AutoUpgradeCog`:
 
@@ -604,7 +604,7 @@ claude_discord/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-682+ tests covering parser, chunker, repository, runner, streaming, webhook triggers, auto-upgrade (including `/upgrade` slash command and approval button), REST API, AskUserQuestion UI, thread dashboard, scheduled tasks, session sync, AI Lounge, startup resume, model switching, and compact detection.
+685+ tests covering parser, chunker, repository, runner, streaming, webhook triggers, auto-upgrade (including `/upgrade` slash command, thread-invocation, and approval button), REST API, AskUserQuestion UI, thread dashboard, scheduled tasks, session sync, AI Lounge, startup resume, model switching, and compact detection.
 
 ---
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -410,7 +410,7 @@ await bot.add_cog(AutoUpgradeCog(bot, config))
 
 #### `/upgrade` スラッシュコマンドによる手動トリガー
 
-`slash_command_enabled=True` の場合、認可されたユーザーが Discord から `/upgrade` を実行することで、Webhook なしで同じアップグレードパイプラインをトリガーできます。`upgrade_approval` および `restart_approval` のゲートが適用され、進捗スレッドが作成されます。すでにアップグレードが実行中の場合はエフェメラルで通知します。
+`slash_command_enabled=True` の場合、認可されたユーザーが Discord から `/upgrade` を実行することで、Webhook なしで同じアップグレードパイプラインをトリガーできます。テキストチャンネルとスレッドの両方から実行でき（スレッド内から実行した場合は親チャンネルにアップグレードスレッドを作成します）。`upgrade_approval` および `restart_approval` のゲートが適用され、進捗スレッドが作成されます。すでにアップグレードが実行中の場合はエフェメラルで通知します。
 
 再起動前に `AutoUpgradeCog` は以下の手順を実行します:
 
@@ -542,7 +542,7 @@ claude_discord/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-682 件以上のテストがパーサー、チャンカー、リポジトリ、ランナー、ストリーミング、Webhook トリガー、自動アップグレード（`/upgrade` スラッシュコマンドおよび承認ボタン含む）、REST API、AskUserQuestion UI、スレッドダッシュボード、スケジュールタスク、セッション同期、AI Lounge、スタートアップリジューム、モデル切り替え、コンパクト検出をカバーしています。
+685 件以上のテストがパーサー、チャンカー、リポジトリ、ランナー、ストリーミング、Webhook トリガー、自動アップグレード（`/upgrade` スラッシュコマンド、スレッド内実行、承認ボタン含む）、REST API、AskUserQuestion UI、スレッドダッシュボード、スケジュールタスク、セッション同期、AI Lounge、スタートアップリジューム、モデル切り替え、コンパクト検出をカバーしています。
 
 ---
 


### PR DESCRIPTION
## Summary
- Fixed `/upgrade` slash command documentation to reflect that it now works from both text channels and Discord threads (running from a thread creates the upgrade thread in the parent channel)
- Updated test count from 682+ to 685+ to reflect the 3 new tests added for thread-invocation scenarios

## 概要
- `/upgrade` スラッシュコマンドのドキュメントを更新。テキストチャンネルだけでなくDiscordスレッド内からも実行可能になったことを反映（スレッド内から実行した場合は親チャンネルにアップグレードスレッドを作成）
- テスト数を 682+ から 685+ に更新（スレッド内実行シナリオ用の新規テスト3件の追加を反映）

## Changed files
- `README.md`
- `docs/ja/README.md`

---
🤖 Auto-generated by [docs-sync](https://github.com/ebibibi/claude-code-discord-bridge)
