### PR TITLE
fix: remove [skip ci] from bump commits

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -89,7 +89,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml
-          git commit -m "chore: bump version to $RELEASE_VERSION [skip ci]"
+          git commit -m "chore: bump version to $RELEASE_VERSION"
           git push origin "$BRANCH"
 
           # auto-approve.yml will approve & merge this PR, then dispatch


### PR DESCRIPTION
## Summary

Bump PRs created by auto-version-bump had `[skip ci]` in the commit message, which prevented CI from running. Since branch protection requires `test (3.11)` status check, the bump PR could never be merged.

Remove `[skip ci]` — the CI run on a pyproject.toml-only change is fast (~45s) and necessary for the auto-merge flow to work.

## Test plan

- [ ] Next normal PR merge should create a bump PR that passes CI and auto-merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)