### PR TITLE
[docs-sync] Document THREAD_AUTO_RENAME feature (English + Japanese)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,7 @@ claude_discord/          # Installable Python package
     permission_view.py   # Allow/Deny buttons for tool permission requests
     elicitation_view.py  # Discord UI for MCP elicitation
     file_sender.py       # File delivery via .ccdb-attachments
+    thread_renamer.py    # suggest_title() — background claude -p call for auto thread renaming
   ext/
     api_server.py        # REST API server (optional, requires aiohttp)
   utils/

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ If the bot restarts mid-session, interrupted Claude sessions are automatically r
 - **Concurrent sessions** — Multiple parallel sessions with configurable limit
 - **Stop without clearing** — `/stop` halts a session while preserving it for resume
 - **Session interrupt** — Sending a new message to an active thread sends SIGINT to the running session and starts fresh with the new instruction; no manual `/stop` needed
+- **Auto-rename threads** — When `THREAD_AUTO_RENAME=true`, each new thread is automatically renamed with a Claude-generated title derived from the first message (background task, never delays session start)
 
 #### 📡 Real-time Feedback
 - **Real-time status** — Emoji reactions: 🧠 thinking, 🛠️ reading files, 💻 editing, 🌐 web search
@@ -485,6 +486,7 @@ In inline-reply mode, Claude's response is sent directly as a message in the cha
 | `CLAUDE_ALLOWED_TOOLS` | Comma-separated list of allowed tools for Claude CLI | (optional) |
 | `CLAUDE_CHANNEL_IDS` | Additional channel IDs (comma-separated) for multi-channel setup | (optional) |
 | `THREAD_INBOX_ENABLED` | Enable the persistent thread inbox (classifies sessions as `waiting`/`done`/`ambiguous` via `claude -p`; shown in thread dashboard) | `false` |
+| `THREAD_AUTO_RENAME` | Auto-rename new thread titles using Claude AI — generates a short, descriptive title from the first user message via a background `claude -p` call (never delays session start) | `false` |
 | `API_HOST` | REST API bind address | `127.0.0.1` |
 | `API_PORT` | REST API port (enables REST API when set) | (optional) |
 
@@ -786,6 +788,7 @@ claude_discord/
     elicitation_view.py    # Discord UI for MCP elicitation (Modal form or URL button)
     file_sender.py         # File delivery via .ccdb-attachments
     inbox_classifier.py    # classify() — lightweight claude -p call to label sessions
+    thread_renamer.py      # suggest_title() — background claude -p call for auto thread naming
   ext/
     api_server.py          # REST API (optional, requires aiohttp)
   utils/

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -139,6 +139,7 @@ Bot の再起動中にセッションが中断された場合、Bot が再起動
 - **並行セッション** — 設定可能な上限での複数並行セッション
 - **削除せず停止** — `/stop` でセッションを保持したまま停止し、リジューム可能
 - **セッション割り込み** — アクティブなスレッドに新しいメッセージを送ると実行中のセッションに SIGINT を送り、新しい指示で即座に再開。手動での `/stop` 不要
+- **スレッド自動リネーム** — `THREAD_AUTO_RENAME=true` のとき、最初のメッセージをもとに Claude が生成した短いタイトルでスレッドを自動リネーム（バックグラウンドタスクのためセッション開始を遅延させない）
 
 #### 📡 リアルタイムフィードバック
 - **リアルタイムステータス** — 絵文字リアクション: 🧠 思考中、🛠️ ファイル読み取り、💻 編集中、🌐 Web 検索
@@ -384,6 +385,7 @@ INLINE_REPLY_CHANNEL_IDS=333,444
 | `INLINE_REPLY_CHANNEL_IDS` | インライン返信チャンネル ID（カンマ区切り、スレッドを作成しない） | （オプション） |
 | `WORKTREE_BASE_DIR` | セッション Worktree のスキャン対象ディレクトリ（自動クリーンアップを有効化） | （オプション） |
 | `THREAD_INBOX_ENABLED` | 永続スレッドインボックスを有効化（`claude -p` でセッションを `waiting`/`done`/`ambiguous` に分類し、スレッドダッシュボードに表示） | `false` |
+| `THREAD_AUTO_RENAME` | 新しいスレッドのタイトルを Claude AI で自動リネーム — 最初のユーザーメッセージをもとにバックグラウンドの `claude -p` 呼び出しで短く分かりやすいタイトルを生成（セッション開始を遅延させない） | `false` |
 
 ### パーミッションモード — `-p` モードで動作するもの
 
@@ -683,6 +685,7 @@ claude_discord/
     elicitation_view.py    # MCP Elicitation 用 Discord UI（Modal フォームまたは URL ボタン）
     file_sender.py         # .ccdb-attachments 経由のファイル配信
     inbox_classifier.py    # classify() — セッションにラベルを付ける軽量 claude -p 呼び出し
+    thread_renamer.py      # suggest_title() — スレッド自動リネーム用バックグラウンド claude -p 呼び出し
   ext/
     api_server.py          # REST API サーバー（オプション、aiohttp が必要）
   utils/


### PR DESCRIPTION
## Summary

- Added `THREAD_AUTO_RENAME` environment variable to the configuration table in `README.md` and `docs/ja/README.md`
- Added auto-rename feature description to the Session Basics feature list (English + Japanese)
- Added `thread_renamer.py` to the architecture/file structure section in `README.md`, `docs/ja/README.md`, and `CLAUDE.md`

## 変更内容

- `README.md` / `docs/ja/README.md` の設定テーブルに `THREAD_AUTO_RENAME` 環境変数を追記
- セッション基本機能一覧にスレッド自動リネーム機能の説明を追記（英語・日本語）
- `README.md` / `docs/ja/README.md` / `CLAUDE.md` のアーキテクチャ/ファイル構成セクションに `thread_renamer.py` を追記

## Test plan

- [ ] Verify `THREAD_AUTO_RENAME` appears in the configuration table
- [ ] Verify the feature description is accurate and matches the implementation in `thread_renamer.py`
- [ ] Verify `thread_renamer.py` is listed in the architecture section
- [ ] Verify Japanese translation is natural and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
