### PR TITLE
fix: resolve relative paths in .ccdb-attachments against working_dir

### DIFF
--- a/claude_discord/cogs/_run_helper.py
+++ b/claude_discord/cogs/_run_helper.py
@@ -93,9 +93,10 @@ async def _build_system_context(config: RunConfig) -> str | None:
         parts.append(
             "## File Delivery\n"
             "The user wants you to send specific files to Discord.\n"
-            "When you are ready to deliver a file, write its absolute path "
-            "(one path per line, UTF-8) to the file:\n"
+            "After creating the file(s) to deliver, use your Bash tool to append "
+            "each file's ABSOLUTE path (one path per line, UTF-8) to:\n"
             f"  {wd}/.ccdb-attachments\n"
+            f"Example: `echo /absolute/path/to/file >> {wd}/.ccdb-attachments`\n"
             "The bot will attach those files to Discord when this session ends.\n"
             "Only include files the user explicitly asked to receive — "
             "not everything you create."

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -64,7 +64,12 @@ async def _send_attachment_requests(
         paths = [p.strip() for p in marker.read_text(encoding="utf-8").splitlines() if p.strip()]
         marker.unlink(missing_ok=True)
         if paths:
-            await send_files(thread, paths, working_dir)  # type: ignore[arg-type]
+            # Resolve relative paths against working_dir.  Claude is instructed to
+            # write absolute paths, but may write a bare filename.  Resolving here
+            # ensures the file is found even when the bot process has a different cwd.
+            wd = Path(working_dir)
+            abs_paths = [raw if Path(raw).is_absolute() else str(wd / raw) for raw in paths]
+            await send_files(thread, abs_paths, working_dir)  # type: ignore[arg-type]
 
 
 # Max characters for tool result display.

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -788,6 +788,36 @@ class TestCcdbAttachmentsDelivery:
 
         mock_send.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_relative_path_resolved_against_working_dir(
+        self, thread: MagicMock, runner: MagicMock, tmp_path
+    ) -> None:
+        """Relative paths in .ccdb-attachments are resolved against working_dir.
+
+        Claude may write a bare filename instead of an absolute path.
+        The bot must resolve it against the session working directory so the
+        file is found even though the bot process has a different cwd.
+        """
+        from unittest.mock import patch
+
+        runner.working_dir = str(tmp_path)
+        f = tmp_path / "out.py"
+        f.write_text("result = 42", encoding="utf-8")
+        # Write only the bare filename (relative path) — no directory prefix
+        (tmp_path / ".ccdb-attachments").write_text("out.py\n", encoding="utf-8")
+
+        config = _make_config(thread, runner)
+        p = EventProcessor(config)
+
+        with patch(
+            "claude_discord.cogs.event_processor.send_files",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            await p.process(_make_result_event(session_id="s1"))
+
+        # "out.py" must be resolved to tmp_path / "out.py"
+        mock_send.assert_called_once_with(thread, [str(f)], str(tmp_path))
+
 
 class TestToolUseCount:
     """tool_use_count state tracking."""


### PR DESCRIPTION
## Summary

- **Bug**: When Claude wrote a bare filename (e.g. `out.py`) to `.ccdb-attachments`, `collect_discord_files()` resolved it relative to the bot process's cwd (`/home/ebi/claude-code-discord-bridge`) rather than `runner.working_dir` (`/home/ebi`). The file was not found and no attachment was sent.
- **Fix** (`event_processor.py`): Relative paths in `.ccdb-attachments` are now resolved against `working_dir` before being passed to `send_files()`.
- **Fix** (`_run_helper.py`): File Delivery system-prompt instruction now includes a concrete bash example (`echo /absolute/path >> .ccdb-attachments`) so Claude is more likely to write absolute paths.

## Test plan

- [x] Added `test_relative_path_resolved_against_working_dir` in `TestCcdbAttachmentsDelivery` — confirms bare filenames are resolved against `working_dir`
- [x] All 960 existing tests pass (`uv run pytest tests/ -v`)
- [x] `ruff check` and `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)