### PR TITLE
fix: auto-version-bump respects branch protection rules

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -93,11 +93,14 @@ gh release view v1.4.0 --repo ebibibi/claude-code-discord-bridge
 PR マージ（auto-approve.yml）
   └── repository_dispatch: pr-merged
         └── auto-version-bump.yml
-              ├── PR タイトルに [release] あり → 現在バージョンでタグ & Release（バンプなし）
-              └── [release] なし → patch++ してコミット → タグ & Release
+              ├── [release] あり → 現在バージョンでタグ & Release（バンプなし）
+              ├── [skip-bump] あり → タグ & Release のみ（bump PR のマージ後）
+              └── どちらもなし → bump PR を作成（auto/bump-vX.Y.Z ブランチ）
+                    └── auto-approve → マージ → dispatch [skip-bump] → タグ & Release
 ```
 
-docs-sync PR（翻訳・ドキュメント更新）はバンプも Release も発生しない。
+- docs-sync PR（翻訳・ドキュメント更新）はバンプも Release も発生しない
+- patch-bump は PR 経由で行う（ブランチ保護ルールを尊重）
 
 ---
 

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -45,9 +45,8 @@ jobs:
                 -d '{"content":"🔄 ebibot-upgrade"}' \
                 "$WEBHOOK_URL"
 
-              # Send docs-sync webhook unless this is a docs-sync PR (prevent infinite loop).
-              # HEAD_REF and PR_TITLE are passed via env: (safe — no direct interpolation in run:).
-              if [[ "$HEAD_REF" != docs-sync/* ]] && [[ "$PR_TITLE" != '[docs-sync]'* ]]; then
+              # --- Docs-sync webhook (skip for docs-sync and auto-bump PRs) ---
+              if [[ "$HEAD_REF" != docs-sync/* ]] && [[ "$PR_TITLE" != '[docs-sync]'* ]] && [[ "$HEAD_REF" != auto/bump-* ]]; then
                 OPEN_PR=$(gh pr list \
                   --repo "$GITHUB_REPOSITORY" \
                   --state open \
@@ -63,11 +62,13 @@ jobs:
                 else
                   echo "Skipping docs-sync: docs-sync PR already open"
                 fi
+              else
+                echo "Skipping docs-sync: excluded branch ($HEAD_REF)"
+              fi
 
-                # Trigger auto patch version bump (skip docs-sync PRs).
-                # repository_dispatch fires even when triggered by GITHUB_TOKEN,
-                # unlike push/pull_request events which are suppressed.
-                # jq --arg safely escapes PR_TITLE (prevents JSON injection).
+              # --- Version bump dispatch (skip only for docs-sync PRs) ---
+              # auto/bump-* PRs DO trigger dispatch (with [skip-bump] title → tag & release).
+              if [[ "$HEAD_REF" != docs-sync/* ]] && [[ "$PR_TITLE" != '[docs-sync]'* ]]; then
                 echo "Dispatching pr-merged event for version bump..."
                 DISPATCH_PAYLOAD=$(jq -c -n \
                   --arg event_type "pr-merged" \
@@ -78,7 +79,7 @@ jobs:
                   --method POST \
                   --input -
               else
-                echo "Skipping docs-sync: this is a docs-sync PR ($HEAD_REF)"
+                echo "Skipping version bump: docs-sync PR ($HEAD_REF)"
               fi
 
               exit 0

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -7,8 +7,8 @@ name: Auto Patch Version Bump
 #
 # Two modes, determined by PR title:
 #   [release] in title → tag & release the current version as-is (no bump, no commit)
-#                        Use this for manual minor/major releases (v1.4.0 etc.)
-#   anything else      → bump patch (1.3.0 → 1.3.1), commit, tag, release
+#   [skip-bump]        → do nothing (prevents infinite loop from bump PRs)
+#   anything else      → bump patch (1.3.0 → 1.3.1) via PR, tag after merge
 on:
   repository_dispatch:
     types: [pr-merged]
@@ -18,41 +18,41 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Detect release mode from PR title
         id: mode
         env:
           PR_TITLE: ${{ github.event.client_payload.pr_title }}
         run: |
-          # [release] marker → manual minor/major release; skip patch bump
-          if [[ "$PR_TITLE" == *"[release]"* ]]; then
+          if [[ "$PR_TITLE" == *"[skip-bump]"* ]]; then
+            echo "mode=skip" >> "$GITHUB_OUTPUT"
+            echo "Mode: skip (bump PR merged, creating tag & release)"
+          elif [[ "$PR_TITLE" == *"[release]"* ]]; then
             echo "mode=release" >> "$GITHUB_OUTPUT"
             echo "Mode: release (tag current version as-is)"
           else
             echo "mode=patch-bump" >> "$GITHUB_OUTPUT"
-            echo "Mode: patch-bump (increment patch version)"
+            echo "Mode: patch-bump (increment patch version via PR)"
           fi
 
       - name: Read current version from pyproject.toml
         id: read
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MODE: ${{ steps.mode.outputs.mode }}
+        if: steps.mode.outputs.mode != 'skip'
         run: |
-          FILE_INFO=$(gh api "repos/$GITHUB_REPOSITORY/contents/pyproject.toml")
-          # Store SHA for the PUT request (required by GitHub Contents API)
-          FILE_SHA=$(echo "$FILE_INFO" | jq -r '.sha')
-          CONTENT=$(echo "$FILE_INFO" | jq -r '.content' | base64 -d)
-
-          CURRENT=$(echo "$CONTENT" | grep '^version = ' | sed 's/version = "\(.*\)"/\1/')
+          CURRENT=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          MODE="${{ steps.mode.outputs.mode }}"
 
           if [ "$MODE" = "release" ]; then
-            # [release] mode: tag and release the current version as-is (no bump)
             RELEASE_VERSION="$CURRENT"
             echo "Tagging current version: $RELEASE_VERSION"
           else
-            # patch-bump mode: increment patch
             MAJOR=$(echo "$CURRENT" | cut -d. -f1)
             MINOR=$(echo "$CURRENT" | cut -d. -f2)
             PATCH=$(echo "$CURRENT" | cut -d. -f3)
@@ -64,71 +64,70 @@ jobs:
           echo "current=$CURRENT"                >> "$GITHUB_OUTPUT"
           echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
           echo "release_tag=v$RELEASE_VERSION"    >> "$GITHUB_OUTPUT"
-          echo "file_sha=$FILE_SHA"               >> "$GITHUB_OUTPUT"
 
-          # Pass file content via temp file to avoid output size limits
-          printf '%s' "$CONTENT" > /tmp/pyproject_original.toml
+      - name: Read version for skip-bump (tag the just-merged bump)
+        id: read-skip
+        if: steps.mode.outputs.mode == 'skip'
+        run: |
+          CURRENT=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "release_version=$CURRENT"      >> "$GITHUB_OUTPUT"
+          echo "release_tag=v$CURRENT"         >> "$GITHUB_OUTPUT"
+          echo "Tagging bump result: v$CURRENT"
 
-      - name: Commit bumped version to main (patch-bump mode only)
-        id: commit
+      - name: Create version bump PR (patch-bump mode)
         if: steps.mode.outputs.mode == 'patch-bump'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CURRENT: ${{ steps.read.outputs.current }}
           RELEASE_VERSION: ${{ steps.read.outputs.release_version }}
-          FILE_SHA: ${{ steps.read.outputs.file_sha }}
         run: |
-          NEW_CONTENT=$(sed "s/^version = \"$CURRENT\"/version = \"$RELEASE_VERSION\"/" /tmp/pyproject_original.toml)
-          # base64 -w 0 produces no line-wrapping (required by GitHub API)
-          ENCODED=$(printf '%s' "$NEW_CONTENT" | base64 -w 0)
+          BRANCH="auto/bump-v$RELEASE_VERSION"
+          git checkout -b "$BRANCH"
 
-          # [skip ci] prevents CI from re-running on this trivial version bump commit
-          # jq --arg safely escapes all values (no injection risk)
-          COMMIT_INFO=$(jq -c -n \
-            --arg message "chore: bump version to $RELEASE_VERSION [skip ci]" \
-            --arg content "$ENCODED" \
-            --arg sha "$FILE_SHA" \
-            '{message: $message, content: $content, sha: $sha}')
+          sed -i "s/^version = \"$CURRENT\"/version = \"$RELEASE_VERSION\"/" pyproject.toml
 
-          RESULT=$(echo "$COMMIT_INFO" | gh api "repos/$GITHUB_REPOSITORY/contents/pyproject.toml" \
-            --method PUT \
-            --input -)
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "chore: bump version to $RELEASE_VERSION [skip ci]"
+          git push origin "$BRANCH"
 
-          NEW_COMMIT_SHA=$(echo "$RESULT" | jq -r '.commit.sha')
-          echo "commit_sha=$NEW_COMMIT_SHA" >> "$GITHUB_OUTPUT"
-          echo "Committed version bump: $NEW_COMMIT_SHA"
+          # auto-approve.yml will approve & merge this PR, then dispatch
+          # pr-merged with [skip-bump] in title to trigger tag creation
+          gh pr create \
+            --title "chore: bump version to $RELEASE_VERSION [skip-bump]" \
+            --body "Automated patch version bump: $CURRENT → $RELEASE_VERSION"
+
+          echo "Created bump PR on branch $BRANCH"
 
       - name: Create tag and GitHub Release
+        if: steps.mode.outputs.mode == 'release' || steps.mode.outputs.mode == 'skip'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MODE: ${{ steps.mode.outputs.mode }}
-          RELEASE_TAG: ${{ steps.read.outputs.release_tag }}
-          RELEASE_VERSION: ${{ steps.read.outputs.release_version }}
-          BUMP_COMMIT_SHA: ${{ steps.commit.outputs.commit_sha }}
+          RELEASE_TAG: ${{ steps.mode.outputs.mode == 'skip' && steps.read-skip.outputs.release_tag || steps.read.outputs.release_tag }}
         run: |
-          # For release mode: tag main HEAD (the release PR's merge commit).
-          # For patch-bump mode: tag the version bump commit we just created.
-          if [ "$MODE" = "release" ]; then
-            TAG_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/refs/heads/main" --jq '.object.sha')
+          # Check if tag already exists (idempotent)
+          if gh api "repos/$GITHUB_REPOSITORY/git/refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Tag $RELEASE_TAG already exists, skipping tag creation"
           else
-            TAG_SHA="$BUMP_COMMIT_SHA"
+            TAG_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/refs/heads/main" --jq '.object.sha')
+            jq -c -n \
+              --arg ref "refs/tags/$RELEASE_TAG" \
+              --arg sha "$TAG_SHA" \
+              '{ref: $ref, sha: $sha}' \
+            | gh api "repos/$GITHUB_REPOSITORY/git/refs" \
+              --method POST \
+              --input -
+            echo "Created tag $RELEASE_TAG -> $TAG_SHA"
           fi
 
-          # Create lightweight tag
-          jq -c -n \
-            --arg ref "refs/tags/$RELEASE_TAG" \
-            --arg sha "$TAG_SHA" \
-            '{ref: $ref, sha: $sha}' \
-          | gh api "repos/$GITHUB_REPOSITORY/git/refs" \
-            --method POST \
-            --input -
-
-          echo "Created tag $RELEASE_TAG -> $TAG_SHA"
-
-          # Create GitHub Release with auto-generated notes (lists merged PRs since last tag)
-          gh release create "$RELEASE_TAG" \
-            --title "$RELEASE_TAG" \
-            --generate-notes \
-            --latest
-
-          echo "Released $RELEASE_TAG"
+          # Check if release already exists (idempotent)
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists, skipping"
+          else
+            gh release create "$RELEASE_TAG" \
+              --title "$RELEASE_TAG" \
+              --generate-notes \
+              --latest
+            echo "Released $RELEASE_TAG"
+          fi

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "1.4.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

The auto-version-bump workflow has been failing on every PR merge since branch protection was enabled. Two issues:

### Problem 1: patch-bump blocked by branch protection
- `gh api PUT repos/.../contents/pyproject.toml` (Contents API) tries to commit directly to main
- Branch protection requires `test (3.11)` status check → HTTP 409 error
- **Fix**: Create a PR (`auto/bump-vX.Y.Z` branch) instead of direct commit. auto-approve.yml handles the rest

### Problem 2: `gh release create --generate-notes` fails without checkout
- No `actions/checkout` step → `fatal: not a git repository`
- Tag was created successfully via API, but release creation failed
- **Fix**: Add `actions/checkout@v4` with `fetch-depth: 0`

### New flow

```
Normal PR merged → dispatch [no markers]
  → auto-version-bump: patch-bump mode
    → creates auto/bump-vX.Y.Z PR
      → auto-approve merges it
        → dispatch [skip-bump]
          → auto-version-bump: skip mode
            → creates tag + GitHub Release

Release PR merged → dispatch [release]
  → auto-version-bump: release mode
    → creates tag + GitHub Release (no bump)
```

### Other changes
- Separated docs-sync webhook and version-bump dispatch conditions
- Made tag and release creation idempotent (skip if already exists)
- Updated release skill docs

## Test plan

- [ ] Next normal PR merge should trigger the full flow successfully
- [ ] Release PR (`[release]`) should still create tag & release directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)