### PR TITLE
fix: update Ask message after 'Other' modal submission for immediate visual feedback

### DIFF
--- a/claude_discord/discord_ui/ask_view.py
+++ b/claude_discord/discord_ui/ask_view.py
@@ -22,6 +22,7 @@ custom_id format:  ``ask_{thread_id}_{q_idx}_{slot}``
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from typing import TYPE_CHECKING
 
@@ -149,18 +150,38 @@ class AskView(discord.ui.View):
         await self._deliver(interaction, values)
 
     async def _other_callback(self, interaction: discord.Interaction) -> None:
+        # Save the original message reference before send_modal() consumes the
+        # interaction response — we need it to update the Ask embed afterward.
+        original_message = interaction.message
         modal = AskModal(title="Your answer")
         await interaction.response.send_modal(modal)
         timed_out = await modal.wait()
         if not timed_out and modal.answer:
             delivered = self._bus.post_answer(self._thread_id, [modal.answer])
-            if not delivered:
+            if delivered:
+                # Mirror the button-click UX: edit the Ask message to confirm
+                # the submission so the user sees immediate visual feedback.
+                if original_message is not None:
+                    with contextlib.suppress(discord.HTTPException):
+                        await original_message.edit(
+                            content=f"-# ✅ **Selected:** {modal.answer}",
+                            embed=None,
+                            view=None,
+                        )
+            else:
                 if self._ask_repo is not None:
                     await self._ask_repo.delete(self._thread_id)
                 logger.warning(
                     "AskView._other_callback: session gone for thread %d after restart",
                     self._thread_id,
                 )
+                if original_message is not None:
+                    with contextlib.suppress(discord.HTTPException):
+                        await original_message.edit(
+                            content=_RESTART_MSG,
+                            embed=None,
+                            view=None,
+                        )
             self.stop()
 
 

--- a/tests/test_ask_feature.py
+++ b/tests/test_ask_feature.py
@@ -318,3 +318,104 @@ class TestCollectAskAnswersTimeout:
             result = await collect_ask_answers(thread, [q], session_id="abc123")
 
         assert result is None  # timeout → no answer → returns None
+
+
+# ---------------------------------------------------------------------------
+# AskView._other_callback — visual feedback after modal submission
+# ---------------------------------------------------------------------------
+
+
+class TestAskViewOtherCallback:
+    """Tests that 'Other' modal submission gives immediate visual feedback.
+
+    Before this fix, the original Ask message was never updated after the modal
+    was submitted, leaving the user uncertain whether their answer was received.
+    """
+
+    def _make_question(self) -> AskQuestion:
+        return AskQuestion(
+            question="Which style?",
+            options=[AskOption(label="A"), AskOption(label="B")],
+        )
+
+    @pytest.mark.asyncio
+    async def test_other_callback_edits_original_message_on_success(self) -> None:
+        """After modal submission the original Ask message is replaced with
+        '✅ Selected: <answer>' so the user sees immediate feedback."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from claude_discord.discord_ui.ask_bus import AskAnswerBus
+        from claude_discord.discord_ui.ask_view import AskModal, AskView
+
+        bus = AskAnswerBus()
+        bus.register(thread_id=42)
+
+        question = self._make_question()
+        view = AskView(question, thread_id=42, q_idx=0, bus=bus)
+
+        # Simulate the original Discord message that holds the Ask embed.
+        original_msg = MagicMock()
+        original_msg.edit = AsyncMock()
+
+        # Simulate the button interaction that opens the modal.
+        interaction = MagicMock()
+        interaction.message = original_msg
+        interaction.response = MagicMock()
+        interaction.response.send_modal = AsyncMock()
+
+        # Patch AskModal so wait() resolves immediately with an answer.
+        async def fake_wait():
+            return False  # not timed out
+
+        mock_modal = MagicMock(spec=AskModal)
+        mock_modal.wait = fake_wait
+        mock_modal.answer = "My custom answer"
+
+        with patch("claude_discord.discord_ui.ask_view.AskModal", return_value=mock_modal):
+            await view._other_callback(interaction)
+
+        # The original message must be edited to confirm the submission.
+        original_msg.edit.assert_awaited_once()
+        call_kwargs = original_msg.edit.call_args.kwargs
+        assert "✅" in call_kwargs["content"]
+        assert "My custom answer" in call_kwargs["content"]
+        assert call_kwargs["view"] is None  # buttons removed
+
+    @pytest.mark.asyncio
+    async def test_other_callback_edits_original_message_when_session_gone(self) -> None:
+        """If the session is gone (bot restarted), the original message is updated
+        with the restart warning instead of silently leaving the ask message."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from claude_discord.discord_ui.ask_bus import AskAnswerBus
+        from claude_discord.discord_ui.ask_view import _RESTART_MSG, AskModal, AskView
+
+        bus = AskAnswerBus()
+        # No register() call → post_answer returns False (session gone).
+
+        question = self._make_question()
+        view = AskView(question, thread_id=99, q_idx=0, bus=bus)
+
+        original_msg = MagicMock()
+        original_msg.edit = AsyncMock()
+
+        interaction = MagicMock()
+        interaction.message = original_msg
+        interaction.response = MagicMock()
+        interaction.response.send_modal = AsyncMock()
+
+        async def fake_wait():
+            return False
+
+        mock_modal = MagicMock(spec=AskModal)
+        mock_modal.wait = fake_wait
+        mock_modal.answer = "Some answer"
+
+        with patch("claude_discord.discord_ui.ask_view.AskModal", return_value=mock_modal):
+            await view._other_callback(interaction)
+
+        # Must edit the original message to show the restart warning.
+        original_msg.edit.assert_awaited_once()
+        call_kwargs = original_msg.edit.call_args.kwargs
+        assert _RESTART_MSG in call_kwargs["content"]
+        assert call_kwargs["view"] is None

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "1.8.2"
+version = "1.8.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Problem

When a user answered an `AskUserQuestion` via the **✏️ Other** free-text modal, the original Ask embed was left unchanged after submission. The buttons remained visible and no confirmation appeared, leaving the user unable to tell whether their answer had been received — especially in long threads where the start of the thread (where any state change might have appeared) is scrolled out of view.

## Root Cause

Button clicks call `interaction.response.edit_message()`, which replaces the embed with `✅ Selected: <label>` in-place. The modal path used a different code flow:
1. `interaction.response.send_modal()` — consumes the button interaction response
2. `await modal.wait()` — waits for the modal to be submitted  
3. `bus.post_answer(...)` — delivers the answer to Claude

Step 3 delivers the answer, but **no code updated the original message**, so the Ask embed with buttons remained on screen forever.

## Fix

Save `interaction.message` before calling `send_modal()` (which consumes the interaction). After `modal.wait()` resolves, edit the original message to show the selection — matching the button-click UX.

```
Before: [Ask embed with buttons stays unchanged forever after modal submit]
After:  [Ask embed → "✅ Selected: <user's text>" — buttons removed]
```

Also fixes the session-gone case: if `post_answer()` returns `False` (bot restarted since the question was asked), the original message is now updated with the restart warning instead of being left stale.

## Tests

`TestAskViewOtherCallback` — 2 new tests:
- `test_other_callback_edits_original_message_on_success` — verifies `✅` message and button removal
- `test_other_callback_edits_original_message_when_session_gone` — verifies restart warning is shown

883 tests pass.