### PR TITLE
[docs-sync] Fix COORDINATION_CHANNEL_ID table description in 6 language READMEs

### DIFF
--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -295,7 +295,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `MAX_CONCURRENT_SESSIONS` | Máximo de sesiones paralelas | `3` |
 | `SESSION_TIMEOUT_SECONDS` | Timeout de inactividad de sesión | `300` |
 | `DISCORD_OWNER_ID` | ID de usuario para @mencionar cuando Claude necesita entrada | (opcional) |
-| `COORDINATION_CHANNEL_ID` | ID del canal para transmisiones de eventos entre sesiones | (opcional) |
+| `COORDINATION_CHANNEL_ID` | ID del canal utilizado como fallback predeterminado para el canal AI Lounge | (opcional) |
 | `WORKTREE_BASE_DIR` | Directorio base para escanear worktrees de sesión (activa limpieza automática) | (opcional) |
 | `MENTION_ONLY_CHANNEL_IDS` | IDs de canal separadas por coma donde el bot solo responde cuando se le @menciona | (opcional) |
 | `INLINE_REPLY_CHANNEL_IDS` | IDs de canal separadas por coma donde el bot responde en línea (sin crear hilo) | (opcional) |

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -295,7 +295,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `MAX_CONCURRENT_SESSIONS` | Nombre maximum de sessions parallèles | `3` |
 | `SESSION_TIMEOUT_SECONDS` | Timeout d'inactivité de session | `300` |
 | `DISCORD_OWNER_ID` | ID utilisateur à @mentionner quand Claude a besoin d'une saisie | (optionnel) |
-| `COORDINATION_CHANNEL_ID` | ID du canal pour les diffusions d'événements entre sessions | (optionnel) |
+| `COORDINATION_CHANNEL_ID` | ID du canal utilisé comme valeur de repli par défaut pour le canal AI Lounge | (optionnel) |
 | `WORKTREE_BASE_DIR` | Répertoire de base pour scanner les worktrees de session (active le nettoyage automatique) | (optionnel) |
 | `MENTION_ONLY_CHANNEL_IDS` | IDs de canal séparés par des virgules où le bot répond uniquement quand il est @mentionné | (optionnel) |
 | `INLINE_REPLY_CHANNEL_IDS` | IDs de canal séparés par des virgules où le bot répond en ligne (sans créer de fil) | (optionnel) |

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -477,7 +477,7 @@ INLINE_REPLY_CHANNEL_IDS=333,444
 | `MAX_CONCURRENT_SESSIONS` | 最大並行セッション数 | `3` |
 | `SESSION_TIMEOUT_SECONDS` | セッション非アクティブタイムアウト | `300` |
 | `DISCORD_OWNER_ID` | Claude が入力待ちのとき @mention する Discord ユーザー ID | （オプション） |
-| `COORDINATION_CHANNEL_ID` | セッション間イベントブロードキャスト用チャンネル ID | （オプション） |
+| `COORDINATION_CHANNEL_ID` | AI Lounge チャンネルのデフォルトフォールバック用チャンネル ID | （オプション） |
 | `MENTION_ONLY_CHANNEL_IDS` | @メンション時のみ応答するチャンネル ID（カンマ区切り） | （オプション） |
 | `INLINE_REPLY_CHANNEL_IDS` | インライン返信チャンネル ID（カンマ区切り、スレッドを作成しない） | （オプション） |
 | `WORKTREE_BASE_DIR` | セッション Worktree のスキャン対象ディレクトリ（自動クリーンアップを有効化） | （オプション） |

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -295,7 +295,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `MAX_CONCURRENT_SESSIONS` | 최대 동시 세션 수 | `3` |
 | `SESSION_TIMEOUT_SECONDS` | 세션 비활성 시간 초과 | `300` |
 | `DISCORD_OWNER_ID` | Claude가 입력이 필요할 때 @멘션할 사용자 ID | (선택) |
-| `COORDINATION_CHANNEL_ID` | 세션 간 이벤트 브로드캐스트 채널 ID | (선택) |
+| `COORDINATION_CHANNEL_ID` | AI Lounge 채널의 기본 폴백 채널 ID | (선택) |
 | `WORKTREE_BASE_DIR` | 세션 worktree 스캔 기본 디렉토리 (자동 정리 활성화) | (선택) |
 | `MENTION_ONLY_CHANNEL_IDS` | 봇이 @멘션될 때만 응답하는 채널 ID (쉼표로 구분) | (선택) |
 | `INLINE_REPLY_CHANNEL_IDS` | 인라인 답장 채널 ID (쉼표로 구분, 스레드 생성 없음) | (선택) |

--- a/docs/pt-BR/README.md
+++ b/docs/pt-BR/README.md
@@ -295,7 +295,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `MAX_CONCURRENT_SESSIONS` | Máximo de sessões paralelas | `3` |
 | `SESSION_TIMEOUT_SECONDS` | Timeout de inatividade da sessão | `300` |
 | `DISCORD_OWNER_ID` | ID do usuário para @mencionar quando o Claude precisa de input | (opcional) |
-| `COORDINATION_CHANNEL_ID` | ID do canal para transmissões de eventos entre sessões | (opcional) |
+| `COORDINATION_CHANNEL_ID` | ID do canal usado como fallback padrão para o canal AI Lounge | (opcional) |
 | `WORKTREE_BASE_DIR` | Diretório base para escanear worktrees de sessão (ativa limpeza automática) | (opcional) |
 | `MENTION_ONLY_CHANNEL_IDS` | IDs de canal separados por vírgula onde o bot responde apenas quando @mencionado | (opcional) |
 | `INLINE_REPLY_CHANNEL_IDS` | IDs de canal separados por vírgula onde o bot responde inline (sem criar thread) | (opcional) |

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -313,7 +313,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `MAX_CONCURRENT_SESSIONS` | 最大并发会话数 | `3` |
 | `SESSION_TIMEOUT_SECONDS` | 会话非活动超时 | `300` |
 | `DISCORD_OWNER_ID` | Claude 需要输入时 @提及的用户 ID | （可选） |
-| `COORDINATION_CHANNEL_ID` | 跨会话事件广播的频道 ID | （可选） |
+| `COORDINATION_CHANNEL_ID` | AI Lounge 频道的默认回退频道 ID | （可选） |
 | `WORKTREE_BASE_DIR` | 扫描会话 worktree 的基础目录（启用自动清理） | （可选） |
 | `MENTION_ONLY_CHANNEL_IDS` | 仅在 @提及时响应的频道 ID（逗号分隔） | （可选） |
 | `INLINE_REPLY_CHANNEL_IDS` | 内联回复的频道 ID（逗号分隔，不创建线程） | （可选） |


### PR DESCRIPTION
## Summary

- Fix `COORDINATION_CHANNEL_ID` table description in 6 language READMEs (ja, ko, es, fr, pt-BR, zh-CN)
- Previous docs-sync (#282) updated the bullet point correctly but left the env var table with the old "inter-session event broadcast" description
- Updated to match the English README: "default fallback for AI Lounge channel"

## Details

The `CoordinationService` was removed in a previous refactor. The `COORDINATION_CHANNEL_ID` env var is now only used as a fallback default for the AI Lounge channel (`lounge_channel_id`). The bullet-point descriptions were already corrected in #282, but the table rows in all non-English READMEs still showed the old purpose.

| File | Old description | New description |
|------|----------------|----------------|
| docs/ja/README.md | セッション間イベントブロードキャスト用チャンネル ID | AI Lounge チャンネルのデフォルトフォールバック用チャンネル ID |
| docs/ko/README.md | 세션 간 이벤트 브로드캐스트 채널 ID | AI Lounge 채널의 기본 폴백 채널 ID |
| docs/es/README.md | ID del canal para transmisiones de eventos entre sesiones | ID del canal utilizado como fallback predeterminado para el canal AI Lounge |
| docs/fr/README.md | ID du canal pour les diffusions d'événements entre sessions | ID du canal utilisé comme valeur de repli par défaut pour le canal AI Lounge |
| docs/pt-BR/README.md | ID do canal para transmissões de eventos entre sessões | ID do canal usado como fallback padrão para o canal AI Lounge |
| docs/zh-CN/README.md | 跨会话事件广播的频道 ID | AI Lounge 频道的默认回退频道 ID |

## Test plan

- [x] Verify table descriptions match the English README in all 6 languages
- [x] Verify bullet-point descriptions were already correct (no changes needed)
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
