### PR TITLE
fix: use ADMIN_PAT for auto version bump to bypass Ruleset

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -10,8 +10,7 @@ jobs:
     # Skip draft PRs — only auto-merge when the PR is explicitly marked ready.
     # This prevents the race condition where auto-merge fires on the first
     # commit before subsequent commits have been pushed.
-    # Auto-approve PRs from: owner (ebibibi) OR github-actions[bot] (version bump PRs).
-    if: (github.event.pull_request.user.login == 'ebibibi' || github.event.pull_request.user.login == 'github-actions[bot]') && github.event.pull_request.draft == false
+    if: github.event.pull_request.user.login == 'ebibibi' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -67,8 +66,8 @@ jobs:
                 echo "Skipping docs-sync: excluded branch ($HEAD_REF)"
               fi
 
-              # --- Version bump dispatch (skip for docs-sync and auto-bump PRs) ---
-              if [[ "$HEAD_REF" != docs-sync/* ]] && [[ "$PR_TITLE" != '[docs-sync]'* ]] && [[ "$HEAD_REF" != auto/bump-* ]] && [[ "$PR_TITLE" != *'[skip bump]'* ]]; then
+              # --- Version bump dispatch (skip for docs-sync PRs) ---
+              if [[ "$HEAD_REF" != docs-sync/* ]] && [[ "$PR_TITLE" != '[docs-sync]'* ]]; then
                 echo "Dispatching pr-merged event for version bump..."
                 DISPATCH_PAYLOAD=$(jq -c -n \
                   --arg event_type "pr-merged" \
@@ -79,7 +78,7 @@ jobs:
                   --method POST \
                   --input -
               else
-                echo "Skipping version bump: excluded PR ($HEAD_REF)"
+                echo "Skipping version bump: docs-sync PR ($HEAD_REF)"
               fi
 
               exit 0

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -7,11 +7,11 @@ name: Auto Patch Version Bump
 #
 # Two modes, determined by PR title:
 #   [release] in title → tag & release the current version as-is (no bump)
-#   anything else      → bump patch via PR (1.3.0 → 1.3.1); no tag/release
+#   anything else      → bump patch only (1.3.0 → 1.3.1), commit to main; no tag/release
 #
-# Patch-bump creates a PR (auto/bump-vX.Y.Z branch) instead of pushing
-# directly to main, so it works with required status checks on main.
-# auto-approve.yml handles merging these PRs.
+# Uses ADMIN_PAT (classic PAT with repo scope) to push to main.
+# The PAT owner (ebibibi) has admin RepositoryRole, which bypasses
+# the Ruleset's required status checks.
 on:
   repository_dispatch:
     types: [pr-merged]
@@ -21,13 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.ADMIN_PAT }}
 
       - name: Detect release mode from PR title
         id: mode
@@ -64,35 +64,23 @@ jobs:
           echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
           echo "release_tag=v$RELEASE_VERSION"    >> "$GITHUB_OUTPUT"
 
-      - name: Create version bump PR (patch-bump mode)
-        id: bump-pr
+      - name: Commit version bump to main (patch-bump mode)
+        id: commit
         if: steps.mode.outputs.mode == 'patch-bump'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CURRENT: ${{ steps.read.outputs.current }}
           RELEASE_VERSION: ${{ steps.read.outputs.release_version }}
         run: |
-          BRANCH="auto/bump-v${RELEASE_VERSION}"
-
-          # Clean up stale branch if it exists
-          git push origin --delete "$BRANCH" 2>/dev/null || true
-
-          git checkout -b "$BRANCH"
           sed -i "s/^version = \"$CURRENT\"/version = \"$RELEASE_VERSION\"/" pyproject.toml
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml
-          git commit -m "chore: bump version to $RELEASE_VERSION"
-          git push origin "$BRANCH"
+          git commit -m "chore: bump version to $RELEASE_VERSION [skip ci]"
+          git push origin main
 
-          gh pr create \
-            --title "chore: bump version to $RELEASE_VERSION [skip bump]" \
-            --body "Automated patch version bump: $CURRENT → $RELEASE_VERSION" \
-            --base main \
-            --head "$BRANCH"
-
-          echo "Created bump PR for $RELEASE_VERSION"
+          echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "Committed version bump to main"
 
       - name: Create tag and GitHub Release
         if: steps.mode.outputs.mode == 'release'


### PR DESCRIPTION
## Summary
- Use `ADMIN_PAT` (classic PAT with repo scope) in auto-version-bump checkout
- The PAT owner (ebibibi) has admin RepositoryRole, bypassing the Ruleset's required status checks
- Reverted the PR-based bump approach from #227 — GITHUB_TOKEN-created PRs don't trigger other workflows (GitHub security feature), making PR-based bump a dead end

## Changes
- `auto-version-bump.yml`: Added `token: ${{ secrets.ADMIN_PAT }}`, reverted to direct push
- `auto-approve.yml`: Reverted github-actions[bot] approval and skip-bump conditions (no longer needed)

## Test plan
- [ ] After merge, the version bump dispatch should push v1.8.1 to main successfully