### PR TITLE
ci: only create tag and release on [release] PR, not every merge

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -7,7 +7,7 @@ name: Auto Patch Version Bump
 #
 # Two modes, determined by PR title:
 #   [release] in title → tag & release the current version as-is (no bump)
-#   anything else      → bump patch (1.3.0 → 1.3.1), commit to main, tag, release
+#   anything else      → bump patch only (1.3.0 → 1.3.1), commit to main; no tag/release
 #
 # Branch protection has enforce_admins=false so GITHUB_TOKEN can push to main.
 on:
@@ -80,6 +80,7 @@ jobs:
           echo "Committed version bump to main"
 
       - name: Create tag and GitHub Release
+        if: steps.mode.outputs.mode == 'release'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MODE: ${{ steps.mode.outputs.mode }}
@@ -118,6 +119,7 @@ jobs:
           fi
 
       - name: Notify えびログ (Discord)
+        if: steps.mode.outputs.mode == 'release'
         env:
           EBILOG_WEBHOOK_URL: ${{ secrets.EBILOG_WEBHOOK_URL }}
           RELEASE_TAG: ${{ steps.read.outputs.release_tag }}


### PR DESCRIPTION
## Summary

- Normal PR merges now only bump the patch version in `pyproject.toml` — no tag, no GitHub Release, no Discord notification
- Tags, GitHub Releases, and Discord notifications are created only when the PR title contains `[release]`

## Changes

Added `if: steps.mode.outputs.mode == 'release'` to two steps in `auto-version-bump.yml`:
- `Create tag and GitHub Release`
- `Notify えびログ (Discord)`

## Before / After

| PR type | Before | After |
|---------|--------|-------|
| Normal merge | version bump + tag + release + notify | version bump only |
| `[release]` PR | tag + release + notify (no bump) | tag + release + notify (no bump) |