### PR TITLE
feat: collapse long tool results behind an expand button

### DIFF
--- a/claude_discord/discord_ui/embeds.py
+++ b/claude_discord/discord_ui/embeds.py
@@ -128,6 +128,26 @@ def session_complete_embed(
     return embed
 
 
+_PREVIEW_LINES = 3
+
+
+def tool_result_preview_embed(tool_title: str, full_content: str) -> discord.Embed:
+    """Collapsed embed showing the first _PREVIEW_LINES lines and a hidden-count hint.
+
+    Paired with ToolResultView so the user can expand on demand.
+    """
+    title = tool_title.rstrip(".")
+    embed = discord.Embed(title=title[:256], color=COLOR_INFO)
+    if full_content:
+        lines = full_content.split("\n")
+        preview = "\n".join(lines[:_PREVIEW_LINES])
+        hidden = len(lines) - _PREVIEW_LINES
+        if hidden > 0:
+            preview += f"\n... +{hidden} lines"
+        embed.description = f"```\n{preview}\n```"
+    return embed
+
+
 def tool_result_embed(tool_title: str, result_content: str) -> discord.Embed:
     """Create an embed for a completed tool with its result.
 

--- a/tests/test_embeds.py
+++ b/tests/test_embeds.py
@@ -355,3 +355,54 @@ class TestTodoEmbed:
         embed = todo_embed([])
         assert embed.description is not None
         assert "no tasks" in embed.description
+
+
+class TestToolResultPreviewEmbed:
+    """tool_result_preview_embed — collapsed view showing first 3 lines."""
+
+    def test_first_3_lines_visible(self) -> None:
+        from claude_discord.discord_ui.embeds import tool_result_preview_embed
+
+        content = "\n".join(f"line{i}" for i in range(10))
+        embed = tool_result_preview_embed("🔧 Running: cat", content)
+
+        assert embed.description is not None
+        assert "line0" in embed.description
+        assert "line1" in embed.description
+        assert "line2" in embed.description
+
+    def test_remaining_lines_hidden(self) -> None:
+        from claude_discord.discord_ui.embeds import tool_result_preview_embed
+
+        content = "\n".join(f"line{i}" for i in range(10))
+        embed = tool_result_preview_embed("🔧 Running: cat", content)
+
+        assert "line3" not in embed.description
+
+    def test_hidden_line_count_shown(self) -> None:
+        from claude_discord.discord_ui.embeds import tool_result_preview_embed
+
+        content = "\n".join(f"line{i}" for i in range(10))
+        embed = tool_result_preview_embed("🔧 Running: cat", content)
+
+        # 10 lines total, 3 shown → 7 hidden
+        assert "+7" in embed.description
+
+    def test_short_content_shows_all(self) -> None:
+        """3 lines or fewer — no hidden-line hint needed."""
+        from claude_discord.discord_ui.embeds import tool_result_preview_embed
+
+        content = "line1\nline2\nline3"
+        embed = tool_result_preview_embed("🔧 Running: cat", content)
+
+        assert "line1" in embed.description
+        assert "line2" in embed.description
+        assert "line3" in embed.description
+        assert "lines" not in embed.description  # No hidden-line hint
+
+    def test_title_strips_trailing_dots(self) -> None:
+        from claude_discord.discord_ui.embeds import tool_result_preview_embed
+
+        embed = tool_result_preview_embed("🔧 Running: cat...", "output")
+        assert embed.title is not None
+        assert not embed.title.endswith(".")


### PR DESCRIPTION
## Summary

- ツール実行結果が4行以上の場合、最初の3行だけを表示して折りたたむ
- 「展開 ▼」ボタンをクリックすると全出力を表示（「折りたたむ ▲」に切り替わる）
- 3行以下の短い出力はボタンなしで従来通り全文表示

## Changes

| ファイル | 変更内容 |
|---|---|
| `embeds.py` | `tool_result_preview_embed()` 追加（先頭3行 + hidden件数ヒント） |
| `views.py` | `ToolResultView` 追加（トグルボタン付き stateful View） |
| `event_processor.py` | `_on_tool_result` — 長い出力は preview embed + ToolResultView で edit |

## Test plan

- [x] `TestToolResultPreviewEmbed` — 5テスト（先頭3行表示、残行数ヒント、短文はボタンなし 等）
- [x] `TestToolResultCollapse` — 3テスト（短文はview無し、長文はToolResultView付き、preview内容確認）
- [x] 全721テストパス