### PR TITLE
chore: bump version to 1.4.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-code-discord-bridge"
-version = "1.4.9"
+version = "1.4.10"
 description = "Connect Claude Code to Discord and GitHub — interactive chat, CI/CD automation, and workflow integration"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Manual version bump to 1.4.10 — the empty prompt fix was merged via a docs-sync/ branch which skipped the auto-version-bump dispatch.