### PR TITLE
docs: highlight mobile + parallel threads use case in README hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**Run multiple Claude Code sessions in parallel — safely — through Discord.**
+**Use Claude Code on your phone. Multiple threads. All at once. Real development included.**
 
-Each Discord thread becomes an isolated Claude Code session. Spin up as many as you need: work on a feature in one thread, review a PR in another, run a scheduled task in a third. The bridge handles coordination automatically so concurrent sessions don't clobber each other.
+Open Claude Code from your smartphone's Discord app, spin up multiple threads, and run parallel development sessions — all without touching a keyboard. Each Discord thread becomes a fully isolated Claude Code session. Work on a feature in one thread, review a PR in another, and run a background task in a third — simultaneously. The bridge handles all the coordination so sessions never clobber each other.
 
 **[日本語](docs/ja/README.md)** | **[简体中文](docs/zh-CN/README.md)** | **[한국어](docs/ko/README.md)** | **[Español](docs/es/README.md)** | **[Português](docs/pt-BR/README.md)** | **[Français](docs/fr/README.md)**
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -9,9 +9,9 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**複数の Claude Code セッションを安全に Discord 経由で並列実行するフレームワーク。**
+**スマホの Discord から Claude Code をガンガン使おう。複数スレッドを同時に回して、本格開発もOK。**
 
-各 Discord スレッドが独立した Claude Code セッションになります。必要なだけスレッドを立ち上げ、あるスレッドで機能開発、別のスレッドで PR レビュー、さらに別のスレッドでスケジュールタスクを実行できます。並行セッションの調整はブリッジが自動的に処理します。
+Discord のスレッドを開くだけで、Claude Code セッションが立ち上がります。スマートフォンから何スレッドでも並行して動かせます — あるスレッドで機能開発、別のスレッドで PR レビュー、さらに別のスレッドでバックグラウンドタスク。全部同時進行。コンフリクトしないように、ブリッジがセッション間の調整を完全自動化します。
 
 **[English](../../README.md)** | **[简体中文](../zh-CN/README.md)** | **[한국어](../ko/README.md)** | **[Español](../es/README.md)** | **[Português](../pt-BR/README.md)** | **[Français](../fr/README.md)**
 


### PR DESCRIPTION
## Summary

- README冒頭の「売り文句」を「スマホで複数スレッド同時開発」にフォーカスして書き直し
- 英語版: `README.md` のタグラインと説明文を刷新
- 日本語版: `docs/ja/README.md` も同等の日本語コピーに更新

## 変更前 → 変更後

**EN (before):** "Run multiple Claude Code sessions in parallel — safely — through Discord."  
**EN (after):** "Use Claude Code on your phone. Multiple threads. All at once. Real development included."

**JA (before):** "複数の Claude Code セッションを安全に Discord 経由で並列実行するフレームワーク。"  
**JA (after):** "スマホの Discord から Claude Code をガンガン使おう。複数スレッドを同時に回して、本格開発もOK。"

## Test plan

- [ ] README.md の冒頭がスマホ + 並列開発ユースケースを明確に伝えていることを確認
- [ ] docs/ja/README.md も日本語として自然であることを確認
- [ ] 既存のバッジ・リンク・免責事項に影響がないことを確認