### PR TITLE
fix: replace --image flag with --input-format stream-json for image attachments (#177)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "1.4.4"
+version = "1.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- **Root cause**: `ClaudeRunner._build_args()` added `--image <path>` flags that **do not exist** in claude CLI. Image attachments were silently dropped.
- **Fix**: Use `--input-format stream-json` + stdin PIPE. Images are base64-encoded and sent as JSON content blocks via stdin immediately after process start.
- Text-only sessions are unchanged (stdin=DEVNULL, prompt as CLI arg).

## Changes

- `claude_discord/claude/runner.py`
  - Remove `--image` flags from `_build_args()`
  - Add `--input-format stream-json` when `image_paths` is set (prompt goes via stdin, not CLI arg)
  - `run()`: use `stdin=PIPE` when images present; `DEVNULL` otherwise
  - New `_send_stream_json_message()`: encodes images + text prompt as JSON, writes to stdin
  - New `_IMAGE_MEDIA_TYPES` class constant for extension → MIME mapping
- `tests/test_runner.py` — `TestImageStreamJson` (7 tests)

## Test plan

- [x] `test_no_image_flag_in_args` — `--image` never appears in args
- [x] `test_stream_json_input_format_added_for_images` — `--input-format stream-json` added
- [x] `test_prompt_not_in_cli_args_when_images_present` — prompt goes via stdin, not CLI arg
- [x] `test_no_stream_json_input_format_without_images` — text-only sessions unchanged
- [x] `test_prompt_in_cli_args_without_images` — text prompt still passed as positional arg
- [x] `test_send_stream_json_message_writes_to_stdin` — JSON structure: image block + text block
- [x] `test_send_stream_json_message_uses_pipe_stdin` — stdin=PIPE when images present
- [x] 735 tests pass total

Closes #177