### PR TITLE
[docs-sync] Update documentation (English + Japanese)

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,28 @@ MENTION_ONLY_CHANNEL_IDS=222,333
 
 Thread replies are not affected — once a session thread is open, all replies are handled normally regardless of mentions.
 
+#### Inline-Reply Channels
+
+To make the bot respond **directly in the channel** (without creating a thread) for specific channels (useful for personal command channels where threads add unnecessary clutter):
+
+```python
+await setup_bridge(
+    bot,
+    runner,
+    claude_channel_ids={111, 333},
+    inline_reply_channel_ids={333},  # bot replies inline in #333, no thread created
+    allowed_user_ids={int(os.environ["DISCORD_OWNER_ID"])},
+)
+```
+
+Or via environment variable (comma-separated channel IDs):
+
+```
+INLINE_REPLY_CHANNEL_IDS=333,444
+```
+
+In inline-reply mode, Claude's response is sent directly as a message in the channel rather than spawning a new thread. Sessions are still tracked internally, so follow-up messages in the channel continue the same Claude session.
+
 ---
 
 ## Configuration
@@ -387,6 +409,8 @@ Thread replies are not affected — once a session thread is open, all replies a
 | `DISCORD_OWNER_ID` | User ID to @-mention when Claude needs input | (optional) |
 | `COORDINATION_CHANNEL_ID` | Channel ID for cross-session event broadcasts | (optional) |
 | `CCDB_COORDINATION_CHANNEL_NAME` | Auto-create coordination channel by name | (optional) |
+| `MENTION_ONLY_CHANNEL_IDS` | Comma-separated channel IDs where the bot only responds when @mentioned | (optional) |
+| `INLINE_REPLY_CHANNEL_IDS` | Comma-separated channel IDs where the bot replies inline (no thread created) | (optional) |
 | `WORKTREE_BASE_DIR` | Base directory to scan for session worktrees (enables automatic cleanup) | (optional) |
 
 ---

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -305,6 +305,28 @@ MENTION_ONLY_CHANNEL_IDS=222,333
 
 スレッド内の返信はメンションチェックの対象外です。セッションスレッドが開かれた後は、メンションの有無に関わらず通常通り応答します。
 
+#### インライン返信チャンネル
+
+特定のチャンネルで**スレッドを作らずにチャンネル内に直接返信**させることができます（個人コマンドチャンネルなど、スレッドが煩わしい場合に便利）:
+
+```python
+await setup_bridge(
+    bot,
+    runner,
+    claude_channel_ids={111, 333},
+    inline_reply_channel_ids={333},  # #333 ではスレッドを作らずインライン返信
+    allowed_user_ids={int(os.environ["DISCORD_OWNER_ID"])},
+)
+```
+
+環境変数でも設定可能（カンマ区切りのチャンネル ID）:
+
+```
+INLINE_REPLY_CHANNEL_IDS=333,444
+```
+
+インライン返信モードでは、Claude の返信は新しいスレッドではなくチャンネル内のメッセージとして直接送信されます。セッションは内部で追跡されているため、その後のメッセージも同じ Claude セッションとして継続します。
+
 ---
 
 ## 設定
@@ -322,6 +344,8 @@ MENTION_ONLY_CHANNEL_IDS=222,333
 | `DISCORD_OWNER_ID` | Claude が入力待ちのとき @mention する Discord ユーザー ID | （オプション） |
 | `COORDINATION_CHANNEL_ID` | セッション間イベントブロードキャスト用チャンネル ID | （オプション） |
 | `CCDB_COORDINATION_CHANNEL_NAME` | 協調チャンネルを名前で自動作成 | （オプション） |
+| `MENTION_ONLY_CHANNEL_IDS` | @メンション時のみ応答するチャンネル ID（カンマ区切り） | （オプション） |
+| `INLINE_REPLY_CHANNEL_IDS` | インライン返信チャンネル ID（カンマ区切り、スレッドを作成しない） | （オプション） |
 | `WORKTREE_BASE_DIR` | セッション Worktree のスキャン対象ディレクトリ（自動クリーンアップを有効化） | （オプション） |
 
 ---


### PR DESCRIPTION
## Summary
- Added `inline_reply_channel_ids` documentation to README, which was introduced in feat commit b2a5445 but omitted from the previous docs-sync
- Added `Inline-Reply Channels` section showing `setup_bridge()` usage and `INLINE_REPLY_CHANNEL_IDS` env var
- Added `MENTION_ONLY_CHANNEL_IDS` and `INLINE_REPLY_CHANNEL_IDS` to the Configuration table

## 概要
- feat コミット b2a5445 で追加された `inline_reply_channel_ids` のドキュメントを追加（前回の docs-sync で漏れていた）
- `setup_bridge()` の使用例と `INLINE_REPLY_CHANNEL_IDS` 環境変数を示す「Inline-Reply Channels」セクションを追加
- 設定テーブルに `MENTION_ONLY_CHANNEL_IDS` と `INLINE_REPLY_CHANNEL_IDS` を追加

## Changed files
- `README.md`
- `docs/ja/README.md`

---
🤖 Auto-generated by [docs-sync](https://github.com/ebibibi/claude-code-discord-bridge)
