### PR TITLE
fix: replace silent suppress(Exception) with logging + narrow exception handling

### DIFF
--- a/claude_discord/cogs/_run_helper.py
+++ b/claude_discord/cogs/_run_helper.py
@@ -137,7 +137,7 @@ async def _cleanup_session_worktree(config: RunConfig) -> None:
             )
             # Notify the Discord thread if there are uncommitted changes
             if "uncommitted changes" in result.reason:
-                with contextlib.suppress(Exception):
+                with contextlib.suppress(discord.HTTPException):
                     await config.thread.send(
                         f"⚠️ **Worktree not cleaned up** — `{result.path}` has uncommitted "
                         f"changes. Please commit or stash them, then run:\n"

--- a/claude_discord/discord_ui/file_sender.py
+++ b/claude_discord/discord_ui/file_sender.py
@@ -139,8 +139,15 @@ async def send_files(
 
     for i in range(0, len(files), _MAX_FILES_PER_MESSAGE):
         batch = files[i : i + _MAX_FILES_PER_MESSAGE]
-        with contextlib.suppress(Exception):
+        try:
             await thread.send(
                 content="-# 📎 Files attached" if i == 0 else None,
                 files=batch,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to send file attachment batch %d/%d to Discord",
+                i // _MAX_FILES_PER_MESSAGE + 1,
+                -(-len(files) // _MAX_FILES_PER_MESSAGE),
+                exc_info=True,
             )

--- a/claude_discord/discord_ui/views.py
+++ b/claude_discord/discord_ui/views.py
@@ -82,7 +82,7 @@ class StopView(discord.ui.View):
         await interaction.response.edit_message(view=self)
         await self._runner.interrupt()
 
-        with contextlib.suppress(Exception):
+        with contextlib.suppress(discord.HTTPException):
             await interaction.followup.send(embed=stopped_embed())
 
     async def disable(self, message: discord.Message | None = None) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "1.7.4"
+version = "1.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Problem

`suppress(Exception)` was used in many places throughout the codebase, silently
discarding ALL errors including programming bugs. The worst cases caused **Claude
to become permanently stuck** waiting for user interaction that was never delivered.

## Root Cause Categories

### CRITICAL — Claude stuck waiting, user sees nothing
- `_handle_plan_approval`: if Discord send fails, Claude pauses forever waiting for approval the user never sees
- `_handle_permission_request`: same — Allow/Deny buttons never appear
- `_handle_elicitation`: same — MCP form/URL button never appears

All three had `logger.info("... posted")` running unconditionally *after* the
suppressed send, giving a **false "posted" log entry** while the user saw nothing.

### HIGH — UI stuck as "in-progress", but session continues
- Tool result embed `edit()` calls: message stays as ⏳ spinning forever on failure
- Todo embed repost: embed silently disappears when send fails

### MEDIUM — Too-broad suppression catches programming bugs
- Compaction notification, requester mention, file attachment delivery, Stop button
  followup, worktree cleanup notification — all using `suppress(Exception)` where
  only `discord.HTTPException` was intended

## Fix

| Location | Before | After |
|----------|--------|-------|
| `_handle_plan_approval` | `suppress(Exception)` | no suppress — exception propagates to outer error handler → user sees error embed |
| `_handle_permission_request` | `suppress(Exception)` | same |
| `_handle_elicitation` | `suppress(Exception)` | same |
| Tool result `edit()` | `suppress(Exception)` | `try/except Exception` + `logger.warning(..., exc_info=True)` |
| Todo delete/repost | `suppress(Exception)` | `try/except Exception` + `logger.warning(..., exc_info=True)` |
| File attachment send | `suppress(Exception)` | `try/except Exception` + `logger.warning(..., exc_info=True)` |
| Compaction notify | `suppress(Exception)` | `suppress(discord.HTTPException)` |
| Requester mention | `suppress(Exception)` | `suppress(discord.HTTPException)` |
| Stop button followup | `suppress(Exception)` | `suppress(discord.HTTPException)` |
| Worktree cleanup notify | `suppress(Exception)` | `suppress(discord.HTTPException)` |

## Principle

> A visible error is always better than silent failure.

- **Critical interactive flows**: let exceptions propagate → outer handler posts error embed
- **Cosmetic UI updates**: catch all exceptions but log at WARNING with traceback
- **Purely decorative Discord API calls**: narrow to `discord.HTTPException` only

## Tests

All 833 tests pass. Existing resilience tests updated from testing silent suppression
to testing that failures are logged (behavior preserved: session never killed by
cosmetic failures).