### PR TITLE
fix: pass images as url-type blocks in stream-json mode (fixes image support)

### DIFF
--- a/claude_discord/cogs/run_config.py
+++ b/claude_discord/cogs/run_config.py
@@ -62,9 +62,9 @@ class RunConfig:
     lounge_repo: LoungeRepository | None = None
     stop_view: StopView | None = None
     worktree_manager: WorktreeManager | None = None
-    # Paths to downloaded image tempfiles passed via --image flags.
-    # Cleaned up in run_claude_with_config() finally block.
-    image_paths: list[str] | None = None
+    # HTTPS URLs of image attachments to pass as stream-json url-type image blocks.
+    # Claude Code CLI silently drops base64 image blocks; URL type is required.
+    image_urls: list[str] | None = None
 
     # Prevent accidental field mutation — RunConfig is a value object.
     # Use dataclasses.replace() to create modified copies.


### PR DESCRIPTION
## Root Cause

Claude Code CLI 2.1.59 **silently drops base64 image content blocks** when reading user messages via `--input-format stream-json`. This was confirmed by direct testing:

```
# base64 format → image silently dropped, Claude responds "I don't see an image"
# url format → image delivered correctly, Claude describes the image ✅
```

PR #178 switched from `--image` (non-existent flag) to `--input-format stream-json` with base64 encoding, which avoided the flag error but still failed to transmit images.

## Fix

Switch from base64 (download → tempfile → encode) to **url-type image blocks** (pass Discord CDN HTTPS URL directly):

```json
// Before (silently dropped by CLI):
{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "..."}}

// After (reaches Anthropic API ✅):
{"type": "image", "source": {"type": "url", "url": "https://cdn.discordapp.com/..."}}
```

## Changes

- **`runner.py`**: `image_paths` → `image_urls`; `_send_stream_json_message()` now writes `{"type": "url"}` blocks; removed `_IMAGE_MEDIA_TYPES` dict and `base64` import
- **`run_config.py`**: `image_paths` → `image_urls`
- **`_run_helper.py`**: update field reference; remove `_cleanup_image_tempfiles` (no tempfiles)
- **`claude_chat.py`**: `_build_prompt_and_images()` collects `attachment.url` directly instead of downloading bytes to a tempfile — no I/O for images, no cleanup needed
- **Tests**: all image tests updated to use `image_urls` and url-type assertions; added `test_multiple_image_urls_all_sent`; replaced base64 test with `test_send_stream_json_message_url_format`

## Test Plan

- [x] 737 tests pass (`pytest` - all green)
- [x] Confirmed base64 format drops images (manual CLI test)
- [x] Confirmed url format delivers images (manual CLI test with real HTTPS image)
- [ ] Live Discord test: send an image, verify Claude describes it