### PR TITLE
fix: allow binary file attachments, raise size limit to 8 MB

### DIFF
--- a/claude_discord/discord_ui/file_sender.py
+++ b/claude_discord/discord_ui/file_sender.py
@@ -5,7 +5,7 @@ Files are specified by writing their paths to ``.ccdb-attachments`` in the
 working directory; the bot reads this marker and sends the listed files.
 
 Discord limits: 10 files per message, 8 MB per file (non-boosted server).
-Files exceeding the size limit or detected as binary are skipped.
+Files exceeding the size limit are skipped.
 """
 
 from __future__ import annotations
@@ -19,18 +19,11 @@ import discord
 
 logger = logging.getLogger(__name__)
 
-# Per-file size limit — generous for source code, avoids large binary uploads.
-_MAX_FILE_BYTES = 512 * 1024  # 512 KB
+# Per-file size limit matching Discord's default upload cap for non-boosted servers.
+_MAX_FILE_BYTES = 8 * 1024 * 1024  # 8 MB
 
 # Discord API hard limit: 10 files per message.
 _MAX_FILES_PER_MESSAGE = 10
-
-
-def _is_binary(data: bytes) -> bool:
-    """Heuristic: treat a file as binary if it contains a null byte in the
-    first 8 KB.  Null bytes never appear in valid UTF-8 source files.
-    """
-    return b"\x00" in data[:8192]
 
 
 def _relative_path(file_path: str, working_dir: str | None) -> str:
@@ -59,8 +52,9 @@ def collect_discord_files(
 
     Skips files that:
     * Do not exist on disk
-    * Exceed *max_bytes* (default: 512 KB)
-    * Appear to be binary (contain a null byte in the first 8 KB)
+    * Exceed *max_bytes* (default: 8 MB, matching Discord's non-boosted limit)
+
+    Binary files (images, ZIPs, PDFs, etc.) are accepted — Discord supports them.
 
     Args:
         file_paths: Absolute or working-dir-relative paths to attach.
@@ -98,10 +92,6 @@ def collect_discord_files(
             data = path.read_bytes()
         except OSError:
             logger.debug("Cannot read file, skipping: %s", path, exc_info=True)
-            continue
-
-        if _is_binary(data):
-            logger.debug("Skipping binary file: %s", path)
             continue
 
         display_name = _relative_path(path_str, working_dir)

--- a/tests/test_file_sender.py
+++ b/tests/test_file_sender.py
@@ -12,32 +12,10 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from claude_discord.discord_ui.file_sender import (
-    _is_binary,
     _relative_path,
     collect_discord_files,
     send_files,
 )
-
-# ---------------------------------------------------------------------------
-# _is_binary
-# ---------------------------------------------------------------------------
-
-
-class TestIsBinary:
-    def test_plain_text_is_not_binary(self) -> None:
-        assert _is_binary(b"hello world\nprint('hi')\n") is False
-
-    def test_null_byte_flags_binary(self) -> None:
-        assert _is_binary(b"data\x00more data") is True
-
-    def test_empty_bytes_are_not_binary(self) -> None:
-        assert _is_binary(b"") is False
-
-    def test_null_byte_beyond_first_8kb_not_detected(self) -> None:
-        """Only the first 8 KB is sampled — null bytes later are ignored."""
-        data = b"a" * 8192 + b"\x00"
-        assert _is_binary(data) is False
-
 
 # ---------------------------------------------------------------------------
 # _relative_path
@@ -98,13 +76,15 @@ class TestCollectDiscordFiles:
 
         assert files == []
 
-    def test_binary_file_is_skipped(self, tmp_path: Path) -> None:
+    def test_binary_file_is_included(self, tmp_path: Path) -> None:
+        """Binary files (e.g. PNG, ZIP) are allowed — Discord supports them."""
         f = tmp_path / "binary.bin"
         f.write_bytes(b"\x00\x01\x02\x03")
 
         files = collect_discord_files([str(f)], str(tmp_path))
 
-        assert files == []
+        assert len(files) == 1
+        assert files[0].filename == "binary.bin"
 
     def test_multiple_valid_files_all_returned(self, tmp_path: Path) -> None:
         (tmp_path / "a.py").write_text("a = 1", encoding="utf-8")
@@ -199,7 +179,8 @@ class TestSendFiles:
         assert len(second_batch) == 2
 
     @pytest.mark.asyncio
-    async def test_skips_all_binary_files_sends_nothing(self, tmp_path: Path) -> None:
+    async def test_binary_file_is_sent(self, tmp_path: Path) -> None:
+        """Binary files like PNG are now allowed and sent as attachments."""
         thread = MagicMock()
         thread.send = AsyncMock()
         f = tmp_path / "img.png"
@@ -207,4 +188,4 @@ class TestSendFiles:
 
         await send_files(thread, [str(f)], str(tmp_path))
 
-        thread.send.assert_not_called()
+        thread.send.assert_called_once()


### PR DESCRIPTION
## Summary

- Remove the `_is_binary()` heuristic that blocked files containing null bytes (PNG, ZIP, PDF, executables, etc.)
- Discord supports all file types — the restriction was ccdb-specific with no user-facing rationale
- Raise `_MAX_FILE_BYTES` from 512 KB → **8 MB** to match Discord's actual upload limit for non-boosted servers

## Why

The original comment said *"avoids large binary uploads"* but Discord itself allows binary attachments freely. Blocking them in ccdb silently prevented users from asking Claude to send images, archives, or any compiled output.

## Test plan

- [x] `test_binary_file_is_included` — binary file with null bytes is returned by `collect_discord_files`
- [x] `test_binary_file_is_sent` — PNG-like bytes are delivered via `send_files`
- [x] All 958 existing tests pass
- [x] `ruff check` and `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)