### PR TITLE
[release] chore: release v1.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-code-discord-bridge"
-version = "1.3.0"
+version = "1.4.0"
 description = "Connect Claude Code to Discord and GitHub — interactive chat, CI/CD automation, and workflow integration"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## v1.4.0 Release

This PR bumps the version to 1.4.0 for release tagging.

## What's in v1.4.0 (from PRs #156, #157, #158)

### New Features
- **TodoWrite live progress** — in-place embed editing; shows ✅/🔄/⬜ status (#46)
- **Image attachments** — Discord images passed to Claude via `--image` (up to 4 × 5 MB) (#43)
- **Bidirectional runner** — stdin=PIPE + `inject_tool_result()` for interactive tool responses (#50)
- **Plan Mode** — ExitPlanMode → Approve/Cancel Discord embed; 5-minute timeout (#44)
- **Tool permission requests** — Allow/Deny buttons for tool execution; 2-minute timeout (#47)
- **MCP Elicitation** — Modal form or URL button for MCP server input requests (#48)

### Documentation
- All 5 multilingual READMEs (es/fr/ko/pt-BR/zh-CN) updated with new features
- CHANGELOG.md v1.4.0 entry added

## Test plan
- [x] 709 tests passing (verified in PR #156)
- [x] All multilingual docs updated (PR #158)

🤖 Generated with [Claude Code](https://claude.com/claude-code)