### PR TITLE
fix(embeds): correct context window % and show remaining until compact

### DIFF
--- a/claude_discord/claude/parser.py
+++ b/claude_discord/claude/parser.py
@@ -162,6 +162,7 @@ def _parse_result(data: dict[str, Any], event: StreamEvent) -> None:
         event.input_tokens = usage.get("input_tokens")
         event.output_tokens = usage.get("output_tokens")
         event.cache_read_tokens = usage.get("cache_read_input_tokens")
+        event.cache_creation_tokens = usage.get("cache_creation_input_tokens")
 
     # Extract context window size from modelUsage (any model key).
     model_usage = data.get("modelUsage", {})

--- a/claude_discord/claude/types.py
+++ b/claude_discord/claude/types.py
@@ -140,6 +140,7 @@ class StreamEvent:
     input_tokens: int | None = None
     output_tokens: int | None = None
     cache_read_tokens: int | None = None
+    cache_creation_tokens: int | None = None
     context_window: int | None = None
     error: str | None = None
 

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -249,6 +249,7 @@ class EventProcessor:
                     event.output_tokens,
                     event.cache_read_tokens,
                     event.context_window,
+                    event.cache_creation_tokens,
                 )
             )
             if self._config.status:


### PR DESCRIPTION
## Summary

- **Root cause of 2911%**: `output_tokens` was incorrectly included in the context usage numerator. Claude Code's own `lrH()` function only uses `input_tokens + cache_creation_input_tokens + cache_read_input_tokens` — output tokens are not yet *in* the context window (they become cached input on the next turn). Additionally, `cache_creation_tokens` was missing from the calculation.
- **Cap at 100%**: Added `min(100.0, ...)` to prevent impossible values regardless of data.
- **Remaining % display**: Changed `"X% context"` → `"X% ctx (Y% until compact)"` so users instantly see headroom before auto-compact (threshold: 83.5%). When above threshold, shows `"X% ctx ⚠️"` inline.

## Before / After

Before:
```
✅ Done
⏱️ 615.6s | 📊 57↑ 33.2k↓ (99% cache) | 📊 2911% context
```

After (example, 3% used with 80% headroom):
```
✅ Done
⏱️ 615.6s | 📊 57↑ 33.2k↓ (99% cache) | 📊 3% ctx (81% until compact)
```

## Test plan

- [x] 690 tests pass
- [x] `test_output_tokens_do_not_affect_context_pct` — output size doesn't change ctx%
- [x] `test_context_usage_capped_at_100_percent` — no values > 100%
- [x] `test_context_usage_shows_remaining_until_compact` — new display format
- [x] `test_above_threshold_shows_warning_icon_in_description` — ⚠️ inline when near compact
- [x] `test_context_usage_includes_cache_creation` — cache_creation_tokens counted

🤖 Generated with [Claude Code](https://claude.com/claude-code)