### PR TITLE
fix: use ADMIN_PAT for auto version bump to bypass Ruleset

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -9,7 +9,9 @@ name: Auto Patch Version Bump
 #   [release] in title → tag & release the current version as-is (no bump)
 #   anything else      → bump patch only (1.3.0 → 1.3.1), commit to main; no tag/release
 #
-# Branch protection has enforce_admins=false so GITHUB_TOKEN can push to main.
+# Uses ADMIN_PAT (classic PAT with repo scope) to push to main.
+# The PAT owner (ebibibi) has admin RepositoryRole, which bypasses
+# the Ruleset's required status checks.
 on:
   repository_dispatch:
     types: [pr-merged]
@@ -25,6 +27,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.ADMIN_PAT }}
 
       - name: Detect release mode from PR title
         id: mode
@@ -83,15 +86,9 @@ jobs:
         if: steps.mode.outputs.mode == 'release'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MODE: ${{ steps.mode.outputs.mode }}
           RELEASE_TAG: ${{ steps.read.outputs.release_tag }}
-          BUMP_COMMIT_SHA: ${{ steps.commit.outputs.commit_sha }}
         run: |
-          if [ "$MODE" = "release" ]; then
-            TAG_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/refs/heads/main" --jq '.object.sha')
-          else
-            TAG_SHA="$BUMP_COMMIT_SHA"
-          fi
+          TAG_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/refs/heads/main" --jq '.object.sha')
 
           # Create tag (idempotent)
           if gh api "repos/$GITHUB_REPOSITORY/git/refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Use `ADMIN_PAT` (classic PAT) in auto-version-bump checkout so the push to main bypasses the Ruleset's required status checks
- The PAT owner (ebibibi) has admin RepositoryRole, which is a bypass actor in the Ruleset

## Root cause
Adding required CI status checks to main (Ruleset) broke the auto version bump workflow. `GITHUB_TOKEN` cannot bypass Rulesets on personal repos. PR-based bump was attempted but GITHUB_TOKEN-created PRs don't trigger other workflows (GitHub security feature).

## Changes
- `auto-version-bump.yml`: Added `token: ${{ secrets.ADMIN_PAT }}` to checkout step
- `ADMIN_PAT` secret already set on the repository

## Test plan
- [ ] Merge this PR → auto-version-bump pushes v1.8.1 directly to main → success