### PR TITLE
fix: use PR-based flow for auto version bump

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -10,7 +10,8 @@ jobs:
     # Skip draft PRs — only auto-merge when the PR is explicitly marked ready.
     # This prevents the race condition where auto-merge fires on the first
     # commit before subsequent commits have been pushed.
-    if: github.event.pull_request.user.login == 'ebibibi' && github.event.pull_request.draft == false
+    # Auto-approve PRs from: owner (ebibibi) OR github-actions[bot] (version bump PRs).
+    if: (github.event.pull_request.user.login == 'ebibibi' || github.event.pull_request.user.login == 'github-actions[bot]') && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -66,8 +67,8 @@ jobs:
                 echo "Skipping docs-sync: excluded branch ($HEAD_REF)"
               fi
 
-              # --- Version bump dispatch (skip for docs-sync PRs) ---
-              if [[ "$HEAD_REF" != docs-sync/* ]] && [[ "$PR_TITLE" != '[docs-sync]'* ]]; then
+              # --- Version bump dispatch (skip for docs-sync and auto-bump PRs) ---
+              if [[ "$HEAD_REF" != docs-sync/* ]] && [[ "$PR_TITLE" != '[docs-sync]'* ]] && [[ "$HEAD_REF" != auto/bump-* ]] && [[ "$PR_TITLE" != *'[skip bump]'* ]]; then
                 echo "Dispatching pr-merged event for version bump..."
                 DISPATCH_PAYLOAD=$(jq -c -n \
                   --arg event_type "pr-merged" \
@@ -78,7 +79,7 @@ jobs:
                   --method POST \
                   --input -
               else
-                echo "Skipping version bump: docs-sync PR ($HEAD_REF)"
+                echo "Skipping version bump: excluded PR ($HEAD_REF)"
               fi
 
               exit 0

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -7,9 +7,11 @@ name: Auto Patch Version Bump
 #
 # Two modes, determined by PR title:
 #   [release] in title → tag & release the current version as-is (no bump)
-#   anything else      → bump patch only (1.3.0 → 1.3.1), commit to main; no tag/release
+#   anything else      → bump patch via PR (1.3.0 → 1.3.1); no tag/release
 #
-# Branch protection has enforce_admins=false so GITHUB_TOKEN can push to main.
+# Patch-bump creates a PR (auto/bump-vX.Y.Z branch) instead of pushing
+# directly to main, so it works with required status checks on main.
+# auto-approve.yml handles merging these PRs.
 on:
   repository_dispatch:
     types: [pr-merged]
@@ -19,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository
@@ -61,37 +64,43 @@ jobs:
           echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
           echo "release_tag=v$RELEASE_VERSION"    >> "$GITHUB_OUTPUT"
 
-      - name: Commit version bump to main (patch-bump mode)
-        id: commit
+      - name: Create version bump PR (patch-bump mode)
+        id: bump-pr
         if: steps.mode.outputs.mode == 'patch-bump'
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CURRENT: ${{ steps.read.outputs.current }}
           RELEASE_VERSION: ${{ steps.read.outputs.release_version }}
         run: |
+          BRANCH="auto/bump-v${RELEASE_VERSION}"
+
+          # Clean up stale branch if it exists
+          git push origin --delete "$BRANCH" 2>/dev/null || true
+
+          git checkout -b "$BRANCH"
           sed -i "s/^version = \"$CURRENT\"/version = \"$RELEASE_VERSION\"/" pyproject.toml
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml
-          git commit -m "chore: bump version to $RELEASE_VERSION [skip ci]"
-          git push origin main
+          git commit -m "chore: bump version to $RELEASE_VERSION"
+          git push origin "$BRANCH"
 
-          echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          echo "Committed version bump to main"
+          gh pr create \
+            --title "chore: bump version to $RELEASE_VERSION [skip bump]" \
+            --body "Automated patch version bump: $CURRENT → $RELEASE_VERSION" \
+            --base main \
+            --head "$BRANCH"
+
+          echo "Created bump PR for $RELEASE_VERSION"
 
       - name: Create tag and GitHub Release
         if: steps.mode.outputs.mode == 'release'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MODE: ${{ steps.mode.outputs.mode }}
           RELEASE_TAG: ${{ steps.read.outputs.release_tag }}
-          BUMP_COMMIT_SHA: ${{ steps.commit.outputs.commit_sha }}
         run: |
-          if [ "$MODE" = "release" ]; then
-            TAG_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/refs/heads/main" --jq '.object.sha')
-          else
-            TAG_SHA="$BUMP_COMMIT_SHA"
-          fi
+          TAG_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/refs/heads/main" --jq '.object.sha')
 
           # Create tag (idempotent)
           if gh api "repos/$GITHUB_REPOSITORY/git/refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Auto version bump now creates a PR (`auto/bump-vX.Y.Z` branch) instead of pushing directly to main
- This works correctly with required status checks (Ruleset) on main
- `auto-approve.yml` now also auto-merges `github-actions[bot]` PRs (for version bump)
- Loop prevention: bump PRs with `[skip bump]` or `auto/bump-*` branch skip the version bump dispatch

## Root cause
Adding required CI status checks to main (Ruleset) broke the auto version bump workflow, which was pushing directly to main with `GITHUB_TOKEN`. On personal repos, `GITHUB_TOKEN` cannot bypass Ruleset required checks.

## Test plan
- [ ] Merge this PR → auto-approve dispatches pr-merged → auto-version-bump creates a bump PR → auto-approve merges it → no infinite loop