### PR TITLE
feat: translate all user-facing and Claude-facing strings to English

### DIFF
--- a/claude_discord/cogs/auto_upgrade.py
+++ b/claude_discord/cogs/auto_upgrade.py
@@ -388,8 +388,12 @@ class AutoUpgradeCog(commands.Cog):
                     session_id=session_id,
                     reason="bot_upgrade",
                     resume_prompt=(
-                        "ボットがパッケージアップグレードのため再起動しました。"
-                        "前の作業の続きを確認し、必要な残作業があれば完了してください。"
+                        "The bot restarted after a package upgrade. "
+                        "Please report what you were working on before resuming. "
+                        "⚠️ Context may have been compressed, which means the approval status of "
+                        "planned tasks could be lost. "
+                        "Before making any code changes, commits, or PRs, "
+                        "re-confirm with the user that they want you to proceed."
                     ),
                 )
                 marked += 1

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -500,12 +500,12 @@ class ClaudeChatCog(commands.Cog):
                     session_id=session_id,
                     reason="bot_shutdown",
                     resume_prompt=(
-                        "ボットが再起動しました。"
-                        "前の作業の状況を確認して、何をしていたかを報告してください。"
-                        "⚠️ コンテキストの圧縮により、計画済みタスクの承認状態が"
-                        "失われている可能性があります。"
-                        "コード変更・コミット・PR作成などの実装作業を再開する前に、"
-                        "必ずユーザーに改めて確認を取ってください。"
+                        "The bot restarted. "
+                        "Please report what you were working on before resuming. "
+                        "⚠️ Context may have been compressed, which means the approval status of "
+                        "planned tasks could be lost. "
+                        "Before making any code changes, commits, or PRs, "
+                        "re-confirm with the user that they want you to proceed."
                     ),
                 )
                 logger.info(
@@ -569,12 +569,12 @@ class ClaudeChatCog(commands.Cog):
                 continue
 
             resume_prompt = entry.resume_prompt or (
-                "ボットが再起動から復帰しました。"
-                "前の作業の状況を確認して、何をしていたかを報告してください。"
-                "⚠️ コンテキストの圧縮により、計画済みタスクの承認状態が"
-                "失われている可能性があります。"
-                "コード変更・コミット・PR作成などの実装作業を再開する前に、"
-                "必ずユーザーに改めて確認を取ってください。"
+                "The bot restarted. "
+                "Please report what you were working on before resuming. "
+                "⚠️ Context may have been compressed, which means the approval status of "
+                "planned tasks could be lost. "
+                "Before making any code changes, commits, or PRs, "
+                "re-confirm with the user that they want you to proceed."
             )
 
             logger.info(
@@ -585,9 +585,7 @@ class ClaudeChatCog(commands.Cog):
             )
             try:
                 # Post directly into the existing thread — no new thread needed
-                seed_message = await thread.send(
-                    f"🔄 **Bot が再起動から復帰しました。**\n{resume_prompt}"
-                )
+                seed_message = await thread.send(f"🔄 **Bot restarted.**\n{resume_prompt}")
                 asyncio.create_task(
                     self._run_claude(
                         seed_message,

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -71,7 +71,7 @@ async def _send_attachment_requests(
 # Sized to show ~30 lines of typical output (100 chars/line × 30 = 3000).
 # The embed description limit is 4096, so this leaves room for code block markers.
 _TOOL_RESULT_MAX_CHARS = 3000
-# Lines of output shown inline before the "展開 ▼" button appears.
+# Lines of output shown inline before the "Expand ▼" button appears.
 # 1 means single-line results are shown flat; 2+ lines get a collapse button.
 _COLLAPSED_LINES = 1
 

--- a/claude_discord/discord_ui/inbox_classifier.py
+++ b/claude_discord/discord_ui/inbox_classifier.py
@@ -23,16 +23,16 @@ logger = logging.getLogger(__name__)
 ClassifyResult = Literal["waiting", "done", "ambiguous"]
 
 _PROMPT_TEMPLATE = """\
-以下はAIアシスタントが送った最後のメッセージです。
-このメッセージを送った後、AIはユーザーからの返信を期待していますか？
+Below is the last message sent by an AI assistant.
+After sending this message, does the AI expect a reply from the user?
 
-【メッセージ】
+[MESSAGE]
 {text}
 
-次の3択から1単語だけで答えてください（他の文字は一切不要）:
-- waiting  : ユーザーの返信・確認・操作が必要
-- done     : タスクが完了しており返信は不要
-- ambiguous: どちらとも判断できない
+Reply with exactly one word — no other text:
+- waiting  : user reply, confirmation, or action is required
+- done     : the task is complete and no reply is needed
+- ambiguous: cannot be determined from the message alone
 """
 
 _VALID = frozenset({"waiting", "done", "ambiguous"})

--- a/claude_discord/discord_ui/views.py
+++ b/claude_discord/discord_ui/views.py
@@ -123,15 +123,15 @@ class ToolResultView(discord.ui.View):
         self._full_content = full_content
         self._expanded = False
 
-    @discord.ui.button(label="展開 ▼", style=discord.ButtonStyle.secondary)
+    @discord.ui.button(label="Expand ▼", style=discord.ButtonStyle.secondary)
     async def toggle(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
         """Toggle between collapsed (preview) and expanded (full) output."""
         self._expanded = not self._expanded
         if self._expanded:
-            button.label = "折りたたむ ▲"
+            button.label = "Collapse ▲"
             embed = tool_result_embed(self._tool_title, self._full_content)
         else:
-            button.label = "展開 ▼"
+            button.label = "Expand ▼"
             embed = tool_result_preview_embed(self._tool_title, self._full_content)
         await interaction.response.edit_message(embed=embed, view=self)
 

--- a/claude_discord/lounge.py
+++ b/claude_discord/lounge.py
@@ -13,43 +13,43 @@ from .database.lounge_repo import LoungeMessage
 # The invitation block tells Claude *what* the lounge is, *how* to post,
 # and sets the expectation that posting at session start is mandatory.
 _LOUNGE_INVITE = """\
-[AI LOUNGE — 控え室へようこそ]
+[AI LOUNGE — welcome to the breakroom]
 
-ここは「AI Lounge（控え室）」。複数のClaudeセッションが同時に作業するとき、
-お互いに状況を伝え合えるDiscordチャンネルです。人間も見ています。
+This is the AI Lounge — a shared space where concurrent Claude sessions
+leave notes for each other and for the humans watching the Discord channel.
 
-【必須】作業を始める前に、まずラウンジに一言投稿してください。
-これが「セッション開始通知」の代わりです。何をするかを自分の言葉で、短く。
+[REQUIRED] Before starting any work, post a one-liner to the lounge.
+This is your session-start announcement. Keep it short and in your own words.
 
-例:
-- 「今からXXXリポジトリのバグ調査するよ。ちょっと複雑そう」
-- 「PRレビュー依頼来てたのでチェックしてきます」
-- 「テストが全部落ちてる… 何が起きたんだろ」
-- 「設定ファイル直すだけなのでサクッと終わらせます」
+Examples:
+- "Investigating a bug in the XXX repo. Looks a bit tricky."
+- "PR review request came in, heading over to check it."
+- "All tests are failing... figuring out what happened."
+- "Just fixing a config file, should be quick."
 
-作業が終わったら感想も一言どうぞ（終了通知にもなる）:
-- 「できた！テストも全部通った」「思ったより時間かかった…」
+When you finish, leave a closing note too (this serves as your session-end signal):
+- "Done! All tests passing." / "Took longer than expected..."
 
-投稿コマンド:
+Post command:
 ```bash
 curl -s -X POST "$CCDB_API_URL/api/lounge" \\
   -H "Content-Type: application/json" \\
-  -d '{"message": "ここに一言", "label": "自分のニックネーム"}'
+  -d '{"message": "your note here", "label": "your nickname"}'
 ```
 
-ラベルは自由。例：「バグハンター」「夜の助っ人」「フロント担当」「慎重派」
+Labels are free-form. Examples: "bug-hunter", "night-shift", "frontend", "careful"
 
-【破壊的操作の前に必ずラウンジを読め】
-Botの再起動・force push・DB操作など「全セッションに影響する操作」をする前に:
-1. 下記の「最近のラウンジのメッセージ」を確認する
-2. 他のセッションが作業中であれば、完了を待つか、ラウンジに予告してから実行する
-3. 問題ない場合のみ実行し、実行前後にラウンジへ報告する
+[READ BEFORE DESTRUCTIVE OPERATIONS]
+Before bot restarts, force pushes, DB operations, or anything that affects all sessions:
+1. Check the recent lounge messages below
+2. If another session is actively working, wait for it to finish or announce your intent
+3. Only proceed if the coast is clear — report before and after
 
-これがAI Loungeの最重要用途。書くだけでなく、読んで判断することが目的。
+This is the lounge's most critical use. Read it to make decisions, not just to write.
 """
 
-_RECENT_HEADER = "\n最近のラウンジのメッセージ:\n"
-_NO_MESSAGES = "\n（まだ誰もいない。あなたが最初の一言を残してみて！）\n"
+_RECENT_HEADER = "\nRecent lounge messages:\n"
+_NO_MESSAGES = "\n(No messages yet — be the first to say hello!)\n"
 _INVITE_CLOSE = "\n---\n"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "1.8.10"
+version = "1.8.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- **lounge.py**: Full AI Lounge invitation block translated to English (`_LOUNGE_INVITE`, `_RECENT_HEADER`, `_NO_MESSAGES`)
- **claude_chat.py**: `cog_unload()` and `on_ready()` resume prompts translated; Discord restart announcement header translated
- **auto_upgrade.py**: Post-upgrade resume prompt translated (also fixes the dangerous _"complete remaining tasks"_ wording that was missed in PR #252)
- **inbox_classifier.py**: `_PROMPT_TEMPLATE` classification prompt translated
- **views.py**: Button labels `"展開 ▼"` → `"Expand ▼"`, `"折りたたむ ▲"` → `"Collapse ▲"`
- **event_processor.py**: Comment updated to reference new `"Expand ▼"` label

## Motivation

ccdb is an OSS framework for a global audience. All strings that are visible to Claude (resume prompts, lounge context, classification prompts) or to Discord users (button labels, status messages) should be in English by default.

This also fixes a second instance of the dangerous `auto_upgrade.py` resume prompt that told Claude to _"complete remaining tasks"_ — the same issue fixed in #252 for `claude_chat.py`.

## Test plan

- [x] `uv run ruff check claude_discord/` — all clean
- [x] `uv run ruff format --check claude_discord/` — all clean
- [x] `uv run pytest tests/ -v` — 909 tests passed
- [ ] Manual: start a session, bot restart, confirm English resume prompt appears in Discord thread
- [ ] Manual: click Expand/Collapse button on a large tool result, confirm English labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)