### PR TITLE
ci: add Windows and macOS runners with cross-platform tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
@@ -31,12 +33,15 @@ jobs:
 
       - name: Lint
         run: uv run ruff check claude_discord/
+        if: matrix.os == 'ubuntu-latest'
 
       - name: Format check
         run: uv run ruff format --check claude_discord/
+        if: matrix.os == 'ubuntu-latest'
 
       - name: Type check
         run: uv run pyright claude_discord/
+        if: matrix.os == 'ubuntu-latest'
 
       - name: Test
         run: uv run pytest tests/ -v --cov=claude_discord --cov-report=term-missing


### PR DESCRIPTION
## Summary
- Extend CI matrix to `ubuntu-latest`, `windows-latest`, `macos-latest` × Python 3.10–3.12
- Add `fail-fast: false` so all OS results are visible even if one fails
- Lint/format/type checks run on Ubuntu only (OS-independent, no need to repeat)
- Add 7 unit tests for `_resolve_windows_cmd` covering primary path, fallback, error cases, and `_build_args` integration

## Why these tests?
`_resolve_windows_cmd` can't be tested on a real Windows npm installation in CI, but by using `tmp_path` fixtures and `sys.platform` mocking, all logic branches are exercised on every OS.

## Test plan
- [ ] All 9 jobs (3 OS × 3 Python versions) pass on GitHub Actions
- [ ] `TestResolveWindowsCmd` — 7 new tests pass on all platforms
- [ ] Existing 750 tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)