### PR TITLE
fix: handle string content blocks in user message parser

### DIFF
--- a/claude_discord/claude/parser.py
+++ b/claude_discord/claude/parser.py
@@ -160,6 +160,8 @@ def _parse_user(data: dict[str, Any], event: StreamEvent) -> None:
     content = message.get("content", [])
 
     for block in content:
+        if not isinstance(block, dict):
+            continue
         if block.get("type") == ContentBlockType.TOOL_RESULT.value:
             event.tool_result_id = block.get("tool_use_id", "")
             # Extract tool result content


### PR DESCRIPTION
## Summary

- Fix AttributeError in _parse_user() when the CLI emits plain strings in user message content blocks
- Adds a type guard to skip non-dict entries before calling .get()

## Test plan

- [x] All 47 parser tests pass
- [x] ruff check and format clean