### PR TITLE
feat: thread inbox — persistent tracking of threads needing user reply

### DIFF
--- a/claude_discord/bot.py
+++ b/claude_discord/bot.py
@@ -16,6 +16,7 @@ from .discord_ui.ask_view import AskView
 
 if TYPE_CHECKING:
     from .database.ask_repo import PendingAskRepository
+    from .database.inbox_repo import ThreadInboxRepository
     from .database.lounge_repo import LoungeRepository
     from .discord_ui.thread_dashboard import ThreadStatusDashboard
     from .worktree import WorktreeManager
@@ -58,6 +59,8 @@ class ClaudeDiscordBot(commands.Bot):
         self.lounge_channel_id: int | None = lounge_channel_id
         # Worktree lifecycle manager — cleans up session worktrees after runs
         self.worktree_manager: WorktreeManager | None = worktree_manager
+        # Thread inbox repository — None until THREAD_INBOX_ENABLED=true and setup_bridge runs
+        self.inbox_repo: ThreadInboxRepository | None = None
 
     async def on_ready(self) -> None:
         logger.info("Logged in as %s (ID: %s)", self.user, self.user.id if self.user else "?")
@@ -79,6 +82,12 @@ class ClaudeDiscordBot(commands.Bot):
             )
             await self.thread_dashboard.initialize()
             logger.info("Thread status dashboard initialised in channel %d", self.channel_id)
+
+            # If inbox is enabled, restore persistent entries from DB into dashboard.
+            inbox_repo = getattr(self, "inbox_repo", None)
+            if inbox_repo is not None:
+                await self.thread_dashboard.refresh_inbox(inbox_repo)
+                logger.info("Thread inbox restored from DB")
         else:
             logger.warning(
                 "Could not resolve channel %d to a TextChannel; dashboard disabled",

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -610,6 +610,20 @@ class ClaudeChatCog(commands.Cog):
         if not prompt and not image_urls:
             return
 
+        # User replied — remove this thread from the inbox immediately so the
+        # dashboard no longer surfaces it as needing attention.
+        # Use isinstance checks so plain MagicMock bots in tests are ignored safely.
+        from ..database.inbox_repo import ThreadInboxRepository
+        from ..discord_ui.thread_dashboard import ThreadStatusDashboard
+
+        _inbox_repo = getattr(self.bot, "inbox_repo", None)
+        if isinstance(_inbox_repo, ThreadInboxRepository):
+            _removed = await _inbox_repo.remove(thread.id)
+            if _removed:
+                _dashboard = getattr(self.bot, "thread_dashboard", None)
+                if isinstance(_dashboard, ThreadStatusDashboard):
+                    await _dashboard.refresh_inbox(_inbox_repo)
+
         # Interrupt any active session in this thread before starting a new one.
         existing_runner = self._active_runners.get(thread.id)
         existing_task = self._active_tasks.get(thread.id)
@@ -705,6 +719,9 @@ class ClaudeChatCog(commands.Cog):
                         worktree_manager=getattr(self.bot, "worktree_manager", None),
                         image_urls=image_urls,
                         attach_on_request=wants_file_attachment(prompt),
+                        inbox_repo=getattr(self.bot, "inbox_repo", None),
+                        inbox_dashboard=dashboard,
+                        claude_command=runner.command,
                     )
                 )
             finally:

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -296,6 +296,8 @@ class EventProcessor:
 
     async def _on_complete(self, event: StreamEvent) -> None:
         """Handle RESULT events — finalize streaming, post summary embed."""
+        import asyncio
+
         from ..discord_ui.embeds import (
             session_complete_embed,
         )
@@ -303,9 +305,16 @@ class EventProcessor:
         from ._run_helper import _make_error_embed
 
         # Finalize any in-progress streaming message.
+        # Capture the URL before sending session_complete_embed (which would
+        # become last_message_id and hide Claude's actual reply).
+        last_assistant_url: str | None = None
+        last_assistant_text: str = self._state.accumulated_text
+
         if self._streamer.has_content:
             await self._streamer.finalize()
             self._assistant_text_sent = True
+            if self._streamer._current_message is not None:
+                last_assistant_url = self._streamer._current_message.jump_url
 
         if event.error:
             await self._config.thread.send(embed=_make_error_embed(event.error))
@@ -315,8 +324,12 @@ class EventProcessor:
             # Post final result text only if no assistant text was already sent.
             response_text = event.text
             if response_text and not self._assistant_text_sent:
+                last_sent: discord.Message | None = None
                 for chunk in chunk_message(response_text):
-                    await self._config.thread.send(chunk)
+                    last_sent = await self._config.thread.send(chunk)
+                if last_sent is not None:
+                    last_assistant_url = last_sent.jump_url
+                last_assistant_text = response_text
 
             # Send files listed in the .ccdb-attachments marker file, if present.
             await _send_attachment_requests(
@@ -337,6 +350,21 @@ class EventProcessor:
             )
             if self._config.status:
                 await self._config.status.set_done()
+
+            # Schedule inbox classification as a background task (non-blocking).
+            # Only runs when inbox_repo is wired in (THREAD_INBOX_ENABLED=true).
+            if self._config.inbox_repo is not None and last_assistant_text:
+                asyncio.create_task(
+                    _classify_and_update_inbox(
+                        thread_id=self._config.thread.id,
+                        last_text=last_assistant_text,
+                        last_message_url=last_assistant_url,
+                        inbox_repo=self._config.inbox_repo,
+                        dashboard=self._config.inbox_dashboard,
+                        claude_command=self._config.claude_command,
+                    ),
+                    name=f"inbox-classify-{self._config.thread.id}",
+                )
 
         if event.session_id:
             if self._config.repo:
@@ -474,3 +502,51 @@ class EventProcessor:
         """Move the Stop button to the bottom of the thread if configured."""
         if self._config.stop_view:
             await self._config.stop_view.bump(self._config.thread)
+
+
+# ---------------------------------------------------------------------------
+# Inbox classification helper (module-level so it can be unit-tested)
+# ---------------------------------------------------------------------------
+
+
+async def _classify_and_update_inbox(
+    thread_id: int,
+    last_text: str,
+    last_message_url: str | None,
+    inbox_repo: object,
+    dashboard: object | None,
+    claude_command: str,
+) -> None:
+    """Classify the session's final message and persist the inbox entry.
+
+    Runs as a background asyncio task so it does not block the main flow.
+    Type annotations use ``object`` to avoid a circular import; the actual
+    types are ThreadInboxRepository and ThreadStatusDashboard.
+    """
+    from ..database.inbox_repo import ThreadInboxRepository
+    from ..discord_ui.inbox_classifier import classify
+    from ..discord_ui.thread_dashboard import ThreadStatusDashboard
+
+    assert isinstance(inbox_repo, ThreadInboxRepository)
+
+    try:
+        result = await classify(last_text, claude_command=claude_command)
+        logger.debug("inbox classify thread_id=%d result=%s", thread_id, result)
+
+        if result == "done":
+            # Proactively remove from inbox — no action needed
+            await inbox_repo.remove(thread_id)
+        else:
+            confidence = "high" if result == "waiting" else "low"
+            await inbox_repo.upsert(
+                thread_id=thread_id,
+                status=result,  # type: ignore[arg-type]
+                confidence=confidence,
+                last_message_url=last_message_url,
+            )
+
+        if isinstance(dashboard, ThreadStatusDashboard):
+            await dashboard.refresh_inbox(inbox_repo)
+
+    except Exception:
+        logger.warning("inbox classify task failed for thread_id=%d", thread_id, exc_info=True)

--- a/claude_discord/cogs/run_config.py
+++ b/claude_discord/cogs/run_config.py
@@ -21,6 +21,8 @@ from ..database.repository import SessionRepository
 from ..discord_ui.status import StatusManager
 
 if TYPE_CHECKING:
+    from ..database.inbox_repo import ThreadInboxRepository
+    from ..discord_ui.thread_dashboard import ThreadStatusDashboard
     from ..discord_ui.views import StopView
     from ..worktree import WorktreeManager
 
@@ -68,6 +70,12 @@ class RunConfig:
     # When True, inject a system-prompt instruction telling Claude to write
     # requested file paths to .ccdb-attachments so the bot can send them.
     attach_on_request: bool = False
+    # Thread inbox — when set, classifies the session's final message after
+    # completion and persists the result so the dashboard can surface threads
+    # that need the user's attention across bot restarts.
+    inbox_repo: ThreadInboxRepository | None = None
+    inbox_dashboard: ThreadStatusDashboard | None = None
+    claude_command: str = "claude"
 
     # Prevent accidental field mutation — RunConfig is a value object.
     # Use dataclasses.replace() to create modified copies.

--- a/claude_discord/database/inbox_repo.py
+++ b/claude_discord/database/inbox_repo.py
@@ -1,0 +1,89 @@
+"""Thread inbox repository — persistent tracking of threads awaiting user reply."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Literal
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+InboxStatus = Literal["waiting", "ambiguous"]
+InboxConfidence = Literal["high", "low"]
+
+
+@dataclass(frozen=True)
+class InboxEntry:
+    thread_id: int
+    status: InboxStatus
+    confidence: InboxConfidence
+    last_message_url: str | None
+    updated_at: str
+
+
+class ThreadInboxRepository:
+    """CRUD for the thread_inbox table.
+
+    All methods open a short-lived connection; this matches the pattern
+    used by the other repositories in this package.
+    """
+
+    def __init__(self, db_path: str) -> None:
+        self._db_path = db_path
+
+    async def upsert(
+        self,
+        thread_id: int,
+        status: InboxStatus,
+        confidence: InboxConfidence = "high",
+        last_message_url: str | None = None,
+    ) -> None:
+        """Insert or replace an inbox entry."""
+        async with aiosqlite.connect(self._db_path) as db:
+            await db.execute(
+                """
+                INSERT INTO thread_inbox (thread_id, status, confidence, last_message_url,
+                                          updated_at)
+                VALUES (?, ?, ?, ?, datetime('now', 'localtime'))
+                ON CONFLICT(thread_id) DO UPDATE SET
+                    status = excluded.status,
+                    confidence = excluded.confidence,
+                    last_message_url = excluded.last_message_url,
+                    updated_at = excluded.updated_at
+                """,
+                (thread_id, status, confidence, last_message_url),
+            )
+            await db.commit()
+        logger.debug("inbox upsert thread_id=%d status=%s", thread_id, status)
+
+    async def remove(self, thread_id: int) -> bool:
+        """Delete an inbox entry. Returns True if a row was deleted."""
+        async with aiosqlite.connect(self._db_path) as db:
+            cursor = await db.execute("DELETE FROM thread_inbox WHERE thread_id = ?", (thread_id,))
+            await db.commit()
+            deleted = cursor.rowcount > 0
+        if deleted:
+            logger.debug("inbox remove thread_id=%d", thread_id)
+        return deleted
+
+    async def list_all(self) -> list[InboxEntry]:
+        """Return all inbox entries ordered by most-recently updated."""
+        async with aiosqlite.connect(self._db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                "SELECT thread_id, status, confidence, last_message_url, updated_at"
+                " FROM thread_inbox ORDER BY updated_at DESC"
+            )
+            rows = await cursor.fetchall()
+        return [
+            InboxEntry(
+                thread_id=row["thread_id"],
+                status=row["status"],
+                confidence=row["confidence"],
+                last_message_url=row["last_message_url"],
+                updated_at=row["updated_at"],
+            )
+            for row in rows
+        ]

--- a/claude_discord/database/models.py
+++ b/claude_discord/database/models.py
@@ -58,6 +58,18 @@ CREATE TABLE IF NOT EXISTS pending_resumes (
     resume_prompt TEXT,        -- message to post + send to Claude on resume
     created_at TEXT NOT NULL DEFAULT (datetime('now', 'localtime'))
 );
+
+-- Thread inbox: persistent status tracking across bot restarts.
+-- Populated when a Claude session ends; cleared when the user replies.
+-- status: 'waiting' (user's reply needed) | 'ambiguous' (unclear)
+-- confidence: 'high' | 'low' (from claude -p classification)
+CREATE TABLE IF NOT EXISTS thread_inbox (
+    thread_id INTEGER PRIMARY KEY,
+    status TEXT NOT NULL DEFAULT 'waiting',
+    confidence TEXT NOT NULL DEFAULT 'high',
+    last_message_url TEXT,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now', 'localtime'))
+);
 """
 
 # Migrations for existing databases that lack new columns.
@@ -83,6 +95,15 @@ _MIGRATIONS = [
         "reason TEXT NOT NULL DEFAULT 'self_restart', "
         "resume_prompt TEXT, "
         "created_at TEXT NOT NULL DEFAULT (datetime('now', 'localtime')))"
+    ),
+    # thread_inbox added in v1.9 — safe to run on existing DBs
+    (
+        "CREATE TABLE IF NOT EXISTS thread_inbox ("
+        "thread_id INTEGER PRIMARY KEY, "
+        "status TEXT NOT NULL DEFAULT 'waiting', "
+        "confidence TEXT NOT NULL DEFAULT 'high', "
+        "last_message_url TEXT, "
+        "updated_at TEXT NOT NULL DEFAULT (datetime('now', 'localtime')))"
     ),
 ]
 

--- a/claude_discord/discord_ui/inbox_classifier.py
+++ b/claude_discord/discord_ui/inbox_classifier.py
@@ -1,0 +1,85 @@
+"""Thread inbox classifier — uses `claude -p` to determine if a session is done.
+
+After a Claude Code session ends, this module runs a lightweight one-shot
+classification call to determine whether the thread requires user action.
+
+Classification result:
+  waiting   — Claude clearly expects a reply (question, request for confirmation, etc.)
+  done      — Claude considers the task complete; no reply needed
+  ambiguous — Cannot be determined from the message alone
+
+When the result is 'done', the thread is NOT added to the inbox.
+When 'waiting' or 'ambiguous', it is persisted so the dashboard can surface it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+ClassifyResult = Literal["waiting", "done", "ambiguous"]
+
+_PROMPT_TEMPLATE = """\
+以下はAIアシスタントが送った最後のメッセージです。
+このメッセージを送った後、AIはユーザーからの返信を期待していますか？
+
+【メッセージ】
+{text}
+
+次の3択から1単語だけで答えてください（他の文字は一切不要）:
+- waiting  : ユーザーの返信・確認・操作が必要
+- done     : タスクが完了しており返信は不要
+- ambiguous: どちらとも判断できない
+"""
+
+_VALID = frozenset({"waiting", "done", "ambiguous"})
+_TIMEOUT_SECONDS = 30
+
+
+async def classify(
+    last_text: str,
+    claude_command: str = "claude",
+) -> ClassifyResult:
+    """Call `claude -p` and parse waiting/done/ambiguous.
+
+    Falls back to 'waiting' on any error so threads are never silently lost.
+    Prompt is passed as a direct argument to the binary (no shell, no injection risk).
+    """
+    if not last_text.strip():
+        return "ambiguous"
+
+    prompt = _PROMPT_TEMPLATE.format(text=last_text[:2000])
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            claude_command,
+            "-p",
+            prompt,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=_TIMEOUT_SECONDS)
+        except TimeoutError:
+            proc.kill()
+            await proc.communicate()
+            logger.warning("inbox classifier timed out after %ds", _TIMEOUT_SECONDS)
+            return "waiting"
+
+        raw = stdout.decode(errors="replace").strip().lower()
+        # Accept the first word in case the model adds punctuation or whitespace
+        word = raw.split()[0] if raw.split() else ""
+        if word in _VALID:
+            result: ClassifyResult = word  # type: ignore[assignment]
+            logger.debug("inbox classify result=%s raw=%r", result, raw)
+            return result
+
+        logger.debug("inbox classify unexpected output=%r, defaulting to ambiguous", raw)
+        return "ambiguous"
+
+    except Exception:
+        logger.warning("inbox classify failed, defaulting to waiting", exc_info=True)
+        return "waiting"

--- a/claude_discord/discord_ui/thread_dashboard.py
+++ b/claude_discord/discord_ui/thread_dashboard.py
@@ -5,6 +5,10 @@ threads are processing automatically vs. waiting for user input.
 When a thread transitions to WAITING_INPUT, the bot mentions the owner
 so Discord's notification system surfaces the request immediately.
 
+When THREAD_INBOX_ENABLED is set, the dashboard also shows a persistent
+inbox section (📬) that survives bot restarts and surfaces threads where
+the user owes a reply.
+
 Issue: https://github.com/ebibibi/claude-code-discord-bridge/issues/67
 """
 
@@ -15,8 +19,12 @@ import logging
 import time
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import TYPE_CHECKING
 
 import discord
+
+if TYPE_CHECKING:
+    from ..database.inbox_repo import InboxEntry, ThreadInboxRepository
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +92,8 @@ class ThreadStatusDashboard:
         self._threads: dict[int, _ThreadInfo] = {}
         self._dashboard_message: discord.Message | None = None
         self._lock = asyncio.Lock()
+        # Persistent inbox entries (populated from DB when inbox is enabled).
+        self._inbox: list[InboxEntry] = []
 
     # ------------------------------------------------------------------
     # Public API
@@ -167,6 +177,16 @@ class ThreadStatusDashboard:
             self._threads.pop(thread_id, None)
             await self._refresh_dashboard()
 
+    async def refresh_inbox(self, inbox_repo: ThreadInboxRepository) -> None:
+        """Reload inbox entries from DB and refresh the dashboard embed.
+
+        Called after every inbox upsert/remove so the embed stays current.
+        """
+        entries = await inbox_repo.list_all()
+        async with self._lock:
+            self._inbox = entries
+            await self._refresh_dashboard()
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
@@ -204,18 +224,23 @@ class ThreadStatusDashboard:
 
     def _build_embed(self) -> discord.Embed:
         """Construct the Discord embed reflecting current thread states."""
-        if not self._threads:
+        has_live = bool(self._threads)
+        has_inbox = bool(self._inbox)
+        any_inbox_waiting = any(e.status == "waiting" for e in self._inbox)
+
+        if not has_live and not has_inbox:
             return discord.Embed(
                 title="📊 Session Status",
                 description="No active sessions.",
                 color=_COLOR_IDLE,
             )
 
-        any_waiting = any(t.state == ThreadState.WAITING_INPUT for t in self._threads.values())
-        color = _COLOR_WAITING if any_waiting else _COLOR_PROCESSING
+        any_live_waiting = any(t.state == ThreadState.WAITING_INPUT for t in self._threads.values())
+        color = _COLOR_WAITING if (any_live_waiting or any_inbox_waiting) else _COLOR_PROCESSING
 
         embed = discord.Embed(title="📊 Session Status", color=color)
 
+        # ── Live sessions ──────────────────────────────────────────────
         now = time.monotonic()
         for info in sorted(self._threads.values(), key=lambda t: t.started_at):
             icon = _STATE_ICON[info.state.value]
@@ -231,5 +256,18 @@ class ThreadStatusDashboard:
                 inline=False,
             )
 
-        embed.set_footer(text="Updates automatically · stale entries removed after 4h")
+        # ── Persistent inbox ───────────────────────────────────────────
+        if has_inbox:
+            embed.add_field(name="📬 Inbox", value="\u200b", inline=False)
+            for entry in self._inbox:
+                icon = "🟡" if entry.status == "waiting" else "❓"
+                conf = "" if entry.confidence == "high" else " _(uncertain)_"
+                link = f" — [→ jump]({entry.last_message_url})" if entry.last_message_url else ""
+                embed.add_field(
+                    name=f"{icon} <#{entry.thread_id}>{conf}",
+                    value=f"{entry.updated_at}{link}",
+                    inline=False,
+                )
+
+        embed.set_footer(text="Updates automatically · stale live entries removed after 4h")
         return embed

--- a/claude_discord/main.py
+++ b/claude_discord/main.py
@@ -57,6 +57,7 @@ def load_config() -> dict[str, str]:
         "api_port": os.getenv("API_PORT", ""),
         "allowed_tools": os.getenv("CLAUDE_ALLOWED_TOOLS", ""),
         "custom_cogs_dir": os.getenv("CUSTOM_COGS_DIR", ""),
+        "thread_inbox_enabled": os.getenv("THREAD_INBOX_ENABLED", "false"),
     }
 
 
@@ -127,6 +128,7 @@ async def main() -> None:
             allowed_user_ids=allowed_user_ids,
             claude_channel_id=channel_id,
             claude_channel_ids=claude_channel_ids,
+            enable_thread_inbox=config["thread_inbox_enabled"].lower() == "true",
         )
 
         # Load custom Cogs from external directory

--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -78,6 +78,7 @@ async def setup_bridge(
     task_db_path: str = "data/tasks.db",
     lounge_channel_id: int | None = None,
     worktree_base_dir: str | None = None,
+    enable_thread_inbox: bool = False,
 ) -> BridgeComponents:
     """Initialize and register all ccdb Cogs in one call.
 
@@ -129,6 +130,7 @@ async def setup_bridge(
     from .cogs.session_manage import SessionManageCog
     from .cogs.skill_command import SkillCommandCog
     from .database.ask_repo import PendingAskRepository
+    from .database.inbox_repo import ThreadInboxRepository
     from .database.lounge_repo import LoungeRepository
     from .database.models import init_db
     from .database.repository import SessionRepository
@@ -185,6 +187,12 @@ async def setup_bridge(
     # without a hard import dependency on ccdb internals.
     bot.session_repo = session_repo  # type: ignore[attr-defined]
     bot.resume_repo = resume_repo  # type: ignore[attr-defined]
+
+    # --- Thread inbox (optional — THREAD_INBOX_ENABLED=true) ---
+    if enable_thread_inbox:
+        inbox_repo = ThreadInboxRepository(session_db_path)
+        bot.inbox_repo = inbox_repo  # type: ignore[attr-defined]
+        logger.info("Thread inbox enabled")
 
     # --- ClaudeChatCog ---
     chat_cog = ClaudeChatCog(

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -1,0 +1,211 @@
+"""Tests for the Thread Inbox feature.
+
+Covers: ThreadInboxRepository, inbox_classifier, ThreadStatusDashboard inbox section.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from claude_discord.database.inbox_repo import ThreadInboxRepository
+from claude_discord.discord_ui.thread_dashboard import ThreadStatusDashboard
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    """Temporary SQLite DB with the thread_inbox table."""
+    import sqlite3
+
+    from claude_discord.database.models import SCHEMA
+
+    path = str(tmp_path / "test.db")
+    conn = sqlite3.connect(path)
+    conn.executescript(SCHEMA)
+    conn.commit()
+    conn.close()
+    return path
+
+
+@pytest.fixture
+def repo(db_path):
+    return ThreadInboxRepository(db_path)
+
+
+def _make_channel():
+    channel = MagicMock(spec=discord.TextChannel)
+    msg = MagicMock(spec=discord.Message)
+    msg.pin = AsyncMock()
+    msg.edit = AsyncMock()
+    channel.send = AsyncMock(return_value=msg)
+    return channel
+
+
+# ---------------------------------------------------------------------------
+# ThreadInboxRepository tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_and_list(repo):
+    await repo.upsert(111, "waiting", "high", "https://discord.com/channels/1/2/3")
+    entries = await repo.list_all()
+    assert len(entries) == 1
+    assert entries[0].thread_id == 111
+    assert entries[0].status == "waiting"
+    assert entries[0].confidence == "high"
+    assert entries[0].last_message_url == "https://discord.com/channels/1/2/3"
+
+
+@pytest.mark.asyncio
+async def test_upsert_updates_existing(repo):
+    await repo.upsert(111, "waiting", "high", "https://example.com/1")
+    await repo.upsert(111, "ambiguous", "low", "https://example.com/2")
+    entries = await repo.list_all()
+    assert len(entries) == 1
+    assert entries[0].status == "ambiguous"
+    assert entries[0].last_message_url == "https://example.com/2"
+
+
+@pytest.mark.asyncio
+async def test_remove_existing(repo):
+    await repo.upsert(111, "waiting")
+    removed = await repo.remove(111)
+    assert removed is True
+    assert await repo.list_all() == []
+
+
+@pytest.mark.asyncio
+async def test_remove_nonexistent(repo):
+    removed = await repo.remove(999)
+    assert removed is False
+
+
+@pytest.mark.asyncio
+async def test_list_all_empty(repo):
+    assert await repo.list_all() == []
+
+
+@pytest.mark.asyncio
+async def test_multiple_entries(repo):
+    await repo.upsert(111, "waiting", "high")
+    await repo.upsert(222, "ambiguous", "low")
+    entries = await repo.list_all()
+    assert len(entries) == 2
+    thread_ids = {e.thread_id for e in entries}
+    assert thread_ids == {111, 222}
+
+
+# ---------------------------------------------------------------------------
+# inbox_classifier tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_classify_waiting():
+    from claude_discord.discord_ui.inbox_classifier import classify
+
+    with patch("asyncio.create_subprocess_exec") as mock_exec:
+        proc = AsyncMock()
+        proc.communicate = AsyncMock(return_value=(b"waiting\n", b""))
+        mock_exec.return_value = proc
+        result = await classify("何かご不明な点はありますか？")
+    assert result == "waiting"
+
+
+@pytest.mark.asyncio
+async def test_classify_done():
+    from claude_discord.discord_ui.inbox_classifier import classify
+
+    with patch("asyncio.create_subprocess_exec") as mock_exec:
+        proc = AsyncMock()
+        proc.communicate = AsyncMock(return_value=(b"done\n", b""))
+        mock_exec.return_value = proc
+        result = await classify("実装が完了しました。")
+    assert result == "done"
+
+
+@pytest.mark.asyncio
+async def test_classify_ambiguous_on_unexpected_output():
+    from claude_discord.discord_ui.inbox_classifier import classify
+
+    with patch("asyncio.create_subprocess_exec") as mock_exec:
+        proc = AsyncMock()
+        proc.communicate = AsyncMock(return_value=(b"I'm not sure\n", b""))
+        mock_exec.return_value = proc
+        result = await classify("...some text...")
+    assert result == "ambiguous"
+
+
+@pytest.mark.asyncio
+async def test_classify_waiting_on_error():
+    from claude_discord.discord_ui.inbox_classifier import classify
+
+    with patch("asyncio.create_subprocess_exec", side_effect=OSError("not found")):
+        result = await classify("some text")
+    assert result == "waiting"
+
+
+@pytest.mark.asyncio
+async def test_classify_ambiguous_on_empty_text():
+    from claude_discord.discord_ui.inbox_classifier import classify
+
+    result = await classify("   ")
+    assert result == "ambiguous"
+
+
+# ---------------------------------------------------------------------------
+# ThreadStatusDashboard inbox section tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dashboard_shows_inbox_section(repo):
+    await repo.upsert(555, "waiting", "high", "https://discord.com/channels/1/555/999")
+
+    channel = _make_channel()
+    dashboard = ThreadStatusDashboard(channel=channel)
+    await dashboard.initialize()
+    await dashboard.refresh_inbox(repo)
+
+    embed_call = channel.send.return_value.edit.call_args
+    embed = channel.send.call_args[1]["embed"] if embed_call is None else embed_call[1]["embed"]
+
+    field_names = [f.name for f in embed.fields]
+    assert any("📬" in name for name in field_names), f"Inbox section missing: {field_names}"
+
+
+@pytest.mark.asyncio
+async def test_dashboard_inbox_cleared_after_remove(repo):
+    await repo.upsert(555, "waiting")
+
+    channel = _make_channel()
+    dashboard = ThreadStatusDashboard(channel=channel)
+    await dashboard.initialize()
+    await dashboard.refresh_inbox(repo)
+
+    # Now remove it
+    await repo.remove(555)
+    await dashboard.refresh_inbox(repo)
+
+    embed = channel.send.return_value.edit.call_args[1]["embed"]
+    field_names = [f.name for f in embed.fields]
+    assert not any("555" in name for name in field_names)
+
+
+@pytest.mark.asyncio
+async def test_refresh_inbox_without_entries_shows_no_inbox_section(repo):
+    channel = _make_channel()
+    dashboard = ThreadStatusDashboard(channel=channel)
+    await dashboard.initialize()
+    await dashboard.refresh_inbox(repo)
+
+    embed = channel.send.return_value.edit.call_args[1]["embed"]
+    field_names = [f.name for f in embed.fields]
+    assert not any("📬" in name for name in field_names)

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "1.8.5"
+version = "1.8.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- **Persistent inbox**: threads where Claude is waiting for a reply are tracked in SQLite (`thread_inbox` table) and survive bot restarts
- **Auto-classification via `claude -p`**: after each session ends, the final assistant message is classified as `waiting` / `done` / `ambiguous` in a background asyncio task — no extra API cost (flat-rate subscription)
- **Dashboard integration**: "📬 Inbox" section appears in the existing status embed with jump-links to the last message in each thread
- **Auto-clear on reply**: when the user replies to an inbox thread, the entry is removed immediately before the new session starts
- **OFF by default**: controlled by `THREAD_INBOX_ENABLED=true/false` (default: `false`). Zero code paths exercised when disabled

## Problem solved

Previously, threads where Claude finished and the user hadn't replied yet would disappear from the dashboard after 4 hours (or on bot restart). There was no way to distinguish "I still need to reply here" from "this thread is done but I'm keeping it open."

## How it works

```
Session ends
  └→ EventProcessor._on_complete
       └→ captures last assistant message jump_url (before session_complete embed)
       └→ asyncio.create_task(_classify_and_update_inbox)
            └→ claude -p "waiting/done/ambiguous?"  [background, non-blocking]
                 └→ inbox_repo.upsert() or remove()
                 └→ dashboard.refresh_inbox()  → embed updated

User replies
  └→ _handle_thread_reply
       └→ inbox_repo.remove(thread.id)  [immediate, before new session]
       └→ dashboard.refresh_inbox()
```

## Test plan

- [x] 14 new tests in `tests/test_inbox.py` (repo CRUD, classifier parsing, dashboard embed)
- [x] 906 total tests pass, 0 failures
- [ ] Enable `THREAD_INBOX_ENABLED=true` in ebibot and run for a few sessions
- [ ] Verify inbox entries appear/disappear correctly in the dashboard embed
- [ ] Verify bot restart restores inbox from DB

## Environment variable

```env
THREAD_INBOX_ENABLED=true   # default: false
```