### PR TITLE
fix: handle text attachments with missing content_type (Discord long-text auto-convert)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "1.7.0"
+version = "1.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Problem

When a user pastes a long message in Discord, it is automatically converted
to a file attachment (e.g. `message.txt`) **without a `content_type`**.

The bot silently skipped these because:
```python
content_type = attachment.content_type or ""  # → ""
"".startswith(("text/", ...))  # → False → skipped
```

## Fix

Fall back to extension-based MIME detection when `content_type` is absent:

| Extension | Treatment |
|-----------|-----------|
| `.txt`, `.py`, `.md`, `.json`, `.yaml`, … | Inlined as text in the prompt |
| `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, … | CDN URL passed as image input |
| Unknown (`.bin`, `.exe`, …) | Skipped safely (unchanged behavior) |

## Test plan

- [x] `TestNoContentType` suite added (4 tests)
  - `.txt` auto-converted message → inlined in prompt ✅
  - `.py` code file → inlined in prompt ✅
  - `.bin` unknown extension → skipped ✅
  - `.png` image → CDN URL collected ✅
- [x] All 831 existing tests still pass