### PR TITLE
[docs-sync] Add Plan Mode, permission requests, MCP elicitation, TodoWrite progress, and image attachments (English + Japanese)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,13 @@ If the bot restarts mid-session, interrupted Claude sessions are automatically r
 - **Hot reload** — New skills added to `~/.claude/skills/` are picked up automatically (60s refresh, no restart)
 - **Concurrent sessions** — Multiple parallel sessions with configurable limit
 - **Stop without clearing** — `/stop` halts a session while preserving it for resume
-- **Attachment support** — Text files auto-appended to prompt (up to 5 × 50 KB)
+- **Attachment support** — Text files auto-appended to prompt (up to 5 × 50 KB); images downloaded and passed via `--image` (up to 4 × 5 MB)
 - **Timeout notifications** — Embed with elapsed time and resume guidance on timeout
 - **Interactive questions** — `AskUserQuestion` renders as Discord Buttons or Select Menu; session resumes with your answer; buttons survive bot restarts
+- **Plan Mode** — When Claude calls `ExitPlanMode`, a Discord embed shows the full plan with Approve/Cancel buttons; Claude proceeds only after approval; auto-cancel on 5-minute timeout
+- **Tool permission requests** — When Claude needs permission to execute a tool, Discord shows Allow/Deny buttons with the tool name and input; auto-deny after 2 minutes
+- **MCP Elicitation** — MCP servers can request user input via Discord (form-mode: up to 5 Modal fields from JSON schema; url-mode: URL button + Done confirmation); 5-minute timeout
+- **Live TodoWrite progress** — When Claude calls `TodoWrite`, a single Discord embed is posted and edited in-place on each update; shows ✅ completed, 🔄 active (with `activeForm` label), ⬜ pending items
 - **Thread dashboard** — Live pinned embed showing which threads are active vs. waiting; owner @-mentioned when input is needed
 - **Token usage** — Cache hit rate and token counts shown in session-complete embed
 - **Context usage** — Context window percentage (input + cache tokens, excluding output) and remaining capacity until auto-compact shown in session-complete embed; ⚠️ warning when above 83.5%
@@ -579,6 +583,9 @@ claude_discord/
     streaming_manager.py   # StreamingMessageManager — debounced in-place message edits
     tool_timer.py          # LiveToolTimer — elapsed time counter for long-running tools
     thread_dashboard.py    # Live pinned embed showing session states
+    plan_view.py           # Approve/Cancel buttons for Plan Mode (ExitPlanMode)
+    permission_view.py     # Allow/Deny buttons for tool permission requests
+    elicitation_view.py    # Discord UI for MCP elicitation (Modal form or URL button)
   session_sync.py          # CLI session discovery and import
   worktree.py              # WorktreeManager — safe git worktree lifecycle (cleanup at session end + startup)
   ext/
@@ -604,7 +611,7 @@ claude_discord/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-685+ tests covering parser, chunker, repository, runner, streaming, webhook triggers, auto-upgrade (including `/upgrade` slash command, thread-invocation, and approval button), REST API, AskUserQuestion UI, thread dashboard, scheduled tasks, session sync, AI Lounge, startup resume, model switching, and compact detection.
+700+ tests covering parser, chunker, repository, runner, streaming, webhook triggers, auto-upgrade (including `/upgrade` slash command, thread-invocation, and approval button), REST API, AskUserQuestion UI, thread dashboard, scheduled tasks, session sync, AI Lounge, startup resume, model switching, compact detection, TodoWrite progress embeds, and permission/elicitation/plan-mode event parsing.
 
 ---
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -141,9 +141,13 @@ Bot の再起動中にセッションが中断された場合、Bot が再起動
 - **ホットリロード** — `~/.claude/skills/` に追加した新スキルを自動検出（60 秒更新、再起動不要）
 - **並行セッション** — 設定可能な上限での複数並行セッション
 - **削除せず停止** — `/stop` でセッションを保持したまま停止し、リジューム可能
-- **添付ファイル対応** — テキストファイルをプロンプトに自動追加（最大 5 ファイル × 50 KB）
+- **添付ファイル対応** — テキストファイルをプロンプトに自動追加（最大 5 ファイル × 50 KB）；画像は `--image` フラグ経由で渡す（最大 4 枚 × 5 MB）
 - **タイムアウト通知** — 経過時間とリジューム手順付きの embed 表示
 - **インタラクティブな質問** — `AskUserQuestion` を Discord ボタンまたは Select Menu でレンダリング。回答でセッション再開。ボタンは Bot 再起動後も有効
+- **Plan Mode** — Claude が `ExitPlanMode` を呼び出すと、プラン全文と Approve/Cancel ボタンを含む Discord embed を表示；承認後にのみ実行を開始；5 分でタイムアウト（自動キャンセル）
+- **ツール実行許可リクエスト** — Claude がツールを実行するために許可が必要な場合、ツール名と入力内容を示した Allow/Deny ボタンを Discord に表示；2 分間応答なしで自動拒否
+- **MCP Elicitation** — MCP サーバーが Discord 経由でユーザー入力を要求（form-mode: JSON スキーマから最大 5 フィールドの Modal；url-mode: URL ボタン + Done 確認）；5 分でタイムアウト
+- **TodoWrite ライブ進捗** — Claude が `TodoWrite` を呼び出すと Discord embed を一度投稿し、以降の更新はその embed をインプレースで編集；✅ 完了、🔄 実行中（`activeForm` ラベル付き）、⬜ 保留中の各状態を表示
 - **スレッドダッシュボード** — アクティブ/待機スレッドを表示するライブピン embed。入力が必要なときはオーナーを @mention
 - **トークン使用量** — セッション完了 embed にキャッシュヒット率とトークン数を表示
 - **コンテキスト使用率** — セッション完了 embed にコンテキストウィンドウの使用率（入力＋キャッシュトークン。出力トークンは除外）と自動コンパクトまでの残容量を表示。83.5% 以上で ⚠️ 警告
@@ -517,6 +521,9 @@ claude_discord/
     streaming_manager.py   # StreamingMessageManager — デバウンス付きインプレース編集
     tool_timer.py          # LiveToolTimer — 長時間ツール実行の経過時間カウンター
     thread_dashboard.py    # スレッドのセッション状態を表示する live ピン embed
+    plan_view.py           # Plan Mode 承認ボタン（Approve/Cancel）
+    permission_view.py     # ツール実行許可ボタン（Allow/Deny）
+    elicitation_view.py    # MCP Elicitation 用 Discord UI（Modal フォームまたは URL ボタン）
   session_sync.py          # CLI セッションの検出とインポート
   worktree.py              # WorktreeManager — git worktree の安全なライフサイクル管理（セッション終了・起動時のクリーンアップ）
   ext/
@@ -542,7 +549,7 @@ claude_discord/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-685 件以上のテストがパーサー、チャンカー、リポジトリ、ランナー、ストリーミング、Webhook トリガー、自動アップグレード（`/upgrade` スラッシュコマンド、スレッド内実行、承認ボタン含む）、REST API、AskUserQuestion UI、スレッドダッシュボード、スケジュールタスク、セッション同期、AI Lounge、スタートアップリジューム、モデル切り替え、コンパクト検出をカバーしています。
+700 件以上のテストがパーサー、チャンカー、リポジトリ、ランナー、ストリーミング、Webhook トリガー、自動アップグレード（`/upgrade` スラッシュコマンド、スレッド内実行、承認ボタン含む）、REST API、AskUserQuestion UI、スレッドダッシュボード、スケジュールタスク、セッション同期、AI Lounge、スタートアップリジューム、モデル切り替え、コンパクト検出、TodoWrite 進捗 embed、許可／Elicitation／Plan Mode イベントパースをカバーしています。
 
 ---
 


### PR DESCRIPTION
## Summary
- Added documentation for 5 new interactive features: Plan Mode approval (Approve/Cancel buttons via ExitPlanMode), tool permission requests (Allow/Deny buttons), MCP Elicitation (Modal form or URL button), live TodoWrite progress embed, and image attachment support via `--image` flag
- Updated architecture section to list 3 new `discord_ui/` files: `plan_view.py`, `permission_view.py`, `elicitation_view.py`
- Updated test count from 685+ to 700+ to reflect new parser and embed tests

## 概要
- 5 つの新しいインタラクティブ機能をドキュメントに追加: Plan Mode 承認（ExitPlanMode による Approve/Cancel ボタン）、ツール実行許可リクエスト（Allow/Deny ボタン）、MCP Elicitation（Modal フォームまたは URL ボタン）、TodoWrite ライブ進捗 embed、`--image` フラグ経由の画像添付対応
- アーキテクチャセクションに新規 `discord_ui/` ファイル 3 つを追加: `plan_view.py`、`permission_view.py`、`elicitation_view.py`
- テスト件数を 685+ から 700+ に更新

## Changed files
- `README.md`
- `docs/ja/README.md`

---
🤖 Auto-generated by [docs-sync](https://github.com/ebibibi/claude-code-discord-bridge)
