### PR TITLE
feat: TodoWrite viz, image attachments, bidirectional runner, Plan Mode, Permission & MCP elicitation

### DIFF
--- a/claude_discord/claude/types.py
+++ b/claude_discord/claude/types.py
@@ -39,6 +39,8 @@ class ToolCategory(Enum):
     WEB = "web"
     THINK = "think"
     ASK = "ask"
+    TASK = "task"
+    PLAN = "plan"
     OTHER = "other"
 
 
@@ -56,6 +58,8 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "WebSearch": ToolCategory.WEB,
     "Task": ToolCategory.OTHER,
     "AskUserQuestion": ToolCategory.ASK,
+    "TodoWrite": ToolCategory.TASK,
+    "ExitPlanMode": ToolCategory.PLAN,
 }
 
 
@@ -75,6 +79,36 @@ class AskQuestion:
     header: str = ""
     multi_select: bool = False
     options: list[AskOption] = field(default_factory=list)
+
+
+@dataclass
+class TodoItem:
+    """A single item in a TodoWrite task list."""
+
+    content: str
+    status: str  # "pending", "in_progress", "completed"
+    active_form: str = ""  # Present-continuous label shown while in_progress
+
+
+@dataclass
+class PermissionRequest:
+    """A permission request from Claude Code for a tool execution."""
+
+    request_id: str
+    tool_name: str
+    tool_input: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ElicitationRequest:
+    """An elicitation request from an MCP server."""
+
+    request_id: str
+    server_name: str
+    mode: str  # "form-mode" or "url-mode"
+    message: str = ""
+    url: str = ""  # url-mode only
+    schema: dict[str, Any] = field(default_factory=dict)  # form-mode only
 
 
 @dataclass
@@ -130,6 +164,10 @@ class StreamEvent:
     thinking: str | None = None
     has_redacted_thinking: bool = False
     ask_questions: list[AskQuestion] | None = None
+    todo_list: list[TodoItem] | None = None
+    is_plan_approval: bool = False
+    permission_request: PermissionRequest | None = None
+    elicitation: ElicitationRequest | None = None
     is_compact: bool = False
     compact_trigger: str | None = None
     compact_pre_tokens: int | None = None
@@ -162,3 +200,5 @@ class SessionState:
     partial_text: str = ""
     active_tools: dict[str, discord.Message] = field(default_factory=dict)
     active_timers: dict[str, asyncio.Task[None]] = field(default_factory=dict)
+    # TodoWrite: reference to the live todo embed message (edited in-place on each update)
+    todo_message: discord.Message | None = None

--- a/claude_discord/cogs/run_config.py
+++ b/claude_discord/cogs/run_config.py
@@ -62,6 +62,9 @@ class RunConfig:
     lounge_repo: LoungeRepository | None = None
     stop_view: StopView | None = None
     worktree_manager: WorktreeManager | None = None
+    # Paths to downloaded image tempfiles passed via --image flags.
+    # Cleaned up in run_claude_with_config() finally block.
+    image_paths: list[str] | None = None
 
     # Prevent accidental field mutation — RunConfig is a value object.
     # Use dataclasses.replace() to create modified copies.

--- a/claude_discord/discord_ui/elicitation_view.py
+++ b/claude_discord/discord_ui/elicitation_view.py
@@ -1,0 +1,163 @@
+"""Discord UI for MCP elicitation requests.
+
+MCP servers can request interactive input from the user via elicitation.
+Two modes are supported:
+
+- url-mode: Show a URL button (the user visits the URL and the MCP server
+  handles the rest). We inject a "done" response after the button is clicked.
+
+- form-mode: Show a Modal with text inputs derived from the JSON schema.
+  We collect the form values and inject them as the response.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import discord
+
+from ..claude.types import ElicitationRequest
+
+logger = logging.getLogger(__name__)
+
+ELICITATION_TIMEOUT = 300  # 5 minutes
+
+
+class ElicitationUrlView(discord.ui.View):
+    """Single button opening a URL for url-mode elicitation."""
+
+    def __init__(self, runner, request: ElicitationRequest) -> None:
+        super().__init__(timeout=ELICITATION_TIMEOUT)
+        self._runner = runner
+        self._request = request
+        # Add the URL as a link button (no callback needed — Discord opens it).
+        if request.url:
+            self.add_item(discord.ui.Button(label="🔗 Open link", url=request.url))
+        # "Done" button to confirm the user completed the URL flow.
+        self._done_added = False
+
+    @discord.ui.button(label="✅ Done", style=discord.ButtonStyle.success)
+    async def done(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        await interaction.response.defer()
+        await self._runner.inject_tool_result(self._request.request_id, {"completed": True})
+        self.stop()
+        for child in self.children:
+            if isinstance(child, discord.ui.Button):
+                child.disabled = True
+        if interaction.message:
+            await interaction.message.edit(view=self)
+        logger.info("Elicitation (url-mode) completed (request_id=%s)", self._request.request_id)
+
+    @discord.ui.button(label="❌ Cancel", style=discord.ButtonStyle.secondary)
+    async def cancel(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        await interaction.response.defer()
+        await self._runner.inject_tool_result(self._request.request_id, {"completed": False})
+        self.stop()
+        for child in self.children:
+            if isinstance(child, discord.ui.Button):
+                child.disabled = True
+        if interaction.message:
+            await interaction.message.edit(view=self)
+
+    async def on_timeout(self) -> None:
+        await self._runner.inject_tool_result(self._request.request_id, {"completed": False})
+
+
+def _schema_to_modal_fields(schema: dict[str, Any]) -> list[tuple[str, str, bool]]:
+    """Extract (name, description, required) tuples from a JSON schema object.
+
+    Only handles simple flat schemas (object with string properties).
+    Returns at most 5 fields (Discord Modal limit).
+    """
+    properties = schema.get("properties", {})
+    required_keys: set[str] = set(schema.get("required", []))
+    fields = []
+    for key, prop in list(properties.items())[:5]:
+        desc = prop.get("description", prop.get("title", key))
+        fields.append((key, desc, key in required_keys))
+    return fields
+
+
+class ElicitationFormModal(discord.ui.Modal):
+    """Modal for form-mode elicitation. Fields are dynamically generated from JSON schema."""
+
+    def __init__(self, runner, request: ElicitationRequest) -> None:
+        title = f"Input required — {request.server_name}"[:45]
+        super().__init__(title=title, timeout=ELICITATION_TIMEOUT)
+        self._runner = runner
+        self._request = request
+
+        # Dynamically add TextInput components from the schema.
+        self._field_names: list[str] = []
+        for name, desc, required in _schema_to_modal_fields(request.schema):
+            self._field_names.append(name)
+            self.add_item(
+                discord.ui.TextInput(
+                    label=name[:45],
+                    placeholder=desc[:100] if desc else None,
+                    required=required,
+                    max_length=1000,
+                )
+            )
+
+        # Fallback: if schema has no properties, add a single free-form field.
+        if not self._field_names:
+            self._field_names = ["response"]
+            self.add_item(
+                discord.ui.TextInput(
+                    label="Response",
+                    placeholder=request.message[:100] if request.message else "Enter your response",
+                    required=True,
+                    style=discord.TextStyle.paragraph,
+                )
+            )
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer()
+        # Collect field values into a dict.
+        values: dict[str, str] = {}
+        for child, name in zip(self.children, self._field_names, strict=False):
+            if isinstance(child, discord.ui.TextInput):
+                values[name] = child.value
+
+        await self._runner.inject_tool_result(self._request.request_id, {"values": values})
+        logger.info(
+            "Elicitation (form-mode) submitted (request_id=%s, fields=%s)",
+            self._request.request_id,
+            list(values.keys()),
+        )
+
+
+class ElicitationFormView(discord.ui.View):
+    """Single button that opens the form Modal for form-mode elicitation."""
+
+    def __init__(self, runner, request: ElicitationRequest) -> None:
+        super().__init__(timeout=ELICITATION_TIMEOUT)
+        self._runner = runner
+        self._request = request
+
+    @discord.ui.button(label="📝 Fill in form", style=discord.ButtonStyle.primary)
+    async def open_form(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        modal = ElicitationFormModal(self._runner, self._request)
+        await interaction.response.send_modal(modal)
+        self.stop()
+        for child in self.children:
+            if isinstance(child, discord.ui.Button):
+                child.disabled = True
+        if interaction.message:
+            await interaction.message.edit(view=self)
+
+    @discord.ui.button(label="❌ Cancel", style=discord.ButtonStyle.secondary)
+    async def cancel(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        await interaction.response.defer()
+        await self._runner.inject_tool_result(self._request.request_id, {"completed": False})
+        self.stop()
+        for child in self.children:
+            if isinstance(child, discord.ui.Button):
+                child.disabled = True
+        if interaction.message:
+            await interaction.message.edit(view=self)
+
+    async def on_timeout(self) -> None:
+        await self._runner.inject_tool_result(self._request.request_id, {"completed": False})

--- a/claude_discord/discord_ui/permission_view.py
+++ b/claude_discord/discord_ui/permission_view.py
@@ -1,0 +1,64 @@
+"""Discord UI for tool permission requests.
+
+When Claude needs to execute a tool in a non-permissive mode, it emits a
+permission_request system event. This module provides the View with
+Allow / Deny buttons and injects the response via runner.inject_tool_result().
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+from ..claude.types import PermissionRequest
+
+logger = logging.getLogger(__name__)
+
+PERMISSION_TIMEOUT = 120  # 2 minutes to approve/deny
+
+
+class PermissionView(discord.ui.View):
+    """Allow / Deny buttons for tool permission requests."""
+
+    def __init__(self, runner, request: PermissionRequest) -> None:
+        super().__init__(timeout=PERMISSION_TIMEOUT)
+        self._runner = runner
+        self._request = request
+
+    @discord.ui.button(label="✅ Allow", style=discord.ButtonStyle.success)
+    async def allow(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        await interaction.response.defer()
+        await self._runner.inject_tool_result(self._request.request_id, {"approved": True})
+        self.stop()
+        for child in self.children:
+            if isinstance(child, discord.ui.Button):
+                child.disabled = True
+        if interaction.message:
+            await interaction.message.edit(view=self)
+        logger.info(
+            "Permission allowed: %s (request_id=%s)",
+            self._request.tool_name,
+            self._request.request_id,
+        )
+
+    @discord.ui.button(label="❌ Deny", style=discord.ButtonStyle.danger)
+    async def deny(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        await interaction.response.defer()
+        await self._runner.inject_tool_result(self._request.request_id, {"approved": False})
+        self.stop()
+        for child in self.children:
+            if isinstance(child, discord.ui.Button):
+                child.disabled = True
+        if interaction.message:
+            await interaction.message.edit(view=self)
+        logger.info(
+            "Permission denied: %s (request_id=%s)",
+            self._request.tool_name,
+            self._request.request_id,
+        )
+
+    async def on_timeout(self) -> None:
+        """Auto-deny if no response within timeout."""
+        await self._runner.inject_tool_result(self._request.request_id, {"approved": False})
+        logger.info("Permission request timed out (request_id=%s)", self._request.request_id)

--- a/claude_discord/discord_ui/plan_view.py
+++ b/claude_discord/discord_ui/plan_view.py
@@ -1,0 +1,56 @@
+"""Discord UI for Plan Mode approval (ExitPlanMode).
+
+When Claude calls ExitPlanMode, it has finished planning and waits for the
+user to approve (execute the plan) or cancel. This module provides the View
+with Approve / Cancel buttons and injects the response via runner.inject_tool_result().
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+logger = logging.getLogger(__name__)
+
+# Timeout for plan approval — if no response in 5 minutes, cancel.
+PLAN_APPROVAL_TIMEOUT = 300
+
+
+class PlanApprovalView(discord.ui.View):
+    """Two-button view: ✅ Approve | ❌ Cancel for plan mode."""
+
+    def __init__(self, runner, request_id: str) -> None:
+        super().__init__(timeout=PLAN_APPROVAL_TIMEOUT)
+        self._runner = runner
+        self._request_id = request_id
+
+    @discord.ui.button(label="✅ Approve", style=discord.ButtonStyle.success)
+    async def approve(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        await interaction.response.defer()
+        await self._runner.inject_tool_result(self._request_id, {"approved": True})
+        self.stop()
+        # Disable buttons so they can't be clicked again
+        for child in self.children:
+            if isinstance(child, discord.ui.Button):
+                child.disabled = True
+        if interaction.message:
+            await interaction.message.edit(view=self)
+        logger.info("Plan approved (request_id=%s)", self._request_id)
+
+    @discord.ui.button(label="❌ Cancel", style=discord.ButtonStyle.danger)
+    async def cancel(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        await interaction.response.defer()
+        await self._runner.inject_tool_result(self._request_id, {"approved": False})
+        self.stop()
+        for child in self.children:
+            if isinstance(child, discord.ui.Button):
+                child.disabled = True
+        if interaction.message:
+            await interaction.message.edit(view=self)
+        logger.info("Plan cancelled (request_id=%s)", self._request_id)
+
+    async def on_timeout(self) -> None:
+        """Auto-cancel if no response within timeout."""
+        await self._runner.inject_tool_result(self._request_id, {"approved": False})
+        logger.info("Plan approval timed out (request_id=%s)", self._request_id)

--- a/tests/test_embeds.py
+++ b/tests/test_embeds.py
@@ -299,3 +299,59 @@ class TestRedactedThinkingEmbed:
         regular = thinking_embed("x")
         redacted = redacted_thinking_embed()
         assert redacted.colour.value != regular.colour.value
+
+
+class TestTodoEmbed:
+    """Tests for todo_embed()."""
+
+    def test_shows_all_statuses(self) -> None:
+        from claude_discord.claude.types import TodoItem
+        from claude_discord.discord_ui.embeds import todo_embed
+
+        todos = [
+            TodoItem(content="Task A", status="completed"),
+            TodoItem(content="Task B", status="in_progress", active_form="Doing Task B"),
+            TodoItem(content="Task C", status="pending"),
+        ]
+        embed = todo_embed(todos)
+        assert embed.description is not None
+        assert "✅" in embed.description
+        assert "🔄" in embed.description
+        assert "⬜" in embed.description
+
+    def test_in_progress_shows_active_form(self) -> None:
+        from claude_discord.claude.types import TodoItem
+        from claude_discord.discord_ui.embeds import todo_embed
+
+        todos = [TodoItem(content="Task", status="in_progress", active_form="Running Task")]
+        embed = todo_embed(todos)
+        assert embed.description is not None
+        assert "Running Task" in embed.description
+
+    def test_in_progress_falls_back_to_content(self) -> None:
+        from claude_discord.claude.types import TodoItem
+        from claude_discord.discord_ui.embeds import todo_embed
+
+        todos = [TodoItem(content="Task without active form", status="in_progress", active_form="")]
+        embed = todo_embed(todos)
+        assert embed.description is not None
+        assert "Task without active form" in embed.description
+
+    def test_title_shows_progress_count(self) -> None:
+        from claude_discord.claude.types import TodoItem
+        from claude_discord.discord_ui.embeds import todo_embed
+
+        todos = [
+            TodoItem(content="Done", status="completed"),
+            TodoItem(content="Pending", status="pending"),
+        ]
+        embed = todo_embed(todos)
+        assert embed.title is not None
+        assert "1/2" in embed.title
+
+    def test_empty_list(self) -> None:
+        from claude_discord.discord_ui.embeds import todo_embed
+
+        embed = todo_embed([])
+        assert embed.description is not None
+        assert "no tasks" in embed.description


### PR DESCRIPTION
## Summary

Implements all remaining open issues in one cohesive PR. Picks up from the unfinished `feature/issue-46-50-44-47-48` branch draft (types + parser stubs), completes the full stack, and rebases onto current `main`.

### #46 — TodoWrite visualization
- `TodoItem` dataclass + `_parse_todo_items()` parser
- `todo_embed()`: renders ✅/🔄/⬜ status per item with `(done/total)` counter
- `EventProcessor._handle_todo_write()`: **posts once, edits in-place** on each subsequent `TodoWrite` call — no thread flooding
- `SessionState.todo_message` holds the live embed reference

### #43 — Image attachments
- `_build_prompt_and_images()`: downloads `image/*` Discord attachments to tempfiles
- `runner.py`: `image_paths` param → `--image <path>` flags per file
- `RunConfig.image_paths` + `_cleanup_image_tempfiles()` in `finally` block

### #50 — Bidirectional runner (foundation)
- `stdin=asyncio.subprocess.PIPE` added to subprocess launch
- `ClaudeRunner.inject_tool_result(request_id, data)`: writes JSON line to stdin
- Required foundation for #44, #47, #48

### #44 — Plan Mode (ExitPlanMode)
- `plan_embed()`: emerald-green embed
- `PlanApprovalView`: ✅ Approve / ❌ Cancel buttons, 300 s timeout → auto-cancel
- `EventProcessor._handle_plan_approval()`: triggered on `event.is_plan_approval`

### #47 — Permission requests
- `PermissionRequest` dataclass + `permission_request` subtype in parser
- `permission_embed()`: shows tool name + formatted JSON input
- `PermissionView`: ✅ Allow / ❌ Deny, 120 s timeout → auto-deny
- `EventProcessor._handle_permission_request()`

### #48 — MCP elicitation
- `ElicitationRequest` dataclass + `elicitation` subtype in parser
- `elicitation_embed()`
- `ElicitationUrlView`: URL link button + ✅ Done / ❌ Cancel
- `ElicitationFormView` + `ElicitationFormModal`: dynamically generates `TextInput` fields from JSON schema (up to 5 fields)
- `EventProcessor._handle_elicitation()`

## Test plan

- [x] 709 tests pass (`python -m pytest -q`)
- [x] `pre-commit` ruff format + lint pass
- [x] Rebased onto current `main` (includes context usage fix, append-system-prompt, etc.)
- [ ] Manual smoke test: send image → bot passes to Claude via `--image`
- [ ] Manual smoke test: TodoWrite in a session → single embed updates in-place
- [ ] Manual smoke test: Plan Mode → Approve/Cancel buttons appear and work

Closes #46, #43, #50, #44, #47, #48