### PR TITLE
fix: defense-in-depth for image-only messages

### DIFF
--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -413,6 +413,10 @@ class ClaudeChatCog(commands.Cog):
         session_id = record.session_id if record else None
         prompt, image_urls = await self._build_prompt_and_images(message)
 
+        # Nothing to send — ignore silently (e.g. unsupported attachment only).
+        if not prompt and not image_urls:
+            return
+
         # Interrupt any active session in this thread before starting a new one.
         existing_runner = self._active_runners.get(thread.id)
         existing_task = self._active_tasks.get(thread.id)

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "1.4.13"
+version = "1.4.14"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Follow-up to #186. Adds multiple defense layers to ensure image-only messages never break again:

- **Guard in `_handle_thread_reply`**: Early return when neither prompt nor image_urls are present
- **5 regression tests** covering the full image-only path:
  - `_build_prompt_and_images` returns empty prompt + image URLs
  - `_handle_thread_reply` passes image_urls through to `_run_claude`
  - Empty messages (no text, no images) are silently skipped
  - `run_claude_with_config` completes with empty prompt + image_urls
  - Image URLs are correctly injected into the runner

## Context

The same root issue (empty prompt from image-only messages) was fixed twice before in different layers (#182, #186) but kept recurring because there were no integration tests covering the full path. This PR adds the test coverage to catch regressions early.

## Test plan

- [x] 750 tests pass (5 new + 745 existing)
- [x] ruff check + ruff format clean
- [ ] Manual: send image-only message to Dynabook thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)