### PR TITLE
[docs-sync] Add Permission Modes section to zh-CN, ko, es, pt-BR, fr translations

### DIFF
--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -260,6 +260,23 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `CCDB_COORDINATION_CHANNEL_NAME` | Crear automáticamente canal de coordinación por nombre | (opcional) |
 | `WORKTREE_BASE_DIR` | Directorio base para escanear worktrees de sesión (activa limpieza automática) | (opcional) |
 
+### Modos de Permiso — Qué Funciona en el Modo `-p`
+
+Claude Code CLI se ejecuta en **modo `-p` (no interactivo)** cuando se usa a través de ccdb. En este modo, el CLI **no puede solicitar permisos** — las herramientas que requieren aprobación son rechazadas de inmediato. Esta es una [restricción de diseño del CLI](https://code.claude.com/docs/en/headless), no una limitación de ccdb.
+
+| Modo | Comportamiento en modo `-p` | Recomendación |
+|------|----------------------|----------------|
+| `default` | ❌ **Todas las herramientas rechazadas** — inutilizable | No usar |
+| `acceptEdits` | ⚠️ Edit/Write aprobados automáticamente, Bash rechazado (Claude usa Write para operaciones de archivo) | Opción mínima viable |
+| `bypassPermissions` | ✅ Todas las herramientas aprobadas | Funciona, pero preferir la opción abajo |
+| **`CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`** | ✅ **Todas las herramientas aprobadas** | **Recomendado** — ccdb ya restringe el acceso con `allowed_user_ids` |
+
+**Nuestra recomendación:** Configura `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`. Como ccdb controla quién puede interactuar con Claude mediante `allowed_user_ids`, las verificaciones de permisos a nivel del CLI añaden fricción sin beneficio de seguridad real. El «dangerously» en el nombre refleja la advertencia general del CLI; en el contexto de ccdb donde el acceso ya está restringido, es la elección práctica.
+
+Si prefieres control granular, el soporte de `CLAUDE_ALLOWED_TOOLS` está planificado ([#217](https://github.com/ebibibi/claude-code-discord-bridge/issues/217)).
+
+> **¿Por qué no aparecen botones de permisos en Discord?** El modo `-p` del CLI nunca emite eventos `permission_request`, por lo que no hay nada que ccdb pueda mostrar. Los botones `AskUserQuestion` que ves (prompts de selección de Claude) son un mecanismo diferente que funciona correctamente. Consulta [#210](https://github.com/ebibibi/claude-code-discord-bridge/issues/210) para la investigación completa.
+
 ---
 
 ## Configuración del Bot de Discord

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -260,6 +260,23 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `CCDB_COORDINATION_CHANNEL_NAME` | Créer automatiquement un canal de coordination par nom | (optionnel) |
 | `WORKTREE_BASE_DIR` | Répertoire de base pour scanner les worktrees de session (active le nettoyage automatique) | (optionnel) |
 
+### Modes d'autorisation — Ce qui fonctionne en mode `-p`
+
+Le CLI Claude Code s'exécute en **mode `-p` (non interactif)** lorsqu'il est utilisé via ccdb. Dans ce mode, le CLI **ne peut pas demander d'autorisation** — les outils nécessitant une approbation sont immédiatement rejetés. Il s'agit d'une [contrainte de conception du CLI](https://code.claude.com/docs/en/headless), pas d'une limitation de ccdb.
+
+| Mode | Comportement en mode `-p` | Recommandation |
+|------|----------------------|----------------|
+| `default` | ❌ **Tous les outils rejetés** — inutilisable | Ne pas utiliser |
+| `acceptEdits` | ⚠️ Edit/Write approuvés automatiquement, Bash rejeté (Claude utilise Write pour les opérations sur fichiers) | Option minimale viable |
+| `bypassPermissions` | ✅ Tous les outils approuvés | Fonctionne, mais préférer l'option ci-dessous |
+| **`CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`** | ✅ **Tous les outils approuvés** | **Recommandé** — ccdb restreint déjà l'accès via `allowed_user_ids` |
+
+**Notre recommandation :** Définissez `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`. Puisque ccdb contrôle qui peut interagir avec Claude via `allowed_user_ids`, les vérifications d'autorisation au niveau du CLI ajoutent des frictions sans bénéfice sécuritaire réel. Le «dangerously» dans le nom reflète l'avertissement général du CLI ; dans le contexte de ccdb où l'accès est déjà contrôlé, c'est le choix pratique.
+
+Si vous préférez un contrôle plus fin, le support de `CLAUDE_ALLOWED_TOOLS` est prévu ([#217](https://github.com/ebibibi/claude-code-discord-bridge/issues/217)).
+
+> **Pourquoi les boutons d'autorisation n'apparaissent-ils pas dans Discord ?** Le mode `-p` du CLI n'émet jamais d'événements `permission_request`, donc il n'y a rien à afficher pour ccdb. Les boutons `AskUserQuestion` que vous voyez (invites de sélection de Claude) sont un mécanisme différent qui fonctionne correctement. Voir [#210](https://github.com/ebibibi/claude-code-discord-bridge/issues/210) pour l'investigation complète.
+
 ---
 
 ## Configuration du Bot Discord

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -260,6 +260,23 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `CCDB_COORDINATION_CHANNEL_NAME` | 이름으로 조율 채널 자동 생성 | (선택) |
 | `WORKTREE_BASE_DIR` | 세션 worktree 스캔 기본 디렉토리 (자동 정리 활성화) | (선택) |
 
+### 권한 모드 — `-p` 모드에서 작동하는 기능
+
+ccdb를 통해 사용할 때 Claude Code CLI는 **`-p`(비대화형) 모드**로 실행됩니다. 이 모드에서 CLI는 **권한 확인을 요청할 수 없으며** — 승인이 필요한 도구는 즉시 거부됩니다. 이는 ccdb의 제한이 아니라 [CLI의 설계 제약](https://code.claude.com/docs/en/headless)입니다.
+
+| 모드 | `-p` 모드에서의 동작 | 권장 |
+|------|----------------------|----------------|
+| `default` | ❌ **모든 도구 거부** — 사용 불가 | 사용하지 않음 |
+| `acceptEdits` | ⚠️ Edit/Write 자동 승인, Bash 거부 (Claude가 파일 작업에 Write로 폴백) | 최소 동작 옵션 |
+| `bypassPermissions` | ✅ 모든 도구 승인 | 작동하나, 아래 플래그 권장 |
+| **`CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`** | ✅ **모든 도구 승인** | **권장** — ccdb가 이미 `allowed_user_ids`로 접근 제한 |
+
+**권장 설정:** `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`를 설정하세요. ccdb가 `allowed_user_ids`를 통해 Claude와의 상호작용을 제어하므로, CLI 수준의 권한 검사는 실질적인 보안 이점 없이 마찰만 추가합니다. 이름의 「dangerously」는 CLI의 범용 경고를 반영한 것이며, 접근이 이미 게이팅된 ccdb 컨텍스트에서는 실용적인 선택입니다.
+
+더 세밀한 제어를 원한다면 `CLAUDE_ALLOWED_TOOLS` 지원이 계획되어 있습니다 ([#217](https://github.com/ebibibi/claude-code-discord-bridge/issues/217)).
+
+> **Discord에 권한 버튼이 나타나지 않는 이유?** CLI의 `-p` 모드는 `permission_request` 이벤트를 발생시키지 않으므로 ccdb에 표시할 내용이 없습니다. 표시되는 `AskUserQuestion` 버튼(Claude의 선택 프롬프트)은 다른 메커니즘으로 정상 작동합니다. 자세한 조사는 [#210](https://github.com/ebibibi/claude-code-discord-bridge/issues/210)을 참조하세요.
+
 ---
 
 ## Discord 봇 설정

--- a/docs/pt-BR/README.md
+++ b/docs/pt-BR/README.md
@@ -260,6 +260,23 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `CCDB_COORDINATION_CHANNEL_NAME` | Criar automaticamente canal de coordenação por nome | (opcional) |
 | `WORKTREE_BASE_DIR` | Diretório base para escanear worktrees de sessão (ativa limpeza automática) | (opcional) |
 
+### Modos de Permissão — O Que Funciona no Modo `-p`
+
+O Claude Code CLI é executado em **modo `-p` (não-interativo)** quando usado através do ccdb. Neste modo, o CLI **não pode solicitar permissões** — ferramentas que requerem aprovação são rejeitadas imediatamente. Esta é uma [restrição de design do CLI](https://code.claude.com/docs/en/headless), não uma limitação do ccdb.
+
+| Modo | Comportamento no modo `-p` | Recomendação |
+|------|----------------------|----------------|
+| `default` | ❌ **Todas as ferramentas rejeitadas** — inutilizável | Não usar |
+| `acceptEdits` | ⚠️ Edit/Write aprovados automaticamente, Bash rejeitado (Claude usa Write para operações de arquivo) | Opção mínima viável |
+| `bypassPermissions` | ✅ Todas as ferramentas aprovadas | Funciona, mas prefira a opção abaixo |
+| **`CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`** | ✅ **Todas as ferramentas aprovadas** | **Recomendado** — ccdb já restringe o acesso via `allowed_user_ids` |
+
+**Nossa recomendação:** Configure `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`. Como o ccdb controla quem pode interagir com o Claude via `allowed_user_ids`, as verificações de permissão no nível do CLI adicionam fricção sem benefício real de segurança. O «dangerously» no nome reflete o aviso geral do CLI; no contexto do ccdb onde o acesso já é controlado, é a escolha prática.
+
+Se preferir controle granular, o suporte a `CLAUDE_ALLOWED_TOOLS` está planejado ([#217](https://github.com/ebibibi/claude-code-discord-bridge/issues/217)).
+
+> **Por que os botões de permissão não aparecem no Discord?** O modo `-p` do CLI nunca emite eventos `permission_request`, então não há nada para o ccdb exibir. Os botões `AskUserQuestion` que você vê (prompts de seleção do Claude) são um mecanismo diferente que funciona corretamente. Veja [#210](https://github.com/ebibibi/claude-code-discord-bridge/issues/210) para a investigação completa.
+
 ---
 
 ## Configuração do Bot Discord

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -280,6 +280,23 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `CCDB_COORDINATION_CHANNEL_NAME` | 按名称自动创建协调频道 | （可选） |
 | `WORKTREE_BASE_DIR` | 扫描会话 worktree 的基础目录（启用自动清理） | （可选） |
 
+### 权限模式 — `-p` 模式下的功能说明
+
+通过 ccdb 使用时，Claude Code CLI 以 **`-p`（非交互式）模式** 运行。在此模式下，CLI **无法请求权限确认** — 需要审批的工具会被立即拒绝。这是 [CLI 的设计约束](https://code.claude.com/docs/en/headless)，而非 ccdb 的限制。
+
+| 模式 | `-p` 模式下的行为 | 推荐 |
+|------|----------------------|----------------|
+| `default` | ❌ **所有工具被拒绝** — 无法使用 | 不要使用 |
+| `acceptEdits` | ⚠️ Edit/Write 自动批准，Bash 被拒绝（Claude 回退到 Write 进行文件操作） | 最低可用选项 |
+| `bypassPermissions` | ✅ 所有工具均被批准 | 可用，但建议使用下方的环境变量 |
+| **`CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`** | ✅ **所有工具均被批准** | **推荐** — ccdb 已通过 `allowed_user_ids` 限制访问 |
+
+**我们的推荐：** 设置 `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`。由于 ccdb 通过 `allowed_user_ids` 控制与 Claude 的交互，CLI 级别的权限检查只会增加摩擦而没有实质性的安全收益。名称中的「dangerously」体现了 CLI 的通用警告；在 ccdb 已限制访问的上下文中，这是实际可行的选择。
+
+如需精细控制，`CLAUDE_ALLOWED_TOOLS` 的支持已在计划中（[#217](https://github.com/ebibibi/claude-code-discord-bridge/issues/217)）。
+
+> **为什么 Discord 中不显示权限按钮？** CLI 的 `-p` 模式不会发出 `permission_request` 事件，因此 ccdb 无内容可显示。您看到的 `AskUserQuestion` 按钮（Claude 的选择提示）是不同的机制，可以正常工作。详细调查请参阅 [#210](https://github.com/ebibibi/claude-code-discord-bridge/issues/210)。
+
 ---
 
 ## Discord Bot 设置


### PR DESCRIPTION
## Summary
- Added "Permission Modes" section to 5 language translations (zh-CN, ko, es, pt-BR, fr) — this section already existed in Japanese (ja) but was missing from the other 5 languages
- The new section explains how Claude Code CLI's `-p` (non-interactive) mode affects tool permissions, and recommends `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true` as the practical configuration for ccdb deployments
- Translations follow existing conventions: technical terms (CLI, Bash, Edit/Write, `-p` mode) are left in English; explanatory prose is translated naturally

## 概要
- 5言語（zh-CN、ko、es、pt-BR、fr）の翻訳に「Permission Modes（権限モード）」セクションを追加 — 日本語（ja）には既に存在していたが他5言語で欠落していた
- 新セクションでは、Claude Code CLIの`-p`（非インタラクティブ）モードがツール権限に与える影響を解説し、ccdbデプロイにおいて`CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`が実用的な設定として推奨されることを説明
- 既存の翻訳規約に従い、技術用語（CLI、Bash、Edit/Write、`-p`モード）は英語のまま、説明文は自然に翻訳

## Changed files
- `docs/zh-CN/README.md`
- `docs/ko/README.md`
- `docs/es/README.md`
- `docs/pt-BR/README.md`
- `docs/fr/README.md`

## Languages updated
zh-CN, ko, es, pt-BR, fr

---
🤖 Auto-generated by [docs-sync](https://github.com/ebibibi/claude-code-discord-bridge)
