### PR TITLE
feat: send written/edited files as Discord attachments on session complete

### DIFF
--- a/claude_discord/claude/types.py
+++ b/claude_discord/claude/types.py
@@ -203,3 +203,6 @@ class SessionState:
     active_timers: dict[str, asyncio.Task[None]] = field(default_factory=dict)
     # TodoWrite: reference to the live todo embed message (edited in-place on each update)
     todo_message: discord.Message | None = None
+    # Paths of files written/edited during this session (Write, Edit, MultiEdit tools).
+    # Collected by _handle_tool_use() and sent as Discord attachments on session complete.
+    written_files: list[str] = field(default_factory=list)

--- a/claude_discord/discord_ui/file_sender.py
+++ b/claude_discord/discord_ui/file_sender.py
@@ -1,0 +1,173 @@
+"""File attachment sender for session-complete events.
+
+Collects files written/edited during a Claude session and sends them as
+Discord attachments when the session completes successfully.
+
+Configuration (environment variables):
+    CCDB_ATTACH_WRITTEN_FILES: Set to "false", "0", or "no" to disable.
+        Defaults to enabled.
+    CCDB_ATTACH_MAX_BYTES: Per-file size limit in bytes.
+        Defaults to 524288 (512 KB).
+
+Discord limits: 10 files per message, 8 MB per file (non-boosted server).
+Files exceeding the configured size limit or detected as binary are skipped.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import logging
+import os
+from pathlib import Path
+
+import discord
+
+logger = logging.getLogger(__name__)
+
+# Default per-file size limit — generous for source code, avoids accidental
+# large binary uploads.
+_DEFAULT_MAX_FILE_BYTES = 512 * 1024  # 512 KB
+
+# Discord API hard limit: 10 files per message.
+_MAX_FILES_PER_MESSAGE = 10
+
+
+def _is_enabled() -> bool:
+    """Return False when CCDB_ATTACH_WRITTEN_FILES is set to a falsy value."""
+    return os.environ.get("CCDB_ATTACH_WRITTEN_FILES", "true").lower() not in (
+        "false",
+        "0",
+        "no",
+    )
+
+
+def _max_file_bytes() -> int:
+    """Return the per-file size limit from env, falling back to the default."""
+    raw = os.environ.get("CCDB_ATTACH_MAX_BYTES", "")
+    if raw:
+        with contextlib.suppress(ValueError):
+            return int(raw)
+    return _DEFAULT_MAX_FILE_BYTES
+
+
+def _is_binary(data: bytes) -> bool:
+    """Heuristic: treat a file as binary if it contains a null byte in the
+    first 8 KB.  Null bytes never appear in valid UTF-8 source files.
+    """
+    return b"\x00" in data[:8192]
+
+
+def _relative_path(file_path: str, working_dir: str | None) -> str:
+    """Return a display name for the file.
+
+    Prefers a path relative to *working_dir* so the user sees ``src/foo.py``
+    rather than the full absolute path.  Falls back to the bare filename when
+    the file lives outside *working_dir* or no *working_dir* is given.
+    """
+    if working_dir:
+        with contextlib.suppress(ValueError):
+            return str(Path(file_path).relative_to(working_dir))
+    return Path(file_path).name
+
+
+def collect_discord_files(
+    file_paths: list[str],
+    working_dir: str | None,
+    max_bytes: int | None = None,
+) -> list[discord.File]:
+    """Read qualifying files from disk and return ``discord.File`` objects.
+
+    Each file is read into an in-memory ``BytesIO`` buffer so that callers
+    can safely delete the source file (e.g. worktree cleanup) after this
+    function returns without invalidating the attachment.
+
+    Skips files that:
+    * Do not exist on disk
+    * Exceed *max_bytes* (default: 512 KB)
+    * Appear to be binary (contain a null byte in the first 8 KB)
+
+    Args:
+        file_paths: Absolute or working-dir-relative paths to attach.
+        working_dir: Base directory used to compute relative display names.
+        max_bytes: Per-file size limit.  ``None`` reads from env / default.
+
+    Returns:
+        List of ``discord.File`` objects, ready to pass to ``thread.send()``.
+    """
+    limit = max_bytes if max_bytes is not None else _max_file_bytes()
+    result: list[discord.File] = []
+
+    for path_str in file_paths:
+        path = Path(path_str)
+
+        if not path.exists() or not path.is_file():
+            logger.debug("Skipping missing or non-file path: %s", path)
+            continue
+
+        try:
+            size = path.stat().st_size
+        except OSError:
+            logger.debug("Cannot stat file, skipping: %s", path)
+            continue
+
+        if size > limit:
+            logger.info(
+                "Skipping file exceeding size limit (%d > %d bytes): %s",
+                size,
+                limit,
+                path,
+            )
+            continue
+
+        try:
+            data = path.read_bytes()
+        except OSError:
+            logger.debug("Cannot read file, skipping: %s", path, exc_info=True)
+            continue
+
+        if _is_binary(data):
+            logger.debug("Skipping binary file: %s", path)
+            continue
+
+        display_name = _relative_path(path_str, working_dir)
+        result.append(discord.File(io.BytesIO(data), filename=display_name))
+
+    return result
+
+
+async def send_written_files(
+    thread: discord.Thread,
+    file_paths: list[str],
+    working_dir: str | None,
+) -> None:
+    """Send files created during a Claude session as Discord attachments.
+
+    Called from ``EventProcessor._on_complete()`` after a successful session.
+    Sends in batches of up to 10 (Discord API limit).  Any Discord error is
+    suppressed so that a network hiccup never kills the session-complete flow.
+
+    Does nothing when:
+    * ``CCDB_ATTACH_WRITTEN_FILES`` is falsy
+    * *file_paths* is empty
+    * All files fail qualification (binary / missing / oversized)
+
+    Args:
+        thread: Discord thread to post attachments to.
+        file_paths: Paths of files written/edited during the session.
+        working_dir: Runner working directory for relative display names.
+    """
+    if not _is_enabled() or not file_paths:
+        return
+
+    files = collect_discord_files(file_paths, working_dir)
+    if not files:
+        return
+
+    for i in range(0, len(files), _MAX_FILES_PER_MESSAGE):
+        batch = files[i : i + _MAX_FILES_PER_MESSAGE]
+        with contextlib.suppress(Exception):
+            await thread.send(
+                content="-# 📎 Files written this session" if i == 0 else None,
+                files=batch,
+            )

--- a/tests/test_file_sender.py
+++ b/tests/test_file_sender.py
@@ -1,0 +1,238 @@
+"""Tests for discord_ui.file_sender — TDD first pass.
+
+All tests use tmp_path (pytest built-in) and AsyncMock so they run on every
+OS without a real Discord connection.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from claude_discord.discord_ui.file_sender import (
+    _is_binary,
+    _relative_path,
+    collect_discord_files,
+    send_written_files,
+)
+
+# ---------------------------------------------------------------------------
+# _is_binary
+# ---------------------------------------------------------------------------
+
+
+class TestIsBinary:
+    def test_plain_text_is_not_binary(self) -> None:
+        assert _is_binary(b"hello world\nprint('hi')\n") is False
+
+    def test_null_byte_flags_binary(self) -> None:
+        assert _is_binary(b"data\x00more data") is True
+
+    def test_empty_bytes_are_not_binary(self) -> None:
+        assert _is_binary(b"") is False
+
+    def test_null_byte_beyond_first_8kb_not_detected(self) -> None:
+        """Only the first 8 KB is sampled — null bytes later are ignored."""
+        data = b"a" * 8192 + b"\x00"
+        assert _is_binary(data) is False
+
+
+# ---------------------------------------------------------------------------
+# _relative_path
+# ---------------------------------------------------------------------------
+
+
+class TestRelativePath:
+    def test_relative_when_inside_working_dir(self) -> None:
+        assert _relative_path("/work/src/foo.py", "/work") == "src/foo.py"
+
+    def test_basename_when_outside_working_dir(self) -> None:
+        assert _relative_path("/other/foo.py", "/work") == "foo.py"
+
+    def test_basename_when_no_working_dir(self) -> None:
+        assert _relative_path("/some/path/foo.py", None) == "foo.py"
+
+    def test_same_dir_returns_filename(self) -> None:
+        assert _relative_path("/work/foo.py", "/work") == "foo.py"
+
+
+# ---------------------------------------------------------------------------
+# collect_discord_files
+# ---------------------------------------------------------------------------
+
+
+class TestCollectDiscordFiles:
+    def test_text_file_returned_as_discord_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "hello.py"
+        f.write_text("print('hello')", encoding="utf-8")
+
+        files = collect_discord_files([str(f)], str(tmp_path))
+
+        assert len(files) == 1
+        assert files[0].filename == "hello.py"
+
+    def test_relative_display_name_inside_subdir(self, tmp_path: Path) -> None:
+        sub = tmp_path / "src"
+        sub.mkdir()
+        f = sub / "main.py"
+        f.write_text("x = 1", encoding="utf-8")
+
+        files = collect_discord_files([str(f)], str(tmp_path))
+
+        assert files[0].filename == "src/main.py"
+
+    def test_missing_file_is_skipped(self, tmp_path: Path) -> None:
+        missing = str(tmp_path / "ghost.py")
+
+        files = collect_discord_files([missing], str(tmp_path))
+
+        assert files == []
+
+    def test_oversized_file_is_skipped(self, tmp_path: Path) -> None:
+        f = tmp_path / "big.txt"
+        f.write_bytes(b"x" * 1024)
+
+        files = collect_discord_files([str(f)], str(tmp_path), max_bytes=512)
+
+        assert files == []
+
+    def test_binary_file_is_skipped(self, tmp_path: Path) -> None:
+        f = tmp_path / "binary.bin"
+        f.write_bytes(b"\x00\x01\x02\x03")
+
+        files = collect_discord_files([str(f)], str(tmp_path))
+
+        assert files == []
+
+    def test_multiple_valid_files_all_returned(self, tmp_path: Path) -> None:
+        (tmp_path / "a.py").write_text("a = 1", encoding="utf-8")
+        (tmp_path / "b.py").write_text("b = 2", encoding="utf-8")
+
+        files = collect_discord_files(
+            [str(tmp_path / "a.py"), str(tmp_path / "b.py")],
+            str(tmp_path),
+        )
+
+        assert len(files) == 2
+        names = {f.filename for f in files}
+        assert names == {"a.py", "b.py"}
+
+    def test_file_content_readable_from_returned_object(self, tmp_path: Path) -> None:
+        f = tmp_path / "code.py"
+        f.write_text("result = 42", encoding="utf-8")
+
+        files = collect_discord_files([str(f)], str(tmp_path))
+
+        # The discord.File fp is an in-memory BytesIO
+        content = files[0].fp.read()
+        assert b"result = 42" in content
+
+    def test_no_working_dir_uses_basename(self, tmp_path: Path) -> None:
+        f = tmp_path / "foo.py"
+        f.write_text("x = 1", encoding="utf-8")
+
+        files = collect_discord_files([str(f)], None)
+
+        assert files[0].filename == "foo.py"
+
+
+# ---------------------------------------------------------------------------
+# send_written_files
+# ---------------------------------------------------------------------------
+
+
+class TestSendWrittenFiles:
+    @pytest.mark.asyncio
+    async def test_does_nothing_when_disabled_by_env(self, tmp_path: Path) -> None:
+        thread = MagicMock()
+        thread.send = AsyncMock()
+        f = tmp_path / "foo.py"
+        f.write_text("x = 1", encoding="utf-8")
+
+        with patch.dict(os.environ, {"CCDB_ATTACH_WRITTEN_FILES": "false"}):
+            await send_written_files(thread, [str(f)], str(tmp_path))
+
+        thread.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_does_nothing_for_empty_list(self) -> None:
+        thread = MagicMock()
+        thread.send = AsyncMock()
+
+        await send_written_files(thread, [], None)
+
+        thread.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sends_file_attachment(self, tmp_path: Path) -> None:
+        thread = MagicMock()
+        thread.send = AsyncMock()
+        f = tmp_path / "result.py"
+        f.write_text("print('done')", encoding="utf-8")
+
+        await send_written_files(thread, [str(f)], str(tmp_path))
+
+        thread.send.assert_called_once()
+        kwargs = thread.send.call_args.kwargs
+        assert "files" in kwargs
+        assert len(kwargs["files"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_discord_error_does_not_propagate(self, tmp_path: Path) -> None:
+        """A Discord API failure must not crash the session."""
+        thread = MagicMock()
+        thread.send = AsyncMock(side_effect=Exception("connection reset"))
+        f = tmp_path / "foo.py"
+        f.write_text("x = 1", encoding="utf-8")
+
+        # Must complete without raising
+        await send_written_files(thread, [str(f)], str(tmp_path))
+
+    @pytest.mark.asyncio
+    async def test_batches_more_than_10_files(self, tmp_path: Path) -> None:
+        """Discord allows max 10 files per message; extras go in a second send."""
+        thread = MagicMock()
+        thread.send = AsyncMock()
+
+        paths = []
+        for i in range(12):
+            f = tmp_path / f"file{i}.py"
+            f.write_text(f"x = {i}", encoding="utf-8")
+            paths.append(str(f))
+
+        await send_written_files(thread, paths, str(tmp_path))
+
+        # 12 files → 2 calls (10 + 2)
+        assert thread.send.call_count == 2
+        first_batch = thread.send.call_args_list[0].kwargs["files"]
+        second_batch = thread.send.call_args_list[1].kwargs["files"]
+        assert len(first_batch) == 10
+        assert len(second_batch) == 2
+
+    @pytest.mark.asyncio
+    async def test_skips_all_binary_files_sends_nothing(self, tmp_path: Path) -> None:
+        thread = MagicMock()
+        thread.send = AsyncMock()
+        f = tmp_path / "img.png"
+        f.write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00")
+
+        await send_written_files(thread, [str(f)], str(tmp_path))
+
+        thread.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_env_false_variants(self, tmp_path: Path) -> None:
+        """'0' and 'no' also disable the feature."""
+        thread = MagicMock()
+        thread.send = AsyncMock()
+        f = tmp_path / "foo.py"
+        f.write_text("x = 1", encoding="utf-8")
+
+        for val in ("0", "no", "NO", "False", "FALSE"):
+            thread.send.reset_mock()
+            with patch.dict(os.environ, {"CCDB_ATTACH_WRITTEN_FILES": val}):
+                await send_written_files(thread, [str(f)], str(tmp_path))
+            thread.send.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "1.5.0"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Closes the gap between Claude writing a file and the user receiving it on mobile
- Files created/edited via **Write**, **Edit**, or **MultiEdit** tools are now automatically sent as Discord attachments when a session completes successfully
- Configurable: `CCDB_ATTACH_WRITTEN_FILES=false` disables, `CCDB_ATTACH_MAX_BYTES` sets per-file size limit (default 512 KB)

## Changes

| File | Type | Description |
|------|------|-------------|
| `claude_discord/discord_ui/file_sender.py` | **New** | Core logic: binary detection, size filtering, `discord.File` creation, batched sending |
| `tests/test_file_sender.py` | **New** | 23 unit tests covering all edge cases |
| `claude_discord/claude/types.py` | **Modified** | `SessionState.written_files: list[str]` field added |
| `claude_discord/cogs/event_processor.py` | **Modified** | Tracks file paths in `_handle_tool_use()`; calls `send_written_files()` in `_on_complete()` |
| `tests/test_event_processor.py` | **Modified** | `TestWrittenFilesTracking` (7 tests) + `TestOnCompleteFileSending` (3 tests) |

## Behavior

- Files are sent **before** the session-complete summary embed (natural order: files → summary)
- First batch message: `-# 📎 Files written this session`
- Batched in groups of 10 (Discord API limit)
- Binary files (null byte heuristic), missing files, and oversized files are silently skipped
- Any Discord API error is suppressed — never crashes the session-complete flow
- Worktree cleanup in `_run_helper.py` happens **after** `_on_complete()`, so files are safe to read

## Test plan

- [x] 790 tests pass (`uv run pytest tests/ -v`)
- [x] `ruff check` — no issues
- [x] `ruff format --check` — no issues
- [x] `pyright` — 0 errors, 0 warnings
- [ ] Manual: send "write a hello.py that prints Hello" in Discord, confirm `hello.py` attached after session completes
- [ ] Manual: set `CCDB_ATTACH_WRITTEN_FILES=false`, confirm no attachments sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)