### PR TITLE
feat: add INFO/DEBUG logging to _send_attachment_requests

### DIFF
--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -56,10 +56,13 @@ async def _send_attachment_requests(
     is suppressed — file attachment is non-fatal.
     """
     if not working_dir:
+        logger.debug("_send_attachment_requests: no working_dir, skipping")
         return
     marker = Path(working_dir) / _ATTACHMENT_MARKER
     if not marker.exists():
+        logger.debug("_send_attachment_requests: %s not found, skipping", marker)
         return
+    logger.info("_send_attachment_requests: found %s", marker)
     with contextlib.suppress(OSError):
         paths = [p.strip() for p in marker.read_text(encoding="utf-8").splitlines() if p.strip()]
         marker.unlink(missing_ok=True)
@@ -69,6 +72,11 @@ async def _send_attachment_requests(
             # ensures the file is found even when the bot process has a different cwd.
             wd = Path(working_dir)
             abs_paths = [raw if Path(raw).is_absolute() else str(wd / raw) for raw in paths]
+            logger.info(
+                "_send_attachment_requests: sending %d file(s): %s",
+                len(abs_paths),
+                abs_paths,
+            )
             await send_files(thread, abs_paths, working_dir)  # type: ignore[arg-type]
 
 

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -789,6 +789,50 @@ class TestCcdbAttachmentsDelivery:
         mock_send.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_logging_when_marker_found(
+        self, thread: MagicMock, runner: MagicMock, tmp_path, caplog
+    ) -> None:
+        """INFO log is emitted when .ccdb-attachments is found and processed."""
+        import logging
+        from unittest.mock import patch
+
+        runner.working_dir = str(tmp_path)
+        f = tmp_path / "out.py"
+        f.write_text("x = 1", encoding="utf-8")
+        (tmp_path / ".ccdb-attachments").write_text(str(f) + "\n", encoding="utf-8")
+
+        config = _make_config(thread, runner)
+        p = EventProcessor(config)
+
+        with (
+            patch("claude_discord.cogs.event_processor.send_files", new_callable=AsyncMock),
+            caplog.at_level(logging.INFO, logger="claude_discord.cogs.event_processor"),
+        ):
+            await p.process(_make_result_event(session_id="s1"))
+
+        assert any("ccdb-attachments" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_logging_when_marker_absent(
+        self, thread: MagicMock, runner: MagicMock, tmp_path, caplog
+    ) -> None:
+        """DEBUG log is emitted when .ccdb-attachments is absent."""
+        import logging
+        from unittest.mock import patch
+
+        runner.working_dir = str(tmp_path)
+        config = _make_config(thread, runner)
+        p = EventProcessor(config)
+
+        with (
+            patch("claude_discord.cogs.event_processor.send_files", new_callable=AsyncMock),
+            caplog.at_level(logging.DEBUG, logger="claude_discord.cogs.event_processor"),
+        ):
+            await p.process(_make_result_event(session_id="s1"))
+
+        assert any("ccdb-attachments" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
     async def test_relative_path_resolved_against_working_dir(
         self, thread: MagicMock, runner: MagicMock, tmp_path
     ) -> None:


### PR DESCRIPTION
## Summary

- Log **INFO** when \`.ccdb-attachments\` is found, including which file paths will be sent
- Log **DEBUG** when the marker file is absent or \`working_dir\` is unset (both are no-op, not errors)
- Enables diagnosing silent non-delivery by reading journalctl without changing non-fatal semantics

## Why

After deploying #275, the file attachment mechanism still appeared to do nothing for some users.
Root cause investigation showed that \`_send_attachment_requests\` has no observable logging:
- If the marker file is missing → silent no-op
- If it's found and files are sent → also silent
Without logs it's impossible to know at which step the delivery stopped.

## Test plan

- [x] \`test_logging_when_marker_found\` — confirms INFO record contains \`ccdb-attachments\`
- [x] \`test_logging_when_marker_absent\` — confirms DEBUG record is emitted when marker is absent
- [x] All 962 existing tests pass
- [x] \`ruff check\` and \`ruff format --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)