### PR TITLE
fix: skip ebibot-upgrade webhook for docs-sync and auto-bump PRs

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -39,11 +39,16 @@ jobs:
           for i in $(seq 1 30); do
             STATE=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state -q .state)
             if [ "$STATE" = "MERGED" ]; then
-              echo "PR merged! Sending upgrade webhook..."
-              curl -s -o /dev/null -w "%{http_code}" \
-                -H "Content-Type: application/json" \
-                -d '{"content":"🔄 ebibot-upgrade"}' \
-                "$WEBHOOK_URL"
+              # --- EbiBot upgrade webhook (skip for docs-sync and auto-bump PRs) ---
+              if [[ "$HEAD_REF" != docs-sync/* ]] && [[ "$PR_TITLE" != '[docs-sync]'* ]] && [[ "$HEAD_REF" != auto/bump-* ]]; then
+                echo "PR merged! Sending upgrade webhook..."
+                curl -s -o /dev/null -w "%{http_code}" \
+                  -H "Content-Type: application/json" \
+                  -d '{"content":"🔄 ebibot-upgrade"}' \
+                  "$WEBHOOK_URL"
+              else
+                echo "Skipping upgrade: docs-sync or auto-bump PR ($HEAD_REF)"
+              fi
 
               # --- Docs-sync webhook (skip for docs-sync and auto-bump PRs) ---
               if [[ "$HEAD_REF" != docs-sync/* ]] && [[ "$PR_TITLE" != '[docs-sync]'* ]] && [[ "$HEAD_REF" != auto/bump-* ]]; then


### PR DESCRIPTION
## Summary

- The `ebibot-upgrade` webhook was being sent for **every** PR merge (including docs-sync and auto-bump PRs), while the `docs-sync` and `version-bump` webhooks already had proper exclusion guards
- This caused ebibot to restart unnecessarily on every docs-sync PR, resulting in repeated upgrade notifications throughout the day
- Today alone, `🔄 ebibot-upgrade` was triggered 9+ times due to docs-sync activity

## Root Cause

In `auto-approve.yml`, the three webhook actions had inconsistent conditions:
- `ebibot-upgrade` webhook: **no condition** (always sent) ← bug
- `docs-sync` webhook: skipped for `docs-sync/*`, `[docs-sync]`, `auto/bump-*` ← correct
- `version-bump` dispatch: skipped for `docs-sync/*`, `[docs-sync]` ← correct

## Fix

Added the same exclusion condition to the `ebibot-upgrade` webhook:
```bash
if [[ "$HEAD_REF" != docs-sync/* ]] && [[ "$PR_TITLE" != '[docs-sync]'* ]] && [[ "$HEAD_REF" != auto/bump-* ]]; then
```

## Test plan
- [ ] Merge a docs-sync PR → `ebibot-upgrade` should NOT be sent
- [ ] Merge a regular feature PR → `ebibot-upgrade` should still be sent