### PR TITLE
feat: add custom Cog loader and EbiBot example integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,8 @@ Discord frontend for Claude Code CLI. **This is a framework (OSS library), not a
 ## Framework vs Instance
 
 - **claude-code-discord-bridge** (this repo) = reusable OSS framework. No personal config, no secrets, no server-specific logic.
-- Personal instances (e.g. EbiBot) install this as a package and import the Cog. The instance repo handles server-specific config, additional Cogs, and secrets.
-- When adding features: if it's useful to anyone → add here. If it's personal workflow → add in the instance repo.
+- Personal instances (e.g. EbiBot) use the custom Cog loader (`CUSTOM_COGS_DIR` / `--cogs-dir`) to add their own Cogs. See `examples/ebibot/` for the reference implementation.
+- When adding features: if it's useful to anyone → add here. If it's personal workflow → add as a custom Cog.
 
 ### Zero-Config Principle (Critical)
 
@@ -143,7 +143,8 @@ See `.claude/skills/tdd/SKILL.md` for detailed patterns per module type.
 claude_discord/          # Installable Python package
   __init__.py            # Public API exports
   protocols.py           # Shared protocols (DrainAware)
-  main.py                # Standalone entry point
+  main.py                # Standalone entry point (setup_bridge + custom cog loader)
+  cog_loader.py          # Dynamic custom Cog loader (CUSTOM_COGS_DIR / --cogs-dir)
   bot.py                 # Discord Bot class
   cogs/
     claude_chat.py       # Main chat Cog (thread creation, message handling)
@@ -171,6 +172,9 @@ claude_discord/          # Installable Python package
   utils/
     logger.py            # Logging setup
 tests/                   # pytest test suite
+examples/
+  ebibot/                # Real-world example: personal bot with custom Cogs
+    cogs/                # ReminderCog, WatchdogCog, AutoUpgradeCog, DocsSyncCog
 pyproject.toml           # Package metadata + dependencies
 uv.lock                  # Dependency lock file
 CONTRIBUTING.md          # Contribution guidelines
@@ -183,6 +187,28 @@ CONTRIBUTING.md          # Contribution guidelines
 3. Export from `claude_discord/cogs/__init__.py`
 4. Add to `claude_discord/__init__.py` public API
 5. Write tests in `tests/test_your_cog.py`
+
+### Custom Cog Protocol (for external Cogs loaded via `--cogs-dir`)
+
+Custom Cog files are loaded by `cog_loader.py` from the directory specified by `CUSTOM_COGS_DIR` env or `--cogs-dir` CLI flag. Each `.py` file must expose:
+
+```python
+async def setup(bot, runner, components):
+    """Called by load_custom_cogs().
+
+    Args:
+        bot: discord.ext.commands.Bot instance
+        runner: ClaudeRunner (may be None if Claude chat is disabled)
+        components: BridgeComponents (session_repo, task_repo, etc.)
+    """
+    await bot.add_cog(MyCog(bot))
+```
+
+Rules:
+- Files prefixed with `_` are skipped
+- Load order is deterministic (`sorted()` by filename)
+- One Cog's failure is logged and skipped — never blocks others
+- `examples/ebibot/cogs/` is the canonical reference implementation
 
 ### Adding a New Discord UI Component
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,37 @@ ccdb start --env /path/to/.env   # custom .env location
 
 Send a message in the configured channel — Claude will reply in a new thread.
 
+### Custom Cogs (Extend Without Forking)
+
+Add your own features by dropping Python files into a directory — no fork, no subclass, no package needed:
+
+```bash
+ccdb start --cogs-dir ./my-cogs/
+# Or: CUSTOM_COGS_DIR=./my-cogs ccdb start
+```
+
+Each `.py` file in the directory must expose an `async def setup(bot, runner, components)`:
+
+```python
+from discord.ext import commands
+
+class GreeterCog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_member_join(self, member):
+        channel = self.bot.get_channel(self.bot.channel_id)
+        await channel.send(f"Welcome {member.mention}!")
+
+async def setup(bot, runner, components):
+    await bot.add_cog(GreeterCog(bot))
+```
+
+Files prefixed with `_` are skipped. If one Cog fails to load, others still load normally.
+
+See [`examples/ebibot/`](examples/ebibot/) for a full real-world example with reminders, Todoist watchdog, auto-upgrade, and docs sync.
+
 ---
 
 ### Minimal Bot (Install as a Package)
@@ -415,6 +446,11 @@ In inline-reply mode, Claude's response is sent directly as a message in the cha
 | `MENTION_ONLY_CHANNEL_IDS` | Comma-separated channel IDs where the bot only responds when @mentioned | (optional) |
 | `INLINE_REPLY_CHANNEL_IDS` | Comma-separated channel IDs where the bot replies inline (no thread created) | (optional) |
 | `WORKTREE_BASE_DIR` | Base directory to scan for session worktrees (enables automatic cleanup) | (optional) |
+| `CUSTOM_COGS_DIR` | Directory containing custom Cog files to load at startup (see [Custom Cogs](#custom-cogs-extend-without-forking)) | (optional) |
+| `CLAUDE_ALLOWED_TOOLS` | Comma-separated list of allowed tools for Claude CLI | (optional) |
+| `CLAUDE_CHANNEL_IDS` | Additional channel IDs (comma-separated) for multi-channel setup | (optional) |
+| `API_HOST` | REST API bind address | `127.0.0.1` |
+| `API_PORT` | REST API port (enables REST API when set) | (optional) |
 
 ### Permission Modes — What Works in `-p` Mode
 
@@ -648,8 +684,9 @@ curl -X POST http://localhost:8080/api/tasks \
 
 ```
 claude_discord/
-  main.py                  # Standalone entry point
+  main.py                  # Standalone entry point (setup_bridge + custom cog loader)
   setup.py                 # setup_bridge() — one-call Cog wiring
+  cog_loader.py            # Dynamic custom Cog loader (CUSTOM_COGS_DIR)
   bot.py                   # Discord Bot class
   concurrency.py           # Worktree instructions + active session registry
   cogs/
@@ -696,6 +733,13 @@ claude_discord/
     api_server.py          # REST API (optional, requires aiohttp)
   utils/
     logger.py              # Logging setup
+examples/
+  ebibot/                  # Real-world example: personal bot with custom Cogs
+    cogs/
+      reminder.py          # /remind slash command + scheduled notifications
+      watchdog.py          # Todoist overdue task monitor
+      auto_upgrade.py      # Self-update via GitHub webhook
+      docs_sync.py         # Auto-translate docs on push
 ```
 
 ### Design Philosophy
@@ -715,7 +759,7 @@ claude_discord/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-700+ tests covering parser, chunker, repository, runner, streaming, webhook triggers, auto-upgrade (including `/upgrade` slash command, thread-invocation, and approval button), REST API, AskUserQuestion UI, thread dashboard, scheduled tasks, session sync, AI Lounge, startup resume, model switching, compact detection, TodoWrite progress embeds, and permission/elicitation/plan-mode event parsing.
+840+ tests covering parser, chunker, repository, runner, streaming, webhook triggers, auto-upgrade (including `/upgrade` slash command, thread-invocation, and approval button), REST API, AskUserQuestion UI, thread dashboard, scheduled tasks, session sync, AI Lounge, startup resume, model switching, compact detection, TodoWrite progress embeds, custom Cog loader, and permission/elicitation/plan-mode event parsing.
 
 ---
 
@@ -736,7 +780,16 @@ The project started on 2026-02-18 and continues to evolve through iterative conv
 
 ## Real-World Example
 
-**[EbiBot](https://github.com/ebibibi/discord-bot)** — A personal Discord bot built on this framework. Includes automated documentation sync (English + Japanese), push notifications, Todoist watchdog, scheduled health checks, and GitHub Actions CI/CD. Use it as a reference for building your own bot.
+**[`examples/ebibot/`](examples/ebibot/)** — A personal Discord bot built on this framework, included right in this repo. Demonstrates the custom Cog loader with:
+
+- **ReminderCog** — `/remind HH:MM "message"` slash command + 30-second send loop
+- **WatchdogCog** — Todoist overdue task monitor (30-minute check, daily dedup, severity-based alerts)
+- **AutoUpgradeCog** — Self-updating via GitHub webhook + systemctl restart
+- **DocsSyncCog** — Auto-translate documentation on push via webhook
+
+Run it with: `ccdb start --cogs-dir examples/ebibot/cogs/`
+
+> The EbiBot custom Cogs were previously maintained in a [separate repository](https://github.com/ebibibi/discord-bot). They are now co-located here so Claude Code always has full context of both the framework and the customizations — preventing accidental feature duplication.
 
 ---
 

--- a/claude_discord/__init__.py
+++ b/claude_discord/__init__.py
@@ -11,6 +11,7 @@ Quick start::
 from .claude.parser import parse_line
 from .claude.runner import ClaudeRunner
 from .claude.types import MessageType, StreamEvent, ToolCategory, ToolUseEvent
+from .cog_loader import load_custom_cogs
 from .cogs.auto_upgrade import AutoUpgradeCog, UpgradeConfig
 from .cogs.claude_chat import ClaudeChatCog
 from .cogs.event_processor import EventProcessor
@@ -74,6 +75,7 @@ __all__ = [
     # Setup
     "setup_bridge",
     "BridgeComponents",
+    "load_custom_cogs",
     # UI
     "StatusManager",
     "chunk_message",

--- a/claude_discord/cli.py
+++ b/claude_discord/cli.py
@@ -387,12 +387,21 @@ def main() -> None:
         metavar="PATH",
         help="Path to the .env file (default: .env)",
     )
+    start_parser.add_argument(
+        "--cogs-dir",
+        default=None,
+        metavar="DIR",
+        help="Directory containing custom Cog files to load",
+    )
 
     args = parser.parse_args()
 
     if args.command == "setup":
         cmd_setup(Path(args.env))
     elif args.command == "start":
+        cogs_dir = getattr(args, "cogs_dir", None)
+        if cogs_dir:
+            os.environ["CUSTOM_COGS_DIR"] = cogs_dir
         cmd_start(Path(args.env))
     else:
         parser.print_help()

--- a/claude_discord/cog_loader.py
+++ b/claude_discord/cog_loader.py
@@ -1,0 +1,90 @@
+"""Dynamic loader for custom Cogs from external directories.
+
+Consumers place Cog files in a directory and point ccdb at it via
+``CUSTOM_COGS_DIR`` env or ``--cogs-dir`` CLI flag.  Each file must
+expose an ``async def setup(bot, runner, components)`` entry point.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from discord.ext.commands import Bot
+
+    from .claude.runner import ClaudeRunner
+    from .setup import BridgeComponents
+
+logger = logging.getLogger(__name__)
+
+
+async def load_custom_cogs(
+    cogs_dir: Path,
+    bot: Bot,
+    runner: ClaudeRunner | None,
+    components: BridgeComponents,
+) -> int:
+    """Load custom Cog files from *cogs_dir*.
+
+    Each ``.py`` file (excluding ``_``-prefixed files) must define::
+
+        async def setup(bot, runner, components):
+            await bot.add_cog(MyCog(bot, ...))
+
+    A single Cog's failure is logged and skipped — it never prevents
+    other Cogs from loading.
+
+    Args:
+        cogs_dir: Directory containing ``.py`` Cog files.
+        bot: Discord bot instance.
+        runner: ClaudeRunner (may be ``None`` if Claude chat is disabled).
+        components: BridgeComponents from ``setup_bridge()``.
+
+    Returns:
+        Number of successfully loaded Cog files.
+    """
+    if not cogs_dir.is_dir():
+        logger.warning("Custom cogs directory does not exist: %s", cogs_dir)
+        return 0
+
+    files = sorted(
+        p for p in cogs_dir.iterdir() if p.suffix == ".py" and not p.name.startswith("_")
+    )
+
+    if not files:
+        logger.info("No custom cog files found in %s", cogs_dir)
+        return 0
+
+    loaded = 0
+    for path in files:
+        module_name = f"_ccdb_custom_cog_{path.stem}"
+        try:
+            spec = importlib.util.spec_from_file_location(module_name, path)
+            if spec is None or spec.loader is None:
+                logger.error("Failed to create module spec for %s", path)
+                continue
+
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[module_name] = module
+            spec.loader.exec_module(module)
+
+            setup_fn = getattr(module, "setup", None)
+            if setup_fn is None:
+                logger.warning("No setup() function in %s — skipped", path.name)
+                continue
+
+            await setup_fn(bot, runner, components)
+            loaded += 1
+            logger.info("Loaded custom cog: %s", path.name)
+
+        except Exception:
+            logger.exception("Failed to load custom cog: %s", path.name)
+            # Clean up partial module registration
+            sys.modules.pop(module_name, None)
+
+    logger.info("Custom cogs loaded: %d/%d from %s", loaded, len(files), cogs_dir)
+    return loaded

--- a/claude_discord/main.py
+++ b/claude_discord/main.py
@@ -1,4 +1,9 @@
-"""Entry point for claude-code-discord-bridge bot."""
+"""Entry point for claude-code-discord-bridge bot.
+
+Standalone launcher that uses ``setup_bridge()`` for full Cog auto-setup
+and optionally loads custom Cogs from an external directory via
+``CUSTOM_COGS_DIR`` env or ``--cogs-dir`` CLI flag.
+"""
 
 from __future__ import annotations
 
@@ -13,11 +18,8 @@ from dotenv import load_dotenv
 
 from .bot import ClaudeDiscordBot
 from .claude.runner import ClaudeRunner
-from .cogs.claude_chat import ClaudeChatCog
-from .database.ask_repo import PendingAskRepository
-from .database.lounge_repo import LoungeRepository
-from .database.models import init_db
-from .database.repository import SessionRepository
+from .cog_loader import load_custom_cogs
+from .setup import setup_bridge
 from .utils.logger import setup_logging
 
 logger = logging.getLogger(__name__)
@@ -50,6 +52,12 @@ def load_config() -> dict[str, str]:
         "coordination_channel_id": os.getenv("COORDINATION_CHANNEL_ID", ""),
         "dangerously_skip_permissions": os.getenv("CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS", "").lower()
         in ("true", "1", "yes"),
+        # Additional config for custom cogs and multi-channel
+        "claude_channel_ids": os.getenv("CLAUDE_CHANNEL_IDS", ""),
+        "api_host": os.getenv("API_HOST", "127.0.0.1"),
+        "api_port": os.getenv("API_PORT", ""),
+        "allowed_tools": os.getenv("CLAUDE_ALLOWED_TOOLS", ""),
+        "custom_cogs_dir": os.getenv("CUSTOM_COGS_DIR", ""),
     }
 
 
@@ -58,16 +66,21 @@ async def main() -> None:
     setup_logging()
     config = load_config()
 
-    # Initialize database
-    data_dir = Path("data")
-    data_dir.mkdir(exist_ok=True)
-    db_path = str(data_dir / "sessions.db")
-    await init_db(db_path)
+    channel_id = int(config["channel_id"])
 
-    # Create components
-    repo = SessionRepository(db_path)
-    ask_repo = PendingAskRepository(db_path)
-    lounge_repo = LoungeRepository(db_path)
+    # Parse optional multi-channel IDs
+    claude_channel_ids: set[int] | None = None
+    if config["claude_channel_ids"]:
+        claude_channel_ids = {
+            int(x.strip()) for x in config["claude_channel_ids"].split(",") if x.strip().isdigit()
+        } or None
+
+    # Parse allowed tools
+    allowed_tools: list[str] | None = None
+    if config["allowed_tools"]:
+        allowed_tools = [t.strip() for t in config["allowed_tools"].split(",") if t.strip()] or None
+
+    # Create runner
     runner = ClaudeRunner(
         command=config["claude_command"],
         model=config["claude_model"],
@@ -75,6 +88,7 @@ async def main() -> None:
         working_dir=config["claude_working_dir"] or None,
         timeout_seconds=int(config["timeout"]),
         dangerously_skip_permissions=config["dangerously_skip_permissions"],
+        allowed_tools=allowed_tools,
     )
 
     owner_id = int(config["owner_id"]) if config["owner_id"] else None
@@ -82,31 +96,52 @@ async def main() -> None:
         int(config["coordination_channel_id"]) if config["coordination_channel_id"] else None
     )
     bot = ClaudeDiscordBot(
-        channel_id=int(config["channel_id"]),
+        channel_id=channel_id,
         owner_id=owner_id,
         coordination_channel_id=coordination_channel_id,
-        ask_repo=ask_repo,
-        lounge_repo=lounge_repo,
-        lounge_channel_id=coordination_channel_id,  # lounge uses the same channel
     )
 
-    # Register cog
-    cog = ClaudeChatCog(
-        bot=bot,
-        repo=repo,
-        runner=runner,
-        max_concurrent=int(config["max_concurrent"]),
-        ask_repo=ask_repo,
-        lounge_repo=lounge_repo,
-    )
+    # Optional API server
+    api_server = None
+    if config["api_port"]:
+        from .database.notification_repo import NotificationRepository
+        from .ext.api_server import ApiServer
+
+        notification_repo = NotificationRepository("data/notifications.db")
+        await notification_repo.init_db()
+        api_server = ApiServer(
+            repo=notification_repo,
+            bot=bot,
+            default_channel_id=channel_id,
+            host=config["api_host"],
+            port=int(config["api_port"]),
+        )
 
     async with bot:
-        await bot.add_cog(cog)
+        # Full Cog auto-setup via setup_bridge
+        allowed_user_ids = {owner_id} if owner_id else None
+        components = await setup_bridge(
+            bot,
+            runner,
+            api_server=api_server,
+            allowed_user_ids=allowed_user_ids,
+            claude_channel_id=channel_id,
+            claude_channel_ids=claude_channel_ids,
+        )
+
+        # Load custom Cogs from external directory
+        cogs_dir = config["custom_cogs_dir"]
+        if cogs_dir:
+            await load_custom_cogs(Path(cogs_dir), bot, runner, components)
 
         # Cleanup old sessions on startup
-        deleted = await repo.cleanup_old(days=30)
+        deleted = await components.session_repo.cleanup_old(days=30)
         if deleted:
             logger.info("Cleaned up %d old sessions", deleted)
+
+        # Start API server if configured
+        if api_server is not None:
+            await api_server.start()
 
         # Handle signals (add_signal_handler is not supported on Windows)
         if sys.platform != "win32":

--- a/examples/ebibot/.env.example
+++ b/examples/ebibot/.env.example
@@ -1,0 +1,33 @@
+# Discord Bot
+DISCORD_BOT_TOKEN=YOUR_BOT_TOKEN_HERE
+DISCORD_CHANNEL_ID=YOUR_CHANNEL_ID
+DISCORD_OWNER_ID=YOUR_USER_ID
+
+# Claude Code
+CLAUDE_COMMAND=claude
+CLAUDE_MODEL=sonnet
+CLAUDE_PERMISSION_MODE=acceptEdits
+CLAUDE_WORKING_DIR=/home/you
+MAX_CONCURRENT_SESSIONS=3
+SESSION_TIMEOUT_SECONDS=300
+
+# Multi-channel support (comma-separated, optional)
+# CLAUDE_CHANNEL_IDS=123456789,987654321
+
+# REST API (optional — enables /api/notify, /api/schedule endpoints)
+# API_HOST=127.0.0.1
+# API_PORT=8099
+
+# Tool restrictions (optional, comma-separated)
+# CLAUDE_ALLOWED_TOOLS=Read,Write,Edit,Bash
+
+# Custom Cogs directory (set automatically by --cogs-dir flag)
+# CUSTOM_COGS_DIR=examples/ebibot/cogs
+
+# Watchdog: path to todoist.sh (optional, defaults to ~/.claude/skills/todoist/scripts/todoist.sh)
+# TODOIST_SH=/path/to/todoist.sh
+
+# Auto Upgrade (optional overrides)
+# UV_PATH=/home/you/.local/bin/uv
+# EBIBOT_WORKING_DIR=/home/you/discord-bot
+# EBIBOT_SERVICE_NAME=discord-bot.service

--- a/examples/ebibot/README.md
+++ b/examples/ebibot/README.md
@@ -1,0 +1,63 @@
+# EbiBot — Example Custom Bot using ccdb
+
+Personal Discord bot built on top of [claude-code-discord-bridge](https://github.com/ebibibi/claude-code-discord-bridge).
+
+This example demonstrates how to extend ccdb with custom Cogs using the `CUSTOM_COGS_DIR` mechanism — no need for a separate repository.
+
+## Custom Cogs
+
+| Cog | File | Description |
+|-----|------|-------------|
+| ReminderCog | `cogs/reminder.py` | `/remind HH:MM "message"` slash command + 30s send loop |
+| WatchdogCog | `cogs/watchdog.py` | Todoist overdue task monitor (30min check, daily dedup) |
+| AutoUpgradeCog | `cogs/auto_upgrade.py` | Self-update via GitHub webhook + systemctl restart |
+| DocsSyncCog | `cogs/docs_sync.py` | Auto-translate docs on push via webhook |
+
+## Quick Start
+
+```bash
+# 1. Clone and install ccdb
+git clone https://github.com/ebibibi/claude-code-discord-bridge.git
+cd claude-code-discord-bridge
+uv sync
+
+# 2. Copy and edit .env
+cp examples/ebibot/.env.example .env
+# Edit .env with your Discord bot token and channel IDs
+
+# 3. Start with custom Cogs
+ccdb start --cogs-dir examples/ebibot/cogs/
+
+# Or via environment variable:
+CUSTOM_COGS_DIR=examples/ebibot/cogs ccdb start
+```
+
+## How Custom Cogs Work
+
+Each `.py` file in the cogs directory must expose a `setup()` function:
+
+```python
+async def setup(bot, runner, components):
+    """Called by ccdb's custom Cog loader.
+
+    Args:
+        bot: discord.ext.commands.Bot instance
+        runner: ClaudeRunner (Claude CLI invocation) — may be None
+        components: BridgeComponents (session_repo, task_repo, etc.)
+    """
+    await bot.add_cog(MyCog(bot))
+```
+
+Files prefixed with `_` are skipped.  If one Cog fails to load, others still load normally.
+
+## Architecture
+
+```
+ccdb (framework)
+  |
+  +-- setup_bridge() -> ClaudeChatCog, SessionManageCog, SkillCommandCog, SchedulerCog
+  |
+  +-- load_custom_cogs(cogs_dir) -> ReminderCog, WatchdogCog, AutoUpgradeCog, DocsSyncCog
+```
+
+All Cogs share the same bot instance, event loop, and Discord connection.

--- a/examples/ebibot/cogs/auto_upgrade.py
+++ b/examples/ebibot/cogs/auto_upgrade.py
@@ -1,0 +1,40 @@
+"""Auto Upgrade — ccdb AutoUpgradeCog configuration for EbiBot.
+
+Flow:
+1. Push to ccdb repo -> GitHub Actions -> Discord webhook "ebibot-upgrade"
+2. AutoUpgradeCog receives it -> uv lock --upgrade-package && uv sync
+3. systemctl restart discord-bot to self-restart
+
+This file is config-only.  Execution logic lives in ccdb's AutoUpgradeCog.
+
+Usage:
+    CUSTOM_COGS_DIR=examples/ebibot/cogs ccdb start
+"""
+
+from __future__ import annotations
+
+import os
+
+from claude_discord.cogs.auto_upgrade import AutoUpgradeCog, UpgradeConfig
+
+_UV = os.getenv("UV_PATH", os.path.expanduser("~/.local/bin/uv"))
+_WORKING_DIR = os.getenv("EBIBOT_WORKING_DIR", os.path.expanduser("~/discord-bot"))
+_SERVICE_NAME = os.getenv("EBIBOT_SERVICE_NAME", "discord-bot.service")
+
+EBIBOT_UPGRADE_CONFIG = UpgradeConfig(
+    package_name="claude-code-discord-bridge",
+    trigger_prefix="\U0001f504 ebibot-upgrade",
+    working_dir=_WORKING_DIR,
+    upgrade_command=[_UV, "lock", "--upgrade-package", "claude-code-discord-bridge"],
+    sync_command=[_UV, "sync"],
+    restart_command=["/usr/bin/sudo", "/usr/bin/systemctl", "restart", _SERVICE_NAME],
+    upgrade_approval=True,
+    restart_approval=True,
+    slash_command_enabled=True,
+)
+
+
+async def setup(bot: object, runner: object, components: object) -> None:
+    """Entry point for the custom Cog loader."""
+    cog = AutoUpgradeCog(bot=bot, config=EBIBOT_UPGRADE_CONFIG)  # type: ignore[arg-type]
+    await bot.add_cog(cog)  # type: ignore[union-attr]

--- a/examples/ebibot/cogs/docs_sync.py
+++ b/examples/ebibot/cogs/docs_sync.py
@@ -1,0 +1,183 @@
+"""Docs Sync — ccdb WebhookTriggerCog configuration for auto-documentation.
+
+Two modes:
+- "docs-sync" (normal push): English docs sync + Japanese translation only
+- "docs-sync-translate" (release): Full multi-language translation
+
+This file is prompt/config-only.  Execution logic lives in ccdb's WebhookTriggerCog.
+
+Usage:
+    CUSTOM_COGS_DIR=examples/ebibot/cogs ccdb start
+"""
+
+from __future__ import annotations
+
+import os
+
+from claude_discord.cogs.webhook_trigger import WebhookTrigger, WebhookTriggerCog
+
+_COMMON_HEADER = """\
+You are a documentation maintainer for the claude-code-discord-bridge project.
+The repository is at /home/ebi/claude-code-discord-bridge.
+
+CRITICAL: NEVER use `git checkout` or `git switch` in the main working directory.
+All doc changes MUST be made in a git worktree to avoid disrupting other sessions.
+
+## Step 1: Pull latest and create a worktree
+
+```bash
+cd /home/ebi/claude-code-discord-bridge && git pull origin main
+BRANCH_NAME="docs-sync/$(date +%Y%m%d-%H%M%S)"
+WORKTREE_DIR="/tmp/ccdb-docs-sync-$$"
+git worktree add -b "$BRANCH_NAME" "$WORKTREE_DIR" HEAD
+```
+
+From this point on, all file reads and edits happen in
+`$WORKTREE_DIR`, NOT in the main repo directory.
+You may read files from the main repo for reference, but NEVER write to it.
+
+## Step 2: Analyze what changed
+
+```bash
+cd /home/ebi/claude-code-discord-bridge && git diff HEAD~1 HEAD --stat && git diff HEAD~1 HEAD
+```
+
+## Step 3: Update English documentation if needed
+
+Work in the worktree directory (`$WORKTREE_DIR`).
+
+If **source code** (.py files) changed:
+- Read the changed code and check if README.md or CONTRIBUTING.md need updates
+- Update sections about features, architecture, configuration, etc. if the code changes affect them
+- Keep documentation accurate and in sync with the code
+- Do NOT update docs for trivial changes (formatting, comments, internal refactors)
+"""
+
+_TRANSLATE_JA_STEP = """
+
+## Step 4: Translate to Japanese
+
+Update or create Japanese translations in `docs/ja/`
+for each English doc (README.md, CONTRIBUTING.md).
+
+Translation rules:
+1. Keep all markdown formatting, code blocks, links, and badges intact
+2. Do NOT translate: code snippets, URLs, file paths, variable names, common English tech terms
+3. DO translate: headings, descriptions, explanatory text, table headers/descriptions
+4. Add a bilingual notice at the top
+5. Use natural, fluent Japanese
+6. Update relative links to point to Japanese versions where they exist
+"""
+
+_TRANSLATE_FULL_STEP = """
+
+## Step 4: Translate to all supported languages
+
+Target languages (create docs/{lang}/ for each):
+- `ja` -- Japanese
+- `zh-CN` -- Chinese Simplified
+- `ko` -- Korean
+- `es` -- Spanish
+- `pt-BR` -- Portuguese (Brazil)
+- `fr` -- French
+
+Translation rules:
+1. Keep all markdown formatting, code blocks, links, and badges intact
+2. Do NOT translate: code snippets, URLs, file paths, variable names, common English tech terms
+3. DO translate: headings, descriptions, explanatory text
+4. Add a bilingual notice at the top of each translated file
+5. Use natural, fluent language
+"""
+
+_PR_STEP_SYNC = """
+
+## Step 5: Create a PR with auto-merge
+
+If any documentation files were changed in the worktree:
+
+1. Commit and push from the worktree:
+```bash
+cd "$WORKTREE_DIR"
+git add -A
+git commit -m "[docs-sync] Update documentation (English + Japanese)"
+git push -u origin HEAD
+```
+
+2. Create PR with bilingual summary and enable auto-merge:
+```bash
+gh pr create --title "[docs-sync] Update documentation" --body-file /tmp/docs-sync-pr-body.md
+gh pr merge --auto --squash
+```
+
+## Step 6: Clean up worktree
+
+```bash
+cd /home/ebi/claude-code-discord-bridge && git worktree remove "$WORKTREE_DIR"
+```
+"""
+
+_PR_STEP_TRANSLATE = """
+
+## Step 5: Create a PR with auto-merge
+
+If any files were changed in the worktree:
+
+1. Commit and push from the worktree:
+```bash
+cd "$WORKTREE_DIR"
+git add -A
+git commit -m "[docs-sync] Update documentation and translations"
+git push -u origin HEAD
+```
+
+2. Create PR with bilingual summary and enable auto-merge:
+```bash
+gh pr create --title "[docs-sync] Update documentation and translations" \
+  --body-file /tmp/docs-sync-pr-body.md
+gh pr merge --auto --squash
+```
+
+## Step 6: Clean up worktree
+
+```bash
+cd /home/ebi/claude-code-discord-bridge && git worktree remove "$WORKTREE_DIR"
+```
+"""
+
+DOCS_SYNC_PROMPT = _COMMON_HEADER + _TRANSLATE_JA_STEP + _PR_STEP_SYNC
+DOCS_TRANSLATE_PROMPT = _COMMON_HEADER + _TRANSLATE_FULL_STEP + _PR_STEP_TRANSLATE
+
+BRIDGE_DIR = os.getenv("CCDB_REPO_DIR", os.path.expanduser("~/claude-code-discord-bridge"))
+
+DOCS_SYNC_TRIGGERS = {
+    "\U0001f504 docs-sync-translate": WebhookTrigger(
+        prompt=DOCS_TRANSLATE_PROMPT,
+        working_dir=BRIDGE_DIR,
+        timeout=900,
+    ),
+    "\U0001f504 docs-sync": WebhookTrigger(
+        prompt=DOCS_SYNC_PROMPT,
+        working_dir=BRIDGE_DIR,
+        timeout=300,
+    ),
+}
+
+
+async def setup(bot: object, runner: object, components: object) -> None:
+    """Entry point for the custom Cog loader."""
+    # Determine channel IDs for the webhook trigger
+    channel_id = getattr(bot, "channel_id", None)
+    channel_ids = {channel_id} if channel_id else set()
+
+    # Also check for CLAUDE_CHANNEL_ID env var
+    env_channel = os.getenv("CLAUDE_CHANNEL_ID", "")
+    if env_channel.isdigit():
+        channel_ids.add(int(env_channel))
+
+    cog = WebhookTriggerCog(
+        bot=bot,  # type: ignore[arg-type]
+        runner=runner,  # type: ignore[arg-type]
+        triggers=DOCS_SYNC_TRIGGERS,
+        channel_ids=channel_ids or None,
+    )
+    await bot.add_cog(cog)  # type: ignore[union-attr]

--- a/examples/ebibot/cogs/reminder.py
+++ b/examples/ebibot/cogs/reminder.py
@@ -1,0 +1,301 @@
+"""/remind slash command & 30-second notification send loop.
+
+Self-contained custom Cog: includes DB schema, repository, embed builders,
+and the ReminderCog itself.  No external dependencies beyond discord.py.
+
+Usage:
+    CUSTOM_COGS_DIR=examples/ebibot/cogs ccdb start
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import sqlite3
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import discord
+from discord import app_commands
+from discord.ext import commands, tasks
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Database
+# ---------------------------------------------------------------------------
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS scheduled_notifications (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    message TEXT NOT NULL,
+    title TEXT,
+    color INTEGER DEFAULT 49151,
+    scheduled_at TEXT NOT NULL,
+    source TEXT NOT NULL DEFAULT 'api',
+    channel_id INTEGER,
+    status TEXT NOT NULL DEFAULT 'pending',
+    sent_at TEXT,
+    error_message TEXT,
+    created_at TEXT DEFAULT (datetime('now', 'localtime'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_notif_status_scheduled
+    ON scheduled_notifications(status, scheduled_at);
+"""
+
+
+class _Database:
+    """Minimal synchronous SQLite wrapper for notifications."""
+
+    def __init__(self, db_path: str = "data/bot.db") -> None:
+        self.db_path = db_path
+        self._connection: sqlite3.Connection | None = None
+
+    def connect(self) -> sqlite3.Connection:
+        if self._connection is not None:
+            return self._connection
+        Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._connection = sqlite3.connect(self.db_path, check_same_thread=False)
+        self._connection.row_factory = sqlite3.Row
+        return self._connection
+
+    def initialize(self) -> None:
+        conn = self.connect()
+        conn.executescript(_SCHEMA)
+        conn.commit()
+
+    def close(self) -> None:
+        if self._connection:
+            self._connection.close()
+            self._connection = None
+
+    @property
+    def connection(self) -> sqlite3.Connection:
+        return self.connect()
+
+
+class _NotificationRepository:
+    """CRUD for scheduled_notifications table."""
+
+    def __init__(self, db: _Database) -> None:
+        self.db = db
+
+    def create(
+        self,
+        message: str,
+        scheduled_at: str,
+        *,
+        title: str | None = None,
+        color: int = 0x00BFFF,
+        source: str = "api",
+        channel_id: int | None = None,
+    ) -> int:
+        conn = self.db.connection
+        cursor = conn.execute(
+            """
+            INSERT INTO scheduled_notifications
+                (message, title, color, scheduled_at, source, channel_id)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (message, title, color, scheduled_at, source, channel_id),
+        )
+        conn.commit()
+        return cursor.lastrowid  # type: ignore[return-value]
+
+    def get_pending(self, before: str | None = None) -> list[dict]:
+        conn = self.db.connection
+        if before:
+            rows = conn.execute(
+                """
+                SELECT * FROM scheduled_notifications
+                WHERE status = 'pending' AND scheduled_at <= ?
+                ORDER BY scheduled_at
+                """,
+                (before,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                """
+                SELECT * FROM scheduled_notifications
+                WHERE status = 'pending'
+                ORDER BY scheduled_at
+                """,
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def mark_sent(self, notification_id: int) -> None:
+        conn = self.db.connection
+        conn.execute(
+            """
+            UPDATE scheduled_notifications
+            SET status = 'sent', sent_at = datetime('now', 'localtime')
+            WHERE id = ?
+            """,
+            (notification_id,),
+        )
+        conn.commit()
+
+    def mark_failed(self, notification_id: int, error: str) -> None:
+        conn = self.db.connection
+        conn.execute(
+            """
+            UPDATE scheduled_notifications
+            SET status = 'failed', error_message = ?
+            WHERE id = ?
+            """,
+            (error, notification_id),
+        )
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Embeds
+# ---------------------------------------------------------------------------
+
+_COLOR_REMINDER = 0x00BFFF
+_COLOR_SUCCESS = 0x00FF00
+
+
+def _build_reminder_embed(message: str, title: str | None = None) -> discord.Embed:
+    embed = discord.Embed(
+        title=title or "\u23f0 Remind!",
+        description=message,
+        color=_COLOR_REMINDER,
+        timestamp=datetime.now(),
+    )
+    embed.set_footer(text="EbiBot Reminder")
+    return embed
+
+
+def _build_schedule_confirm_embed(message: str, scheduled_at: str) -> discord.Embed:
+    embed = discord.Embed(
+        title="\u2705 Reminder scheduled!",
+        description=f"**{scheduled_at}** — notification set.\n\n> {message}",
+        color=_COLOR_SUCCESS,
+        timestamp=datetime.now(),
+    )
+    embed.set_footer(text="EbiBot Reminder")
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# Cog
+# ---------------------------------------------------------------------------
+
+
+class ReminderCog(commands.Cog):
+    """Reminder: /remind slash command + periodic send loop."""
+
+    def __init__(self, bot: commands.Bot, repo: _NotificationRepository) -> None:
+        self.bot = bot
+        self.repo = repo
+
+    async def cog_load(self) -> None:
+        self.check_scheduled.start()
+        logger.info("ReminderCog loaded, check loop started")
+
+    async def cog_unload(self) -> None:
+        self.check_scheduled.cancel()
+
+    @app_commands.command(
+        name="remind",
+        description="Set a reminder at a specific time!",
+    )
+    @app_commands.describe(
+        time="Time in HH:MM format",
+        message="Reminder message",
+    )
+    async def remind(
+        self,
+        interaction: discord.Interaction,
+        time: str,
+        message: str,
+    ) -> None:
+        match = re.match(r"^(\d{1,2}):(\d{2})$", time.strip())
+        if not match:
+            await interaction.response.send_message(
+                "Please use HH:MM format (e.g. 14:30)",
+                ephemeral=True,
+            )
+            return
+
+        hour, minute = int(match.group(1)), int(match.group(2))
+        if not (0 <= hour <= 23 and 0 <= minute <= 59):
+            await interaction.response.send_message(
+                "Time out of range! Use 00:00-23:59.",
+                ephemeral=True,
+            )
+            return
+
+        now = datetime.now()
+        scheduled = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+        if scheduled <= now:
+            scheduled += timedelta(days=1)
+
+        scheduled_str = scheduled.strftime("%Y-%m-%dT%H:%M:%S")
+
+        self.repo.create(
+            message=message,
+            scheduled_at=scheduled_str,
+            source="slash_command",
+            channel_id=interaction.channel_id,
+        )
+
+        embed = _build_schedule_confirm_embed(
+            message=message,
+            scheduled_at=scheduled.strftime("%m/%d %H:%M"),
+        )
+        await interaction.response.send_message(embed=embed)
+
+    @tasks.loop(seconds=30)
+    async def check_scheduled(self) -> None:
+        """Check pending notifications every 30 seconds and send them."""
+        now_str = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+        pending = self.repo.get_pending(before=now_str)
+
+        for notif in pending:
+            try:
+                channel_id = notif.get("channel_id") or getattr(
+                    self.bot, "default_channel_id", None
+                )
+                if not channel_id:
+                    logger.warning("No channel ID for notification %d", notif["id"])
+                    self.repo.mark_failed(notif["id"], "No channel ID")
+                    continue
+
+                channel = self.bot.get_channel(int(channel_id))
+                if not channel:
+                    channel = await self.bot.fetch_channel(int(channel_id))
+
+                embed = _build_reminder_embed(
+                    message=notif["message"],
+                    title=notif.get("title"),
+                )
+                if notif.get("color"):
+                    embed.color = notif["color"]
+
+                await channel.send(embed=embed)
+                self.repo.mark_sent(notif["id"])
+                logger.info("Notification sent: id=%d", notif["id"])
+
+            except Exception as e:
+                logger.error("Failed to send notification %d: %s", notif["id"], e)
+                self.repo.mark_failed(notif["id"], str(e))
+
+    @check_scheduled.before_loop
+    async def before_check_scheduled(self) -> None:
+        await self.bot.wait_until_ready()
+
+
+# ---------------------------------------------------------------------------
+# setup() — called by load_custom_cogs
+# ---------------------------------------------------------------------------
+
+
+async def setup(bot: commands.Bot, runner: object, components: object) -> None:
+    """Entry point for the custom Cog loader."""
+    db = _Database(db_path="data/bot.db")
+    db.initialize()
+    repo = _NotificationRepository(db)
+    await bot.add_cog(ReminderCog(bot, repo))

--- a/examples/ebibot/cogs/watchdog.py
+++ b/examples/ebibot/cogs/watchdog.py
@@ -1,0 +1,180 @@
+"""Todoist overdue task watchdog — 30-minute check loop.
+
+Checks Todoist for overdue tasks via todoist.sh and posts a warning
+embed to the default channel.  Each task is only notified once per day.
+
+Usage:
+    CUSTOM_COGS_DIR=examples/ebibot/cogs ccdb start
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+from datetime import datetime
+
+import discord
+from discord.ext import commands, tasks
+
+logger = logging.getLogger(__name__)
+
+# Default path — can be overridden via TODOIST_SH env var
+TODOIST_SH = os.getenv(
+    "TODOIST_SH",
+    os.path.expanduser("~/.claude/skills/todoist/scripts/todoist.sh"),
+)
+
+# ---------------------------------------------------------------------------
+# Embeds
+# ---------------------------------------------------------------------------
+
+_COLOR_WARN = 0xFF6B6B
+_COLOR_DANGER = 0xFF4444
+_COLOR_CRITICAL = 0xFF0000
+
+_TEMPLATES = {
+    "warn": {"title": "Hey! You have overdue tasks!", "color": _COLOR_WARN},
+    "danger": {"title": "Seriously?! Are you slacking off?!", "color": _COLOR_DANGER},
+    "critical": {
+        "title": "\U0001f6a8\U0001f6a8\U0001f6a8 Too many overdue tasks!",
+        "color": _COLOR_CRITICAL,
+    },
+}
+
+
+def _get_level(count: int) -> str:
+    if count >= 6:
+        return "critical"
+    if count >= 3:
+        return "danger"
+    return "warn"
+
+
+def _build_watchdog_embed(overdue_tasks: list[dict]) -> discord.Embed:
+    count = len(overdue_tasks)
+    level = _get_level(count)
+    template = _TEMPLATES[level]
+
+    task_lines = []
+    for task in overdue_tasks[:15]:
+        content = task.get("content", "???")
+        due = task.get("due", "")
+        task_lines.append(f"- **{content}**  (due: {due})")
+
+    if count > 15:
+        task_lines.append(f"...and {count - 15} more")
+
+    embed = discord.Embed(
+        title=template["title"],
+        description=f"**{count}** overdue task(s)!\n\n" + "\n".join(task_lines),
+        color=template["color"],
+        timestamp=datetime.now(),
+    )
+    embed.set_footer(text="EbiBot Watchdog")
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# Cog
+# ---------------------------------------------------------------------------
+
+
+class WatchdogCog(commands.Cog):
+    """Todoist overdue task monitor."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self._notified_today: set[str] = set()
+        self._last_reset_date: str = ""
+
+    async def cog_load(self) -> None:
+        self.check_overdue.start()
+        logger.info("WatchdogCog loaded, overdue check loop started")
+
+    async def cog_unload(self) -> None:
+        self.check_overdue.cancel()
+
+    def _reset_daily(self) -> None:
+        today = datetime.now().strftime("%Y-%m-%d")
+        if self._last_reset_date != today:
+            self._notified_today.clear()
+            self._last_reset_date = today
+
+    def _is_active_hours(self) -> bool:
+        hour = datetime.now().hour
+        return 8 <= hour < 23
+
+    def _fetch_overdue_tasks(self) -> list[dict]:
+        try:
+            result = subprocess.run(
+                [TODOIST_SH, "tasks", "--filter", "(overdue)"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if result.returncode != 0:
+                logger.error("todoist.sh failed: %s", result.stderr)
+                return []
+
+            data = json.loads(result.stdout)
+            return data if isinstance(data, list) else []
+        except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError) as e:
+            logger.error("Todoist fetch error: %s", e)
+            return []
+
+    @tasks.loop(minutes=30)
+    async def check_overdue(self) -> None:
+        """Check Todoist for overdue tasks every 30 minutes."""
+        if not self._is_active_hours():
+            return
+
+        self._reset_daily()
+
+        overdue_tasks = self._fetch_overdue_tasks()
+        if not overdue_tasks:
+            return
+
+        new_tasks = []
+        for task in overdue_tasks:
+            task_id = task.get("id", "")
+            if task_id and task_id not in self._notified_today:
+                new_tasks.append(task)
+                self._notified_today.add(task_id)
+
+        if not new_tasks:
+            return
+
+        channel_id = getattr(self.bot, "default_channel_id", None) or getattr(
+            self.bot, "channel_id", None
+        )
+        if not channel_id:
+            logger.warning("No default channel ID set — cannot send watchdog alert")
+            return
+
+        channel = self.bot.get_channel(channel_id)
+        if not channel:
+            try:
+                channel = await self.bot.fetch_channel(channel_id)
+            except Exception as e:
+                logger.error("Failed to fetch channel: %s", e)
+                return
+
+        embed = _build_watchdog_embed(new_tasks)
+        await channel.send(embed=embed)
+        logger.info("Watchdog alert sent: %d task(s)", len(new_tasks))
+
+    @check_overdue.before_loop
+    async def before_check_overdue(self) -> None:
+        await self.bot.wait_until_ready()
+
+
+# ---------------------------------------------------------------------------
+# setup() — called by load_custom_cogs
+# ---------------------------------------------------------------------------
+
+
+async def setup(bot: commands.Bot, runner: object, components: object) -> None:
+    """Entry point for the custom Cog loader."""
+    await bot.add_cog(WatchdogCog(bot))

--- a/tests/test_cog_loader.py
+++ b/tests/test_cog_loader.py
@@ -1,0 +1,169 @@
+"""Tests for claude_discord.cog_loader.load_custom_cogs."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from claude_discord.cog_loader import load_custom_cogs
+
+
+@pytest.fixture
+def cogs_dir(tmp_path: Path) -> Path:
+    """Create a temporary directory for custom Cog files."""
+    d = tmp_path / "cogs"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def mock_bot() -> MagicMock:
+    bot = MagicMock()
+    bot.add_cog = AsyncMock()
+    return bot
+
+
+@pytest.fixture
+def mock_components() -> MagicMock:
+    return MagicMock()
+
+
+async def test_load_empty_dir(
+    cogs_dir: Path, mock_bot: MagicMock, mock_components: MagicMock
+) -> None:
+    """Empty directory should load 0 cogs."""
+    result = await load_custom_cogs(cogs_dir, mock_bot, None, mock_components)
+    assert result == 0
+
+
+async def test_load_nonexistent_dir(
+    mock_bot: MagicMock, mock_components: MagicMock, tmp_path: Path
+) -> None:
+    """Non-existent directory should return 0 without error."""
+    result = await load_custom_cogs(tmp_path / "nope", mock_bot, None, mock_components)
+    assert result == 0
+
+
+async def test_load_valid_cog(
+    cogs_dir: Path, mock_bot: MagicMock, mock_components: MagicMock
+) -> None:
+    """A valid Cog file with setup() should be loaded."""
+    cog_file = cogs_dir / "hello.py"
+    cog_file.write_text(
+        textwrap.dedent("""\
+        async def setup(bot, runner, components):
+            bot._test_hello_loaded = True
+    """)
+    )
+
+    result = await load_custom_cogs(cogs_dir, mock_bot, None, mock_components)
+    assert result == 1
+    assert mock_bot._test_hello_loaded is True
+
+
+async def test_skip_underscore_prefix(
+    cogs_dir: Path, mock_bot: MagicMock, mock_components: MagicMock
+) -> None:
+    """Files starting with _ should be skipped."""
+    (cogs_dir / "_helper.py").write_text("async def setup(bot, runner, components): pass")
+    (cogs_dir / "good.py").write_text("async def setup(bot, runner, components): pass")
+
+    result = await load_custom_cogs(cogs_dir, mock_bot, None, mock_components)
+    assert result == 1  # only good.py
+
+
+async def test_skip_non_py_files(
+    cogs_dir: Path, mock_bot: MagicMock, mock_components: MagicMock
+) -> None:
+    """Non-.py files should be ignored."""
+    (cogs_dir / "readme.txt").write_text("not a cog")
+    (cogs_dir / "config.json").write_text("{}")
+
+    result = await load_custom_cogs(cogs_dir, mock_bot, None, mock_components)
+    assert result == 0
+
+
+async def test_skip_no_setup_function(
+    cogs_dir: Path, mock_bot: MagicMock, mock_components: MagicMock
+) -> None:
+    """A .py file without setup() should be skipped with a warning."""
+    (cogs_dir / "no_setup.py").write_text("x = 42")
+
+    result = await load_custom_cogs(cogs_dir, mock_bot, None, mock_components)
+    assert result == 0
+
+
+async def test_one_failure_does_not_block_others(
+    cogs_dir: Path, mock_bot: MagicMock, mock_components: MagicMock
+) -> None:
+    """A broken Cog should not prevent other Cogs from loading."""
+    # aaa.py loads first (sorted order) — broken
+    (cogs_dir / "aaa_broken.py").write_text(
+        textwrap.dedent("""\
+        async def setup(bot, runner, components):
+            raise RuntimeError("intentional failure")
+    """)
+    )
+    # bbb.py loads second — good
+    (cogs_dir / "bbb_good.py").write_text(
+        textwrap.dedent("""\
+        async def setup(bot, runner, components):
+            bot._test_bbb_loaded = True
+    """)
+    )
+
+    result = await load_custom_cogs(cogs_dir, mock_bot, None, mock_components)
+    assert result == 1
+    assert mock_bot._test_bbb_loaded is True
+
+
+async def test_deterministic_load_order(
+    cogs_dir: Path, mock_bot: MagicMock, mock_components: MagicMock
+) -> None:
+    """Cogs should be loaded in sorted filename order."""
+    load_order: list[str] = []
+
+    for name in ["charlie.py", "alpha.py", "bravo.py"]:
+        (cogs_dir / name).write_text(
+            textwrap.dedent(f"""\
+            async def setup(bot, runner, components):
+                bot._load_order.append("{name}")
+        """)
+        )
+
+    mock_bot._load_order = load_order
+    result = await load_custom_cogs(cogs_dir, mock_bot, None, mock_components)
+    assert result == 3
+    assert load_order == ["alpha.py", "bravo.py", "charlie.py"]
+
+
+async def test_runner_and_components_passed(
+    cogs_dir: Path, mock_bot: MagicMock, mock_components: MagicMock
+) -> None:
+    """setup() should receive bot, runner, and components."""
+    (cogs_dir / "check_args.py").write_text(
+        textwrap.dedent("""\
+        async def setup(bot, runner, components):
+            bot._test_runner = runner
+            bot._test_components = components
+    """)
+    )
+
+    mock_runner = MagicMock()
+    result = await load_custom_cogs(cogs_dir, mock_bot, mock_runner, mock_components)
+    assert result == 1
+    assert mock_bot._test_runner is mock_runner
+    assert mock_bot._test_components is mock_components
+
+
+async def test_syntax_error_in_cog(
+    cogs_dir: Path, mock_bot: MagicMock, mock_components: MagicMock
+) -> None:
+    """A file with syntax errors should be skipped gracefully."""
+    (cogs_dir / "bad_syntax.py").write_text("def setup(bot, runner, components) oops")
+
+    result = await load_custom_cogs(cogs_dir, mock_bot, None, mock_components)
+    assert result == 0

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "1.7.6"
+version = "1.7.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Add dynamic custom Cog loader (`cog_loader.py`) that loads external Cog files from a configurable directory (`CUSTOM_COGS_DIR` env / `--cogs-dir` CLI flag)
- Rewrite `main.py` to use `setup_bridge()` for full auto-setup + custom Cog loading
- Port EbiBot's 4 custom Cogs to `examples/ebibot/cogs/` as a reference implementation (reminder, watchdog, auto_upgrade, docs_sync)
- Each custom Cog file is self-contained with `async def setup(bot, runner, components)` protocol

## Motivation

Having ccdb framework and personal bot (EbiBot) in separate repos meant Claude Code could only see one at a time, causing accidental feature duplication (10 incidents). This PR adds the "receiver" side — Phase 2 (switching production EbiBot to run from ccdb) is a separate task.

## Test plan

- [x] 10 new tests for `cog_loader.py` (empty dir, nonexistent dir, valid cog, underscore skip, non-py skip, no setup function, failure isolation, load order, args passing, syntax error handling)
- [x] All 843 existing tests pass
- [x] ruff check + ruff format clean
- [ ] Manual: `CUSTOM_COGS_DIR=examples/ebibot/cogs ccdb start` loads all 4 Cogs

🤖 Generated with [Claude Code](https://claude.com/claude-code)