### PR TITLE
[docs-sync] Add systemd service deployment section to all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,37 @@ ccdb start --env /path/to/.env   # custom .env location
 
 Send a message in the configured channel — Claude will reply in a new thread.
 
+### Running as a systemd Service (Production)
+
+For production deployments, run the bot under systemd so it starts on boot and auto-restarts on failure.
+
+The repo ships a ready-to-adapt template (`discord-bot.service`) and a pre-start script (`scripts/pre-start.sh`). Copy and customize them:
+
+```bash
+# 1. Edit the service file — replace /home/ebi and User=ebi with your paths/user
+sudo cp discord-bot.service /etc/systemd/system/mybot.service
+sudo nano /etc/systemd/system/mybot.service
+
+# 2. Enable and start
+sudo systemctl daemon-reload
+sudo systemctl enable mybot.service
+sudo systemctl start mybot.service
+
+# 3. Check status
+sudo systemctl status mybot.service
+journalctl -u mybot.service -f
+```
+
+**What `scripts/pre-start.sh` does** (runs as `ExecStartPre` before the bot process):
+
+1. **`git pull --ff-only`** — pulls the latest code from `origin main`
+2. **`uv sync`** — keeps dependencies in sync with `uv.lock`
+3. **Import validation** — verifies that `claude_discord.main` imports cleanly
+4. **Auto-rollback** — if import fails, reverts to the previous commit and retries; posts a Discord webhook notification on failure or success
+5. **Worktree cleanup** — removes stale git worktrees left by crashed sessions
+
+The script requires the `DISCORD_WEBHOOK_URL` variable in `.env` for failure notifications (optional — the script works without it).
+
 ### Custom Cogs (Extend Without Forking)
 
 Add your own features by dropping Python files into a directory — no fork, no subclass, no package needed:

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -207,6 +207,37 @@ cp .env.example .env
 uv run python -m claude_discord.main
 ```
 
+### Ejecutar como servicio systemd (producción)
+
+Para entornos de producción, ejecutar bajo systemd permite el inicio automático al arranque y reinicio ante fallos.
+
+El repositorio incluye plantillas: `discord-bot.service` y `scripts/pre-start.sh`. Copia y personaliza las rutas y el usuario:
+
+```bash
+# 1. Edita el archivo de servicio — reemplaza /home/ebi y User=ebi con tu ruta/usuario
+sudo cp discord-bot.service /etc/systemd/system/mybot.service
+sudo nano /etc/systemd/system/mybot.service
+
+# 2. Habilitar e iniciar
+sudo systemctl daemon-reload
+sudo systemctl enable mybot.service
+sudo systemctl start mybot.service
+
+# 3. Verificar estado
+sudo systemctl status mybot.service
+journalctl -u mybot.service -f
+```
+
+**Qué hace `scripts/pre-start.sh`** (se ejecuta como `ExecStartPre` antes del proceso del bot):
+
+1. **`git pull --ff-only`** — obtiene el código más reciente de `origin main`
+2. **`uv sync`** — sincroniza dependencias según `uv.lock`
+3. **Validación de importación** — verifica que `claude_discord.main` se importe correctamente
+4. **Reversión automática** — si la importación falla, revierte al commit anterior y reintenta; envía notificación vía Discord webhook
+5. **Limpieza de worktrees** — elimina git worktrees huérfanos de sesiones que fallaron
+
+Configura `DISCORD_WEBHOOK_URL` en `.env` para recibir notificaciones de fallo (opcional).
+
 ### Instalar como paquete
 
 Si ya tienes un bot discord.py en ejecución (Discord solo permite una conexión Gateway por token):

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -207,6 +207,37 @@ cp .env.example .env
 uv run python -m claude_discord.main
 ```
 
+### Exécuter comme service systemd (production)
+
+En production, gérer le bot via systemd permet le démarrage automatique au boot et le redémarrage automatique en cas de panne.
+
+Le dépôt fournit des modèles prêts à l'emploi : `discord-bot.service` et `scripts/pre-start.sh`. Copiez-les et adaptez les chemins et l'utilisateur :
+
+```bash
+# 1. Éditez le fichier de service — remplacez /home/ebi et User=ebi par votre chemin/utilisateur
+sudo cp discord-bot.service /etc/systemd/system/mybot.service
+sudo nano /etc/systemd/system/mybot.service
+
+# 2. Activer et démarrer
+sudo systemctl daemon-reload
+sudo systemctl enable mybot.service
+sudo systemctl start mybot.service
+
+# 3. Vérifier le statut
+sudo systemctl status mybot.service
+journalctl -u mybot.service -f
+```
+
+**Ce que fait `scripts/pre-start.sh`** (exécuté comme `ExecStartPre` avant le processus du bot) :
+
+1. **`git pull --ff-only`** — récupère le code le plus récent depuis `origin main`
+2. **`uv sync`** — synchronise les dépendances selon `uv.lock`
+3. **Validation des imports** — vérifie que `claude_discord.main` s'importe correctement
+4. **Rollback automatique** — en cas d'échec de l'import, revient au commit précédent et réessaie ; envoie une notification via Discord webhook
+5. **Nettoyage des worktrees** — supprime les git worktrees orphelins laissés par des sessions qui ont planté
+
+Configurez `DISCORD_WEBHOOK_URL` dans `.env` pour recevoir des notifications d'échec (optionnel).
+
 ### Installer comme paquet
 
 Si vous avez déjà un bot discord.py en fonctionnement (Discord n'autorise qu'une connexion Gateway par token) :

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -231,6 +231,37 @@ cp .env.example .env
 uv run python -m claude_discord.main
 ```
 
+### systemd サービスとして運用（本番環境）
+
+本番環境では systemd 管理下で動かすと、起動時の自動開始と障害時の自動再起動が得られます。
+
+リポジトリにはテンプレートとして `discord-bot.service`（サービスファイル）と `scripts/pre-start.sh`（起動前スクリプト）が同梱されています。コピーしてパスやユーザー名を書き換えてください:
+
+```bash
+# 1. サービスファイルを編集 — /home/ebi と User=ebi をご自身のパス/ユーザーに変更
+sudo cp discord-bot.service /etc/systemd/system/mybot.service
+sudo nano /etc/systemd/system/mybot.service
+
+# 2. 有効化して起動
+sudo systemctl daemon-reload
+sudo systemctl enable mybot.service
+sudo systemctl start mybot.service
+
+# 3. 状態確認
+sudo systemctl status mybot.service
+journalctl -u mybot.service -f
+```
+
+**`scripts/pre-start.sh` の動作**（ボットプロセス起動前に `ExecStartPre` として実行）:
+
+1. **`git pull --ff-only`** — `origin main` から最新コードを取得
+2. **`uv sync`** — `uv.lock` に従って依存関係を最新の状態に同期
+3. **インポート検証** — `claude_discord.main` が正常にインポートできるか確認
+4. **自動ロールバック** — インポートに失敗した場合は前のコミットに戻して再試行。Discord webhook に成功/失敗を通知
+5. **Worktree クリーンアップ** — クラッシュしたセッションが残した git worktree を削除
+
+`.env` に `DISCORD_WEBHOOK_URL` を設定すると障害通知が届きます（任意）。
+
 ### パッケージとしてインストール
 
 すでに discord.py Bot を動かしている場合（Discord はトークンごとに 1 Gateway 接続のみ許可）:

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -207,6 +207,37 @@ cp .env.example .env
 uv run python -m claude_discord.main
 ```
 
+### systemd 서비스로 실행 (프로덕션)
+
+프로덕션 환경에서는 systemd로 관리하면 부팅 시 자동 시작과 장애 시 자동 재시작이 가능합니다.
+
+리포지토리에는 템플릿 파일 `discord-bot.service`와 `scripts/pre-start.sh`가 포함되어 있습니다. 복사 후 경로와 사용자명을 수정하세요:
+
+```bash
+# 1. 서비스 파일 편집 — /home/ebi와 User=ebi를 본인의 경로/사용자로 변경
+sudo cp discord-bot.service /etc/systemd/system/mybot.service
+sudo nano /etc/systemd/system/mybot.service
+
+# 2. 활성화 및 시작
+sudo systemctl daemon-reload
+sudo systemctl enable mybot.service
+sudo systemctl start mybot.service
+
+# 3. 상태 확인
+sudo systemctl status mybot.service
+journalctl -u mybot.service -f
+```
+
+**`scripts/pre-start.sh` 동작** (봇 프로세스 시작 전 `ExecStartPre`로 실행):
+
+1. **`git pull --ff-only`** — `origin main`에서 최신 코드 가져오기
+2. **`uv sync`** — `uv.lock`에 따라 의존성 동기화
+3. **임포트 검증** — `claude_discord.main`이 정상적으로 임포트되는지 확인
+4. **자동 롤백** — 임포트 실패 시 이전 커밋으로 되돌리고 재시도. Discord webhook으로 성공/실패 알림 전송
+5. **Worktree 정리** — 충돌된 세션이 남긴 git worktree 삭제
+
+`.env`에 `DISCORD_WEBHOOK_URL`을 설정하면 장애 알림을 받을 수 있습니다 (선택사항).
+
 ### 패키지로 설치
 
 이미 discord.py 봇이 있는 경우 (Discord는 토큰당 하나의 Gateway 연결만 허용):

--- a/docs/pt-BR/README.md
+++ b/docs/pt-BR/README.md
@@ -207,6 +207,37 @@ cp .env.example .env
 uv run python -m claude_discord.main
 ```
 
+### Executar como serviço systemd (produção)
+
+Em produção, gerenciar via systemd garante inicialização automática na boot e reinício em caso de falha.
+
+O repositório inclui modelos prontos: `discord-bot.service` e `scripts/pre-start.sh`. Copie e ajuste os caminhos e o usuário:
+
+```bash
+# 1. Edite o arquivo de serviço — substitua /home/ebi e User=ebi pelo seu caminho/usuário
+sudo cp discord-bot.service /etc/systemd/system/mybot.service
+sudo nano /etc/systemd/system/mybot.service
+
+# 2. Habilitar e iniciar
+sudo systemctl daemon-reload
+sudo systemctl enable mybot.service
+sudo systemctl start mybot.service
+
+# 3. Verificar status
+sudo systemctl status mybot.service
+journalctl -u mybot.service -f
+```
+
+**O que `scripts/pre-start.sh` faz** (executado como `ExecStartPre` antes do processo do bot):
+
+1. **`git pull --ff-only`** — obtém o código mais recente de `origin main`
+2. **`uv sync`** — sincroniza dependências conforme `uv.lock`
+3. **Validação de importação** — verifica se `claude_discord.main` importa corretamente
+4. **Rollback automático** — se a importação falhar, reverte para o commit anterior e tenta novamente; envia notificação via Discord webhook
+5. **Limpeza de worktrees** — remove git worktrees órfãos de sessões que falharam
+
+Configure `DISCORD_WEBHOOK_URL` no `.env` para receber notificações de falha (opcional).
+
 ### Instalar como pacote
 
 Se você já tem um bot discord.py rodando (Discord permite apenas uma conexão Gateway por token):

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -227,6 +227,37 @@ cp .env.example .env
 uv run python -m claude_discord.main
 ```
 
+### 作为 systemd 服务运行（生产环境）
+
+在生产环境中，建议通过 systemd 管理，以实现开机自启和故障自动重启。
+
+仓库提供了模板文件 `discord-bot.service` 和 `scripts/pre-start.sh`，复制后修改路径和用户名即可：
+
+```bash
+# 1. 编辑服务文件 — 将 /home/ebi 和 User=ebi 替换为你的路径/用户
+sudo cp discord-bot.service /etc/systemd/system/mybot.service
+sudo nano /etc/systemd/system/mybot.service
+
+# 2. 启用并启动
+sudo systemctl daemon-reload
+sudo systemctl enable mybot.service
+sudo systemctl start mybot.service
+
+# 3. 查看状态
+sudo systemctl status mybot.service
+journalctl -u mybot.service -f
+```
+
+**`scripts/pre-start.sh` 的功能**（在机器人进程启动前作为 `ExecStartPre` 运行）：
+
+1. **`git pull --ff-only`** — 从 `origin main` 拉取最新代码
+2. **`uv sync`** — 根据 `uv.lock` 同步依赖
+3. **导入验证** — 验证 `claude_discord.main` 可以正常导入
+4. **自动回滚** — 导入失败时回退到上一个提交并重试；通过 Discord webhook 发送通知
+5. **Worktree 清理** — 删除崩溃会话遗留的 git worktree
+
+在 `.env` 中设置 `DISCORD_WEBHOOK_URL` 可接收故障通知（可选）。
+
 ### 作为包安装
 
 如果你已有运行中的 discord.py Bot（Discord 每个 token 只允许一个 Gateway 连接）：


### PR DESCRIPTION
## Summary

- Add "Running as a systemd Service" section to `README.md` documenting the new `discord-bot.service` and `scripts/pre-start.sh` template files
- Explain the 5-step pre-start pipeline: git pull → uv sync → import validation → auto-rollback → worktree cleanup
- Note that the service file has hardcoded paths and must be customized before use
- Sync all translations: `docs/ja/`, `docs/zh-CN/`, `docs/ko/`, `docs/es/`, `docs/pt-BR/`, `docs/fr/`

## Test plan

- [ ] Verify the new section renders correctly in GitHub Markdown preview
- [ ] Verify all 6 translation files have the new section with appropriate localization
- [ ] Verify no broken links or formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
