### PR TITLE
fix: use GitHub API for branch cleanup to support squash merges

### DIFF
--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -12,35 +12,41 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Delete merged remote branches
+      - name: Delete branches with merged/closed PRs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # main にマージ済みのリモートブランチを一括削除
-          # 保護ブランチ (main, master, develop, release/*) は除外
-          PROTECTED="^(main|master|develop|release/)$"
-
-          git fetch --prune origin
+          # squash merge を使うと git branch --merged では検出できないため
+          # GitHub API で「マージ済み or クローズ済みの PR を持つブランチ」を削除する
+          PROTECTED="^(main|master|develop|release/)"
 
           DELETED=0
-          for branch in $(git branch -r --merged origin/main \
-                          | grep 'origin/' \
-                          | sed 's|origin/||' \
-                          | grep -vE "$PROTECTED"); do
-            echo "Deleting merged branch: $branch"
-            gh api repos/${{ github.repository }}/git/refs/heads/$branch \
-              --method DELETE && DELETED=$((DELETED + 1))
+
+          # クローズ済み PR のブランチを取得して削除
+          for branch in $(gh api repos/${{ github.repository }}/pulls \
+              --method GET \
+              --field state=closed \
+              --field per_page=100 \
+              --paginate \
+              --jq '.[].head.ref' \
+              | grep -vE "$PROTECTED" \
+              | sort -u); do
+
+            # そのブランチが現在リモートに存在するか確認してから削除
+            if gh api "repos/${{ github.repository }}/git/refs/heads/$branch" \
+                --silent 2>/dev/null; then
+              echo "Deleting: $branch"
+              gh api "repos/${{ github.repository }}/git/refs/heads/$branch" \
+                --method DELETE
+              DELETED=$((DELETED + 1))
+            fi
           done
 
-          echo "Deleted $DELETED merged branch(es)."
+          echo "Deleted $DELETED branch(es)."
 
           if [ "$DELETED" -gt 0 ]; then
             curl -s -o /dev/null -w "%{http_code}" \
               -H "Content-Type: application/json" \
-              -d "{\"content\": \"🧹 **Branch cleanup** — ${DELETED} merged branch(es) deleted.\"}" \
+              -d "{\"content\": \"🧹 **Branch cleanup** — ${DELETED} merged/closed branch(es) deleted.\"}" \
               "${{ secrets.DISCORD_WEBHOOK_URL }}"
           fi


### PR DESCRIPTION
## Summary

Fixes the `cleanup-branches.yml` workflow to correctly detect merged branches
when using squash merge strategy.

## Problem

`git branch -r --merged origin/main` cannot detect squash-merged branches
because the branch tip commit is not included in main's ancestry (a new
squashed commit is created instead).

## Fix

Use the GitHub API to query closed PRs and delete their head branches.
This works regardless of merge strategy (squash, merge commit, rebase).

```yaml
gh api repos/.../pulls --field state=closed --paginate --jq '.[].head.ref'
```