### PR TITLE
fix: allow empty prompt when image_urls are provided

### DIFF
--- a/claude_discord/cogs/run_config.py
+++ b/claude_discord/cogs/run_config.py
@@ -69,7 +69,7 @@ class RunConfig:
     # Prevent accidental field mutation — RunConfig is a value object.
     # Use dataclasses.replace() to create modified copies.
     def __post_init__(self) -> None:
-        if not self.prompt:
+        if not self.prompt and not self.image_urls:
             raise ValueError("RunConfig.prompt must not be empty")
 
     def with_prompt(self, prompt: str) -> RunConfig:

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -1,0 +1,57 @@
+"""Tests for RunConfig validation."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from claude_discord.cogs.run_config import RunConfig
+
+
+def _make_config(**overrides):
+    """Create a RunConfig with minimal required fields."""
+    defaults = {
+        "thread": MagicMock(),
+        "runner": MagicMock(),
+        "prompt": "hello",
+    }
+    defaults.update(overrides)
+    return RunConfig(**defaults)
+
+
+class TestRunConfigValidation:
+    """Test RunConfig.__post_init__ validation."""
+
+    def test_empty_prompt_no_images_raises(self):
+        """Empty prompt without images should raise ValueError."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            _make_config(prompt="")
+
+    def test_empty_prompt_with_images_allowed(self):
+        """Empty prompt with image_urls should be accepted."""
+        config = _make_config(prompt="", image_urls=["https://cdn.example.com/img.png"])
+        assert config.prompt == ""
+        assert config.image_urls == ["https://cdn.example.com/img.png"]
+
+    def test_nonempty_prompt_no_images_allowed(self):
+        """Normal text prompt should work as before."""
+        config = _make_config(prompt="hello")
+        assert config.prompt == "hello"
+
+    def test_nonempty_prompt_with_images_allowed(self):
+        """Text prompt with images should work."""
+        config = _make_config(prompt="describe this", image_urls=["https://example.com/a.png"])
+        assert config.prompt == "describe this"
+
+    def test_empty_prompt_empty_images_raises(self):
+        """Empty prompt with empty image list should raise ValueError."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            _make_config(prompt="", image_urls=[])
+
+    def test_with_prompt_preserves_images(self):
+        """with_prompt should carry over image_urls."""
+        original = _make_config(prompt="old", image_urls=["https://example.com/img.png"])
+        updated = original.with_prompt("new prompt")
+        assert updated.prompt == "new prompt"
+        assert updated.image_urls == ["https://example.com/img.png"]

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "1.4.6"
+version = "1.4.13"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- **Root cause**: `RunConfig.__post_init__` rejected empty prompts unconditionally (`if not self.prompt: raise ValueError`), but image-only Discord messages (no text, just an attachment) produce `prompt=""` with valid `image_urls`
- The `ValueError` was raised at `RunConfig` construction **before** the `try/finally` block in `_run_claude`, propagating uncaught through `on_message` and freezing the bot's event loop
- Fix: accept empty prompts when `image_urls` is non-empty (`if not self.prompt and not self.image_urls`)

## Symptoms

When a user sends an image without text to a Discord thread:
1. All trace logs pass up to `starting run_claude_with_config`
2. `run_claude_with_config: entry` never appears — the function is never called
3. The entire bot event loop freezes (no logs from any handler)
4. Eventually the bot process crashes (SIGABRT or gets killed)

## Test plan

- [x] New `tests/test_run_config.py` with 6 tests covering all validation cases
- [x] `test_empty_prompt_with_images_allowed` — the regression test
- [x] `test_empty_prompt_no_images_raises` — existing behavior preserved
- [x] Full suite passes (745 tests)
- [ ] Manual: send image-only message to Dynabook thread after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)