### PR TITLE
fix: resolve pyright type errors in main.py

### DIFF
--- a/claude_discord/main.py
+++ b/claude_discord/main.py
@@ -50,8 +50,7 @@ def load_config() -> dict[str, str]:
         "timeout": os.getenv("SESSION_TIMEOUT_SECONDS", "300"),
         "owner_id": os.getenv("DISCORD_OWNER_ID", ""),
         "coordination_channel_id": os.getenv("COORDINATION_CHANNEL_ID", ""),
-        "dangerously_skip_permissions": os.getenv("CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS", "").lower()
-        in ("true", "1", "yes"),
+        "dangerously_skip_permissions": os.getenv("CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS", ""),
         # Additional config for custom cogs and multi-channel
         "claude_channel_ids": os.getenv("CLAUDE_CHANNEL_IDS", ""),
         "api_host": os.getenv("API_HOST", "127.0.0.1"),
@@ -87,7 +86,8 @@ async def main() -> None:
         permission_mode=config["claude_permission_mode"],
         working_dir=config["claude_working_dir"] or None,
         timeout_seconds=int(config["timeout"]),
-        dangerously_skip_permissions=config["dangerously_skip_permissions"],
+        dangerously_skip_permissions=config["dangerously_skip_permissions"].lower()
+        in ("true", "1", "yes"),
         allowed_tools=allowed_tools,
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "1.7.8"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Fix 2 pyright errors in `main.py` introduced by #220
- `load_config()` return type was `dict[str, str]` but `dangerously_skip_permissions` was a `bool`
- Move the bool conversion from `load_config()` to the `ClaudeRunner()` call site

## Context

This was the cause of CI failure on the v1.8.0 release. Also added required status checks to branch protection so CI-failing PRs can no longer be merged.