### PR TITLE
fix: prevent log injection in api_server.py

### DIFF
--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 from collections.abc import Awaitable, Callable
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -33,6 +34,15 @@ if TYPE_CHECKING:
     from ..database.task_repo import TaskRepository
 
 logger = logging.getLogger(__name__)
+
+
+def _sanitize_log(value: object) -> str:
+    """Sanitize user-provided values before writing to logs.
+
+    Strips newline and carriage-return characters to prevent log injection
+    attacks where an attacker embeds fake log entries in a single field.
+    """
+    return re.sub(r"[\r\n]", " ", str(value))
 
 
 class ApiServer:
@@ -283,7 +293,7 @@ class ApiServer:
             logger.warning("Failed to create task: %s", exc)
             return web.json_response({"error": "Task name already exists"}, status=409)
 
-        logger.info("Task registered via API: id=%d, name=%s", task_id, data["name"])
+        logger.info("Task registered via API: id=%d, name=%s", task_id, _sanitize_log(data["name"]))
         return web.json_response({"status": "created", "id": task_id}, status=201)
 
     async def list_tasks(self, request: web.Request) -> web.Response:
@@ -587,8 +597,8 @@ class ApiServer:
         logger.info(
             "Thread %d marked for resume (reason=%s, session_id=%s)",
             thread_id,
-            reason,
-            session_id,
+            _sanitize_log(reason),
+            _sanitize_log(session_id),
         )
         return web.json_response({"status": "marked", "id": row_id}, status=201)
 


### PR DESCRIPTION
## Summary

- Add `_sanitize_log()` helper that strips `\r` and `\n` from user-provided values before writing to logs
- Apply sanitization to 3 affected logger call sites in `api_server.py`
- Fixes CodeQL code scanning alerts #1, #2, #3 (py/log-injection)

## Root cause

User-provided values (`task name`, `reason`, `session_id`) were passed directly to `logger` calls. An attacker could embed newline characters to inject fake log entries, making malicious activity appear to originate from the system itself.

## Test plan

- [ ] Confirm the three CodeQL alerts are resolved after merge
- [ ] Manually test: send a request with `\n[CRITICAL] fake` in a log-injectable field and verify it appears on one line with the newline replaced by a space