### PR TITLE
fix: suppress stream_event debug log noise

### DIFF
--- a/claude_discord/claude/types.py
+++ b/claude_discord/claude/types.py
@@ -19,6 +19,7 @@ class MessageType(Enum):
     USER = "user"
     RESULT = "result"
     PROGRESS = "progress"
+    STREAM_EVENT = "stream_event"  # low-level streaming events; parsed but not acted on
 
 
 class ContentBlockType(Enum):


### PR DESCRIPTION
## Summary
- Add `STREAM_EVENT = "stream_event"` to `MessageType` enum
- This suppresses the repeated `Unknown message type: stream_event` DEBUG log spam
- `stream_event` is a low-level Claude CLI streaming event (generated by `--include-partial-messages`) that the parser knows about but does not need to act on

## Why
After enabling full DEBUG logging for `claude_discord.*` loggers in the discord-bot, the `stream_event` messages (which Claude CLI emits frequently during streaming) were showing up as spam in journald. Adding them to the enum makes them "known but ignored" types instead of "unknown" types.

## Test plan
- [x] All 44 parser tests pass (`pytest tests/test_parser.py`)
- [x] `stream_event` lines now parse to `None` cleanly (known unknown type → existing behavior, no regression)