### PR TITLE
fix: remove duplicate user mention on session completion

### DIFF
--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -705,7 +705,6 @@ class ClaudeChatCog(commands.Cog):
                         worktree_manager=getattr(self.bot, "worktree_manager", None),
                         image_urls=image_urls,
                         attach_on_request=wants_file_attachment(prompt),
-                        requester_id=(None if user_message.author.bot else user_message.author.id),
                     )
                 )
             finally:

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -74,9 +74,6 @@ _TOOL_RESULT_MAX_CHARS = 3000
 # Lines of output shown inline before the "展開 ▼" button appears.
 # 1 means single-line results are shown flat; 2+ lines get a collapse button.
 _COLLAPSED_LINES = 1
-# Minimum tool calls in a session before the requester is mentioned on completion.
-# Sessions with fewer tool calls are considered simple Q&A — no ping needed.
-_MENTION_TOOL_THRESHOLD = 3
 
 
 def _truncate_result(content: str) -> str:
@@ -340,14 +337,6 @@ class EventProcessor:
             )
             if self._config.status:
                 await self._config.status.set_done()
-
-            # Mention the requester when significant work (≥ threshold tool calls) was done.
-            if (
-                self._config.requester_id is not None
-                and self._state.tool_use_count >= _MENTION_TOOL_THRESHOLD
-            ):
-                with contextlib.suppress(discord.HTTPException):
-                    await self._config.thread.send(f"<@{self._config.requester_id}>")
 
         if event.session_id:
             if self._config.repo:

--- a/claude_discord/cogs/run_config.py
+++ b/claude_discord/cogs/run_config.py
@@ -68,10 +68,6 @@ class RunConfig:
     # When True, inject a system-prompt instruction telling Claude to write
     # requested file paths to .ccdb-attachments so the bot can send them.
     attach_on_request: bool = False
-    # Discord user ID of the person who triggered this session.
-    # When set, the user is mentioned after significant work (≥ threshold tool calls).
-    # None for bot-spawned sessions (no user to ping).
-    requester_id: int | None = None
 
     # Prevent accidental field mutation — RunConfig is a value object.
     # Use dataclasses.replace() to create modified copies.

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -789,73 +789,8 @@ class TestCcdbAttachmentsDelivery:
         mock_send.assert_not_called()
 
 
-class TestRequesterMention:
-    """User mention after significant work (>= _MENTION_TOOL_THRESHOLD tool calls)."""
-
-    async def _dispatch_tools(self, p: EventProcessor, count: int) -> None:
-        """Fire `count` tool-use events through the processor."""
-        for i in range(count):
-            await p.process(_make_tool_event(tool_id=f"tool{i}"))
-
-    @pytest.mark.asyncio
-    async def test_mention_sent_after_threshold_tool_calls(
-        self, thread: MagicMock, runner: MagicMock
-    ) -> None:
-        """requester_id set + >=3 tool uses -> mention is sent after session complete."""
-        config = _make_config(thread, runner, requester_id=123456789)
-        p = EventProcessor(config)
-
-        await self._dispatch_tools(p, 3)
-        await p.process(_make_result_event(session_id="s1"))
-
-        all_sends = [c.args[0] for c in thread.send.call_args_list if c.args]
-        mention_sends = [s for s in all_sends if "<@123456789>" in s]
-        assert len(mention_sends) == 1
-
-    @pytest.mark.asyncio
-    async def test_no_mention_below_threshold(self, thread: MagicMock, runner: MagicMock) -> None:
-        """Fewer than 3 tool uses -> no mention, even with requester_id set."""
-        config = _make_config(thread, runner, requester_id=123456789)
-        p = EventProcessor(config)
-
-        await self._dispatch_tools(p, 2)
-        await p.process(_make_result_event(session_id="s1"))
-
-        all_sends = [c.args[0] for c in thread.send.call_args_list if c.args]
-        mention_sends = [s for s in all_sends if "<@123456789>" in s]
-        assert len(mention_sends) == 0
-
-    @pytest.mark.asyncio
-    async def test_no_mention_without_requester_id(
-        self, thread: MagicMock, runner: MagicMock
-    ) -> None:
-        """requester_id is None (bot-spawned session) -> no mention even with many tools."""
-        config = _make_config(thread, runner, requester_id=None)
-        p = EventProcessor(config)
-
-        await self._dispatch_tools(p, 5)
-        await p.process(_make_result_event(session_id="s1"))
-
-        all_sends = [c.args[0] for c in thread.send.call_args_list if c.args]
-        mention_sends = [s for s in all_sends if s.startswith("<@")]
-        assert len(mention_sends) == 0
-
-    @pytest.mark.asyncio
-    async def test_no_mention_on_error_completion(
-        self, thread: MagicMock, runner: MagicMock
-    ) -> None:
-        """Error session -> no mention even if threshold was reached."""
-        config = _make_config(thread, runner, requester_id=123456789)
-        p = EventProcessor(config)
-
-        await self._dispatch_tools(p, 3)
-        await p.process(
-            StreamEvent(message_type=MessageType.RESULT, is_complete=True, error="Oops")
-        )
-
-        all_sends = [c.args[0] for c in thread.send.call_args_list if c.args]
-        mention_sends = [s for s in all_sends if "<@123456789>" in s]
-        assert len(mention_sends) == 0
+class TestToolUseCount:
+    """tool_use_count state tracking."""
 
     @pytest.mark.asyncio
     async def test_tool_use_count_increments(self, thread: MagicMock, runner: MagicMock) -> None:
@@ -864,5 +799,6 @@ class TestRequesterMention:
         p = EventProcessor(config)
 
         assert p._state.tool_use_count == 0
-        await self._dispatch_tools(p, 4)
+        for i in range(4):
+            await p.process(_make_tool_event(tool_id=f"tool{i}"))
         assert p._state.tool_use_count == 4


### PR DESCRIPTION
## Summary

- On session completion, the bot was sending two separate mentions to the requester:
  1. A bare `<@user_id>` ping from `EventProcessor` (after `result` event with sufficient tool calls)
  2. `🟡 <@user_id> Claude has finished — your reply is needed here.` from `ThreadDashboard` (on WAITING_INPUT transition)
- Remove the bare ping entirely — the ThreadDashboard message already provides notification with helpful context
- Also removes the now-unused `requester_id` field from `RunConfig` and `_MENTION_TOOL_THRESHOLD` constant

## Test plan

- [x] Deleted `TestRequesterMention` test class (tested removed behavior)
- [x] Kept `TestToolUseCount` for the `tool_use_count` state tracking logic
- [x] All 45 tests pass