### PR TITLE
fix: update StopView runner reference after system-context clone (#174)

### DIFF
--- a/claude_discord/cogs/_run_helper.py
+++ b/claude_discord/cogs/_run_helper.py
@@ -168,6 +168,14 @@ async def run_claude_with_config(config: RunConfig) -> str | None:
     if config.image_paths:
         runner.image_paths = config.image_paths
 
+    # Keep stop_view in sync with the runner that will own the live subprocess.
+    # When system_context is present a fresh clone is created above, making the
+    # original config.runner a "dead" runner with no process.  Without this
+    # update the Stop button would send SIGINT to that dead runner and have no
+    # effect.  See: https://github.com/ebibibi/claude-code-discord-bridge/issues/174
+    if config.stop_view is not None and runner is not config.runner:
+        config.stop_view.update_runner(runner)
+
     processor = EventProcessor(config)
 
     try:

--- a/claude_discord/discord_ui/views.py
+++ b/claude_discord/discord_ui/views.py
@@ -36,6 +36,17 @@ class StopView(discord.ui.View):
         """Store the message this view is attached to."""
         self._message = message
 
+    def update_runner(self, runner: ClaudeRunner) -> None:
+        """Replace the runner reference with the one that owns the live subprocess.
+
+        ``run_claude_with_config`` may clone the runner to inject an
+        ``--append-system-prompt`` (lounge context, concurrency notice).
+        The subprocess lives in that clone, not in the original runner passed
+        to the constructor.  Call this immediately after the clone is created
+        so that the Stop button sends SIGINT to the right process.
+        """
+        self._runner = runner
+
     async def bump(self, thread: discord.Thread) -> None:
         """Re-post the Stop button as the latest message in the thread.
 


### PR DESCRIPTION
## Summary

- **Root cause**: `run_claude_with_config()` creates a fresh `ClaudeRunner` clone to inject `--append-system-prompt` (AI Lounge context + concurrency notice). The subprocess lives in that clone, but `StopView` was constructed with the original runner whose `_process` is `None`. Clicking ⏹ Stop sent `SIGINT` to the dead runner with no effect.

- **Fix**: Added `StopView.update_runner()` and call it in `_run_helper.py` immediately after the clone is created, so the Stop button always targets the runner that actually owns the live subprocess.

## Changes

- `claude_discord/discord_ui/views.py` — add `update_runner(runner)` to `StopView`
- `claude_discord/cogs/_run_helper.py` — call `config.stop_view.update_runner(runner)` after clone
- `tests/test_views.py` — `TestStopViewUpdateRunner` (2 tests)
- `tests/test_run_helper.py` — `TestStopViewRunnerSync` (2 tests)

## Test plan

- [x] `TestStopViewUpdateRunner::test_update_runner_replaces_runner` — update_runner() redirects interrupt to new runner
- [x] `TestStopViewUpdateRunner::test_stop_button_uses_updated_runner` — regression test for the exact bug scenario
- [x] `TestStopViewRunnerSync::test_stop_view_updated_to_cloned_runner` — integration: stop_view.update_runner() called when clone is created
- [x] `TestStopViewRunnerSync::test_stop_view_not_updated_when_no_clone` — no-op when no system context (no clone needed)
- [x] 728 tests pass total

Closes #174