### PR TITLE
docs: add CLAUDE_ALLOWED_TOOLS usage guide with examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,11 @@ CLAUDE_PERMISSION_MODE=acceptEdits
 CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=false
 CLAUDE_WORKING_DIR=
 
+# Fine-grained tool control (optional, comma-separated)
+# Use with CLAUDE_PERMISSION_MODE=default for precise control
+# Common tools: Bash,Read,Write,Edit,Glob,Grep,WebFetch,WebSearch
+# CLAUDE_ALLOWED_TOOLS=Bash,Read,Write,Edit,Glob,Grep
+
 # Limits
 MAX_CONCURRENT_SESSIONS=3
 SESSION_TIMEOUT_SECONDS=300

--- a/README.md
+++ b/README.md
@@ -495,7 +495,17 @@ Claude Code CLI runs in **`-p` (non-interactive) mode** when used through ccdb. 
 
 **Our recommendation:** Set `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`. Since ccdb controls who can interact with Claude via `allowed_user_ids`, the CLI-level permission checks add friction without meaningful security benefit. The "dangerously" in the name reflects the CLI's general-purpose warning; in the ccdb context where access is already gated, it's the practical choice.
 
-If you prefer fine-grained control, `CLAUDE_ALLOWED_TOOLS` support is planned ([#217](https://github.com/ebibibi/claude-code-discord-bridge/issues/217)).
+**For fine-grained control**, use `CLAUDE_ALLOWED_TOOLS` to allow specific tools without fully bypassing permissions:
+
+```env
+# Example: allow file operations and code execution, but not web access
+CLAUDE_ALLOWED_TOOLS=Bash,Read,Write,Edit,Glob,Grep
+
+# Example: read-only mode — Claude can explore but not modify
+CLAUDE_ALLOWED_TOOLS=Read,Glob,Grep
+```
+
+Common tool names: `Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`, `WebFetch`, `WebSearch`, `NotebookEdit`. Set `CLAUDE_PERMISSION_MODE=default` when using this (other modes may override).
 
 > **Why don't permission buttons appear in Discord?** The CLI's `-p` mode never emits `permission_request` events, so there's nothing for ccdb to display. The `AskUserQuestion` buttons you see (choice prompts from Claude) are a different mechanism that works correctly. See [#210](https://github.com/ebibibi/claude-code-discord-bridge/issues/210) for the full investigation.
 


### PR DESCRIPTION
## Summary
The `CLAUDE_ALLOWED_TOOLS` feature was already implemented but the README still said "planned". Updated docs to show users how to actually use it.

### Changes
- **README**: Replaced "planned (#217)" with concrete usage examples and common tool names
- **.env.example**: Added commented example with tool name reference

### User experience improvement
Before: User sees "planned" in docs, doesn't know the feature exists
After: User sees copy-paste examples for common scenarios (full access, read-only mode)

## Test plan
- [x] 860 tests pass
- [x] ruff clean