### PR TITLE
[docs-sync] Update documentation (English + Japanese)

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,8 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `COORDINATION_CHANNEL_ID` | Channel ID for cross-session event broadcasts | (optional) |
 | `CCDB_COORDINATION_CHANNEL_NAME` | Auto-create coordination channel by name | (optional) |
 | `WORKTREE_BASE_DIR` | Base directory to scan for session worktrees (enables automatic cleanup) | (optional) |
+| `CCDB_ATTACH_WRITTEN_FILES` | Send files written/edited during a session as Discord attachments on session complete (`true`/`1`/`yes` to enable) | `false` |
+| `CCDB_ATTACH_MAX_BYTES` | Per-file size limit for attachments in bytes (files over this limit are skipped) | `524288` (512 KB) |
 
 ---
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -279,6 +279,8 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `COORDINATION_CHANNEL_ID` | セッション間イベントブロードキャスト用チャンネル ID | （オプション） |
 | `CCDB_COORDINATION_CHANNEL_NAME` | 協調チャンネルを名前で自動作成 | （オプション） |
 | `WORKTREE_BASE_DIR` | セッション Worktree のスキャン対象ディレクトリ（自動クリーンアップを有効化） | （オプション） |
+| `CCDB_ATTACH_WRITTEN_FILES` | セッション完了時に書き込み・編集したファイルを Discord に添付（`true`/`1`/`yes` で有効化） | `false` |
+| `CCDB_ATTACH_MAX_BYTES` | 添付ファイルのサイズ上限（バイト単位、上限超過のファイルはスキップ） | `524288`（512 KB） |
 
 ---
 


### PR DESCRIPTION
## Summary
- Added `CCDB_ATTACH_WRITTEN_FILES` and `CCDB_ATTACH_MAX_BYTES` environment variables to the Configuration table — these were introduced in v1.6.0 but were missing from the docs
- Reflects the v1.6.1 behavior change: file attachment is now **opt-in** (default `false`) rather than opt-out

## 概要
- v1.6.0 で追加されたファイル添付機能の環境変数 `CCDB_ATTACH_WRITTEN_FILES` / `CCDB_ATTACH_MAX_BYTES` が Configuration テーブルに未記載だったため追記
- v1.6.1 の動作変更を反映：ファイル添付はデフォルト `false`（opt-in）に変更済み

## Changed files
- `README.md`
- `docs/ja/README.md`

---
🤖 Auto-generated by [docs-sync](https://github.com/ebibibi/claude-code-discord-bridge)
