### PR TITLE
[docs-sync] Update architecture diagram for prompt_builder and session_sync modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,8 @@ claude_discord/
     claude_chat.py         # Interactive chat (thread creation, message handling)
     skill_command.py       # /skill slash command with autocomplete
     session_manage.py      # /sessions, /sync-sessions, /resume-info
+    session_sync.py        # Thread-creation and message-posting logic for sync-sessions (extracted from SessionManageCog)
+    prompt_builder.py      # build_prompt_and_images() — pure function, no Cog/Bot state
     scheduler.py           # Periodic Claude Code task executor
     webhook_trigger.py     # Webhook → Claude Code task execution (CI/CD)
     auto_upgrade.py        # Webhook → package upgrade + drain-aware restart

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -502,6 +502,8 @@ claude_discord/
     claude_chat.py         # インタラクティブチャット（スレッド作成、メッセージ処理）
     skill_command.py       # /skill スラッシュコマンド（オートコンプリート付き）
     session_manage.py      # /sessions, /sync-sessions, /resume-info
+    session_sync.py        # sync-sessions のスレッド作成・メッセージ投稿ロジック（SessionManageCog から抽出）
+    prompt_builder.py      # build_prompt_and_images() — 純粋関数、Cog/Bot 状態に非依存
     scheduler.py           # 定期 Claude Code タスク実行エンジン
     webhook_trigger.py     # Webhook → Claude Code タスク実行（CI/CD）
     auto_upgrade.py        # Webhook → パッケージアップグレード + DrainAware 再起動


### PR DESCRIPTION
## Summary
- Added `cogs/session_sync.py` and `cogs/prompt_builder.py` to the architecture diagram in README.md
- These two modules were extracted from `SessionManageCog` and `ClaudeChatCog` respectively in PR #188 (refactor: extract prompt_builder and session_sync, remove dead re-exports)

## 概要
- PR #188 のリファクタリングで `SessionManageCog` から抽出された `cogs/session_sync.py` と、`ClaudeChatCog` から抽出された `cogs/prompt_builder.py` をアーキテクチャ図に追記
- 英語版 `README.md` および日本語版 `docs/ja/README.md` の両方を更新

## Changed files
- `README.md`
- `docs/ja/README.md`

---
🤖 Auto-generated by [docs-sync](https://github.com/ebibibi/claude-code-discord-bridge)
