### PR TITLE
release: v1.4.1 — Fix CLI hang on Claude >=2.1.50 [release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-02-24
+
+### Fixed
+- **Critical: CLI subprocess hang on Claude >=2.1.50** — `ClaudeRunner` spawned Claude CLI with `stdin=asyncio.subprocess.PIPE`, which causes Claude CLI >=2.1.50 to block indefinitely even in non-interactive (`-p`) mode. Switched to `stdin=asyncio.subprocess.DEVNULL`. This was causing all Bot-spawned sessions to create threads but never respond. `inject_tool_result()` already handles the missing stdin gracefully (logs a warning and returns) (#162)
+
+### Changed
+- Improved debug logging in `ClaudeRunner`: logs cwd at startup, PID after process creation, first 3 stdout lines, and EOF line count for easier troubleshooting (#162)
+- README: reorganized Interactive Chat features from flat 23-item list into 5 scannable sub-sections with emoji headers (#160)
+
 ## [1.4.0] - 2026-02-22
 
 ### Added
@@ -139,7 +148,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI pipeline: Python 3.10/3.11/3.12, ruff, pytest
 - Branch protection and PR workflow
 
-[Unreleased]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v1.4.1...HEAD
+[1.4.1]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/ebibibi/claude-code-discord-bridge/compare/v1.1.0...v1.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-code-discord-bridge"
-version = "1.4.0"
+version = "1.4.1"
 description = "Connect Claude Code to Discord and GitHub — interactive chat, CI/CD automation, and workflow integration"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## v1.4.1 — Fix CLI hang on Claude >=2.1.50

### Critical Bug Fix

**All Discord Bot sessions were hanging** — threads were created but Claude never responded.

**Root Cause**: Claude CLI >=2.1.50 introduced a behavioral change where the process blocks indefinitely on startup when `stdin` is an open pipe, even in non-interactive (`-p`) mode. `ClaudeRunner` was using `stdin=asyncio.subprocess.PIPE` for bidirectional communication (Plan Mode, Permission requests, MCP elicitation), which triggered this hang.

**Diagnosis**: Reproduced with an isolated Python test script:

| stdin mode | Result |
|------------|--------|
| `PIPE` (open) | Hangs indefinitely (0% CPU, no output) |
| `DEVNULL` | Responds in ~3.5s |
| `PIPE` + immediate `close()` | Responds in ~3.4s |

**Fix**: Switch from `stdin=asyncio.subprocess.PIPE` to `stdin=asyncio.subprocess.DEVNULL`. The existing `inject_tool_result()` method already handles missing stdin gracefully (logs a warning and returns).

### Other Changes

- Improved debug logging in `ClaudeRunner`: logs cwd, PID, first 3 stdout lines, EOF line count
- README: reorganized Interactive Chat features into 5 scannable sub-sections

### Full Changelog

See [CHANGELOG.md](CHANGELOG.md) for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)