### PR TITLE
[docs-sync] Update documentation (English + Japanese)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ If the bot restarts mid-session, interrupted Claude sessions are automatically r
 
 #### 🔌 Input & Skills
 - **Attachment support** — Text files auto-appended to prompt (up to 5 × 50 KB); images sent as Discord CDN URLs via `--input-format stream-json` (up to 4 × 5 MB)
+- **On-demand file delivery** — Ask Claude to "send me" or "attach" a file and it writes the path to `.ccdb-attachments`; the bot reads it and delivers the file as a Discord attachment when the session completes
 - **Skill execution** — `/skill` command with autocomplete, optional args, in-thread resume
 - **Hot reload** — New skills added to `~/.claude/skills/` are picked up automatically (60s refresh, no restart)
 
@@ -344,8 +345,6 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `COORDINATION_CHANNEL_ID` | Channel ID for cross-session event broadcasts | (optional) |
 | `CCDB_COORDINATION_CHANNEL_NAME` | Auto-create coordination channel by name | (optional) |
 | `WORKTREE_BASE_DIR` | Base directory to scan for session worktrees (enables automatic cleanup) | (optional) |
-| `CCDB_ATTACH_WRITTEN_FILES` | Send files written/edited during a session as Discord attachments on session complete (`true`/`1`/`yes` to enable) | `false` |
-| `CCDB_ATTACH_MAX_BYTES` | Per-file size limit for attachments in bytes (files over this limit are skipped) | `524288` (512 KB) |
 
 ---
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -162,6 +162,7 @@ Bot の再起動中にセッションが中断された場合、Bot が再起動
 
 #### 🔌 入力とスキル
 - **添付ファイル対応** — テキストファイルをプロンプトに自動追加（最大 5 ファイル × 50 KB）；画像は Discord CDN URL として `--input-format stream-json` 経由で送信（最大 4 枚 × 5 MB）
+- **オンデマンドファイル配信** — 「送って」「添付して」などと指示すると Claude が `.ccdb-attachments` にパスを書き込み、セッション完了時に Bot がファイルを Discord に添付して送信
 - **スキル実行** — `/skill` コマンド（オートコンプリート付き）、オプション引数、スレッド内リジューム
 - **ホットリロード** — `~/.claude/skills/` に追加した新スキルを自動検出（60 秒更新、再起動不要）
 
@@ -279,8 +280,6 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `COORDINATION_CHANNEL_ID` | セッション間イベントブロードキャスト用チャンネル ID | （オプション） |
 | `CCDB_COORDINATION_CHANNEL_NAME` | 協調チャンネルを名前で自動作成 | （オプション） |
 | `WORKTREE_BASE_DIR` | セッション Worktree のスキャン対象ディレクトリ（自動クリーンアップを有効化） | （オプション） |
-| `CCDB_ATTACH_WRITTEN_FILES` | セッション完了時に書き込み・編集したファイルを Discord に添付（`true`/`1`/`yes` で有効化） | `false` |
-| `CCDB_ATTACH_MAX_BYTES` | 添付ファイルのサイズ上限（バイト単位、上限超過のファイルはスキップ） | `524288`（512 KB） |
 
 ---
 


### PR DESCRIPTION
## Summary
- Removed `CCDB_ATTACH_WRITTEN_FILES` and `CCDB_ATTACH_MAX_BYTES` environment variables from docs — both were deleted from source code in v1.6.1 as part of the file attachment redesign
- Added description of the new on-demand file delivery mechanism: Claude writes paths to `.ccdb-attachments`; the bot attaches the listed files when the session completes

## 概要
- `CCDB_ATTACH_WRITTEN_FILES` と `CCDB_ATTACH_MAX_BYTES` 環境変数の説明を削除 — v1.6.1 のファイル添付リデザインでソースコードから完全削除されたため
- 新しいオンデマンドファイル配信の仕組みの説明を追加：Claude が `.ccdb-attachments` にパスを書き込み、セッション完了時に Bot がファイルを Discord に添付

## Changed files
- `README.md`
- `docs/ja/README.md`

---
🤖 Auto-generated by [docs-sync](https://github.com/ebibibi/claude-code-discord-bridge)
