### PR TITLE
feat: add /rewind and /fork slash commands for conversation management

### DIFF
--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -53,6 +53,8 @@ _HELP_CATEGORY: dict[str, str | None] = {
     "help": None,  # the help command doesn't list itself
     "stop": "📌 Session",
     "clear": "📌 Session",
+    "rewind": "📌 Session",
+    "fork": "📌 Session",
     "sessions": "📌 Session",
     "resume-info": "📌 Session",
     "sync-sessions": "📌 Session",
@@ -312,6 +314,99 @@ class ClaudeChatCog(commands.Cog):
             await interaction.response.send_message(
                 "No active session found for this thread.", ephemeral=True
             )
+
+    @app_commands.command(
+        name="rewind",
+        description="Reset the conversation while keeping your working files",
+    )
+    async def rewind_session(self, interaction: discord.Interaction) -> None:
+        """Reset conversation history, preserving working files in the thread's directory.
+
+        Unlike /clear, this command emphasises that **files created by Claude are kept** —
+        only the conversation context is erased.  The thread remains open and the next
+        message will start a fresh Claude session in the same working directory.
+
+        Useful when Claude has gone off-track and you want to restart the conversation
+        without losing the code or files it already wrote.
+        """
+        if not isinstance(interaction.channel, discord.Thread):
+            await interaction.response.send_message(
+                "This command can only be used in a Claude chat thread.", ephemeral=True
+            )
+            return
+
+        # Kill active runner if any — same as /clear.
+        runner = self._active_runners.get(interaction.channel.id)
+        if runner:
+            await runner.kill()
+            del self._active_runners[interaction.channel.id]
+
+        deleted = await self.repo.delete(interaction.channel.id)
+        if not deleted:
+            await interaction.response.send_message(
+                "No active session found for this thread.", ephemeral=True
+            )
+            return
+
+        await interaction.response.send_message(
+            "🔄 **Conversation reset.** "
+            "Working files are preserved — only the conversation history was cleared. "
+            "Send a new message to start a fresh session."
+        )
+
+    @app_commands.command(
+        name="fork",
+        description="Branch this conversation into a new thread",
+    )
+    async def fork_session(self, interaction: discord.Interaction) -> None:
+        """Create a new thread that continues this conversation from the current point.
+
+        The new thread starts a fresh Claude process that resumes the **same session**
+        via ``--resume``, giving you a copy of the conversation history so you can
+        explore a different direction without affecting the original thread.
+
+        Useful when you want to try an alternative approach while keeping the current
+        thread intact.
+        """
+        if not isinstance(interaction.channel, discord.Thread):
+            await interaction.response.send_message(
+                "This command can only be used in a Claude chat thread.", ephemeral=True
+            )
+            return
+
+        record = await self.repo.get(interaction.channel.id)
+        if record is None:
+            await interaction.response.send_message(
+                "No active session found for this thread. "
+                "Start a conversation first, then use /fork to branch it.",
+                ephemeral=True,
+            )
+            return
+
+        parent_channel = getattr(interaction.channel, "parent", None)
+        if not isinstance(parent_channel, discord.TextChannel):
+            await interaction.response.send_message(
+                "Cannot create a fork: unable to find the parent channel.", ephemeral=True
+            )
+            return
+
+        # Defer so we have time to create the thread before Discord's 3-second limit.
+        await interaction.response.defer(ephemeral=False)
+
+        fork_name = f"🔀 Fork of {interaction.channel.name}"[:100]
+        new_thread = await self.spawn_session(
+            channel=parent_channel,
+            prompt=(
+                "This thread is a fork of the previous conversation. "
+                "Continue from where we left off."
+            ),
+            thread_name=fork_name,
+            session_id=record.session_id,
+        )
+
+        await interaction.followup.send(
+            f"🔀 Forked! Continue in {new_thread.mention} — this thread is unchanged."
+        )
 
     async def _handle_new_conversation(self, message: discord.Message) -> None:
         """Start a Claude Code session, creating a thread unless inline-reply mode is active."""

--- a/tests/test_rewind_fork.py
+++ b/tests/test_rewind_fork.py
@@ -1,0 +1,303 @@
+"""Tests for /rewind and /fork slash commands.
+
+/rewind — Reset conversation history while preserving working files.
+/fork   — Create a new thread continuing this conversation from the same point.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from claude_discord.cogs.claude_chat import ClaudeChatCog
+from claude_discord.database.repository import SessionRecord
+
+
+def _make_cog() -> ClaudeChatCog:
+    """Return a ClaudeChatCog with minimal mocked dependencies."""
+    bot = MagicMock()
+    bot.channel_id = 999
+    repo = MagicMock()
+    repo.get = AsyncMock(return_value=None)
+    repo.save = AsyncMock()
+    repo.delete = AsyncMock(return_value=True)
+    runner = MagicMock()
+    runner.clone = MagicMock(return_value=MagicMock())
+    return ClaudeChatCog(bot=bot, repo=repo, runner=runner)
+
+
+def _make_thread_interaction(thread_id: int = 12345) -> MagicMock:
+    """Return an Interaction whose channel is a discord.Thread."""
+    interaction = MagicMock(spec=discord.Interaction)
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = thread_id
+    interaction.channel = thread
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _make_channel_interaction() -> MagicMock:
+    """Return an Interaction whose channel is NOT a thread."""
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.channel = MagicMock(spec=discord.TextChannel)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+def _make_session_record(
+    thread_id: int = 12345,
+    session_id: str = "sess-abc",
+    working_dir: str | None = "/tmp/work",
+) -> SessionRecord:
+    return SessionRecord(
+        thread_id=thread_id,
+        session_id=session_id,
+        working_dir=working_dir,
+        model=None,
+        origin="discord",
+        summary=None,
+        created_at="2026-01-01 00:00:00",
+        last_used_at="2026-01-01 00:00:00",
+    )
+
+
+# ---------------------------------------------------------------------------
+# /rewind
+# ---------------------------------------------------------------------------
+
+
+class TestRewindCommand:
+    @pytest.mark.asyncio
+    async def test_rewind_outside_thread_sends_ephemeral(self) -> None:
+        """Using /rewind outside a thread shows an ephemeral error."""
+        cog = _make_cog()
+        interaction = _make_channel_interaction()
+
+        await cog.rewind_session.callback(cog, interaction)
+
+        interaction.response.send_message.assert_called_once()
+        assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+    @pytest.mark.asyncio
+    async def test_rewind_no_session_sends_ephemeral(self) -> None:
+        """Using /rewind when no session exists shows an ephemeral notice."""
+        cog = _make_cog()
+        cog.repo.get = AsyncMock(return_value=None)
+        cog.repo.delete = AsyncMock(return_value=False)
+        interaction = _make_thread_interaction()
+
+        await cog.rewind_session.callback(cog, interaction)
+
+        interaction.response.send_message.assert_called_once()
+        assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+    @pytest.mark.asyncio
+    async def test_rewind_deletes_session_from_db(self) -> None:
+        """/rewind must delete the session from the DB to clear conversation."""
+        cog = _make_cog()
+        thread_id = 12345
+        cog.repo.get = AsyncMock(return_value=_make_session_record(thread_id))
+        cog.repo.delete = AsyncMock(return_value=True)
+        interaction = _make_thread_interaction(thread_id=thread_id)
+
+        await cog.rewind_session.callback(cog, interaction)
+
+        cog.repo.delete.assert_called_once_with(thread_id)
+
+    @pytest.mark.asyncio
+    async def test_rewind_kills_active_runner(self) -> None:
+        """/rewind stops any currently running Claude process."""
+        cog = _make_cog()
+        thread_id = 12345
+        cog.repo.get = AsyncMock(return_value=_make_session_record(thread_id))
+        cog.repo.delete = AsyncMock(return_value=True)
+        interaction = _make_thread_interaction(thread_id=thread_id)
+
+        mock_runner = MagicMock()
+        mock_runner.kill = AsyncMock()
+        cog._active_runners[thread_id] = mock_runner
+
+        await cog.rewind_session.callback(cog, interaction)
+
+        mock_runner.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_rewind_removes_runner_from_active_dict(self) -> None:
+        """/rewind removes the runner from _active_runners after killing it."""
+        cog = _make_cog()
+        thread_id = 12345
+        cog.repo.get = AsyncMock(return_value=_make_session_record(thread_id))
+        cog.repo.delete = AsyncMock(return_value=True)
+        interaction = _make_thread_interaction(thread_id=thread_id)
+
+        mock_runner = MagicMock()
+        mock_runner.kill = AsyncMock()
+        cog._active_runners[thread_id] = mock_runner
+
+        await cog.rewind_session.callback(cog, interaction)
+
+        assert thread_id not in cog._active_runners
+
+    @pytest.mark.asyncio
+    async def test_rewind_sends_confirmation_message(self) -> None:
+        """/rewind sends a visible (non-ephemeral) confirmation message."""
+        cog = _make_cog()
+        thread_id = 12345
+        cog.repo.get = AsyncMock(return_value=_make_session_record(thread_id))
+        cog.repo.delete = AsyncMock(return_value=True)
+        interaction = _make_thread_interaction(thread_id=thread_id)
+
+        await cog.rewind_session.callback(cog, interaction)
+
+        interaction.response.send_message.assert_called_once()
+        call_kwargs = interaction.response.send_message.call_args.kwargs
+        # Must NOT be ephemeral — the rewind notice should be visible in the thread.
+        assert not call_kwargs.get("ephemeral", False)
+
+    @pytest.mark.asyncio
+    async def test_rewind_confirmation_mentions_files_preserved(self) -> None:
+        """The confirmation message must convey that working files are kept."""
+        cog = _make_cog()
+        thread_id = 12345
+        cog.repo.get = AsyncMock(return_value=_make_session_record(thread_id))
+        cog.repo.delete = AsyncMock(return_value=True)
+        interaction = _make_thread_interaction(thread_id=thread_id)
+
+        await cog.rewind_session.callback(cog, interaction)
+
+        content: str = interaction.response.send_message.call_args.args[0]
+        # The message should mention files are preserved so users understand what changed.
+        assert any(
+            word in content.lower() for word in ("file", "work", "保持", "preserved", "kept")
+        )
+
+
+# ---------------------------------------------------------------------------
+# /fork
+# ---------------------------------------------------------------------------
+
+
+class TestForkCommand:
+    @pytest.mark.asyncio
+    async def test_fork_outside_thread_sends_ephemeral(self) -> None:
+        """Using /fork outside a thread shows an ephemeral error."""
+        cog = _make_cog()
+        interaction = _make_channel_interaction()
+
+        await cog.fork_session.callback(cog, interaction)
+
+        interaction.response.send_message.assert_called_once()
+        assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+    @pytest.mark.asyncio
+    async def test_fork_no_session_sends_ephemeral(self) -> None:
+        """Using /fork when no session exists shows an ephemeral error."""
+        cog = _make_cog()
+        cog.repo.get = AsyncMock(return_value=None)
+        interaction = _make_thread_interaction()
+
+        await cog.fork_session.callback(cog, interaction)
+
+        interaction.response.send_message.assert_called_once()
+        assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+    @pytest.mark.asyncio
+    async def test_fork_creates_new_thread(self) -> None:
+        """/fork creates a new Discord thread in the parent channel."""
+        cog = _make_cog()
+        thread_id = 12345
+        session_id = "sess-abc"
+        record = _make_session_record(thread_id=thread_id, session_id=session_id)
+        cog.repo.get = AsyncMock(return_value=record)
+
+        interaction = _make_thread_interaction(thread_id=thread_id)
+        parent_channel = MagicMock(spec=discord.TextChannel)
+        interaction.channel.parent = parent_channel
+
+        new_thread = MagicMock(spec=discord.Thread)
+        new_thread.id = 99999
+        new_thread.mention = "<#99999>"
+
+        with patch.object(
+            cog, "spawn_session", new=AsyncMock(return_value=new_thread)
+        ) as mock_spawn:
+            await cog.fork_session.callback(cog, interaction)
+
+        mock_spawn.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_fork_uses_same_session_id(self) -> None:
+        """/fork passes the current session_id to spawn_session for conversation continuity."""
+        cog = _make_cog()
+        thread_id = 12345
+        session_id = "sess-abc"
+        record = _make_session_record(thread_id=thread_id, session_id=session_id)
+        cog.repo.get = AsyncMock(return_value=record)
+
+        interaction = _make_thread_interaction(thread_id=thread_id)
+        parent_channel = MagicMock(spec=discord.TextChannel)
+        interaction.channel.parent = parent_channel
+
+        new_thread = MagicMock(spec=discord.Thread)
+        new_thread.id = 99999
+        new_thread.mention = "<#99999>"
+
+        with patch.object(
+            cog, "spawn_session", new=AsyncMock(return_value=new_thread)
+        ) as mock_spawn:
+            await cog.fork_session.callback(cog, interaction)
+
+        call_kwargs = mock_spawn.call_args.kwargs
+        assert call_kwargs.get("session_id") == session_id
+
+    @pytest.mark.asyncio
+    async def test_fork_sends_link_to_new_thread(self) -> None:
+        """/fork replies with a link to the newly created thread."""
+        cog = _make_cog()
+        thread_id = 12345
+        record = _make_session_record(thread_id=thread_id)
+        cog.repo.get = AsyncMock(return_value=record)
+
+        interaction = _make_thread_interaction(thread_id=thread_id)
+        parent_channel = MagicMock(spec=discord.TextChannel)
+        interaction.channel.parent = parent_channel
+
+        new_thread = MagicMock(spec=discord.Thread)
+        new_thread.id = 99999
+        new_thread.mention = "<#99999>"
+
+        with patch.object(cog, "spawn_session", new=AsyncMock(return_value=new_thread)):
+            await cog.fork_session.callback(cog, interaction)
+
+        # /fork uses defer+followup so the fork link appears via followup.send.
+        interaction.followup.send.assert_called_once()
+        content: str = interaction.followup.send.call_args.args[0]
+        # The reply should reference the new thread.
+        assert "<#99999>" in content
+
+    @pytest.mark.asyncio
+    async def test_fork_no_parent_channel_sends_ephemeral(self) -> None:
+        """/fork in a thread without a parent channel shows an ephemeral error.
+
+        This can happen when the thread's parent channel is unavailable (e.g.
+        a DM thread, or a thread the bot can't see).
+        """
+        cog = _make_cog()
+        thread_id = 12345
+        record = _make_session_record(thread_id=thread_id)
+        cog.repo.get = AsyncMock(return_value=record)
+
+        interaction = _make_thread_interaction(thread_id=thread_id)
+        interaction.channel.parent = None  # No parent channel
+
+        await cog.fork_session.callback(cog, interaction)
+
+        interaction.response.send_message.assert_called_once()
+        assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "1.8.4"
+version = "1.8.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- **`/rewind`**: Reset the conversation while keeping working files. Stops any active runner, deletes the session from DB (clearing conversation history), and posts a visible confirmation that files are preserved. Distinct from `/clear` in its explicit communication about file preservation.

- **`/fork`**: Branch the current conversation into a new thread. Creates a new Discord thread via `spawn_session()` with the **same `session_id`** so Claude resumes from the exact same conversation point, enabling parallel exploration of different approaches.

Both commands appear in `/help` under the "📌 Session" section.

## Motivation

Inspired by Claude Code CLI's `/rewind` and `/fork` commands (covered in https://zenn.dev/take4/articles/b7fad1a0c52481). Discord users now have equivalent session management tools without needing CLI access.

## Changes

- `claude_discord/cogs/claude_chat.py`: Added `rewind_session` and `fork_session` app commands; registered both in `_HELP_CATEGORY`
- `tests/test_rewind_fork.py`: 13 new tests covering edge cases (not-in-thread, no session, active runner kill, DB deletion, new thread creation, session_id forwarding, link in reply)

## Test plan

- [x] `pytest tests/test_rewind_fork.py` — 13/13 passed
- [x] `pytest tests/test_help_sync.py` — 4/4 passed (verifies `_HELP_CATEGORY` coverage)
- [x] `pytest tests/` — 896/896 passed
- [x] `ruff check` and `ruff format --check` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)