### PR TITLE
fix: exclude external-issue labeled PRs from auto-merge

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -10,7 +10,12 @@ jobs:
     # Skip draft PRs — only auto-merge when the PR is explicitly marked ready.
     # This prevents the race condition where auto-merge fires on the first
     # commit before subsequent commits have been pushed.
-    if: github.event.pull_request.user.login == 'ebibibi' && github.event.pull_request.draft == false
+    # Skip 'external-issue' PRs — these are created from external user Issues via
+    # Docker sandbox and require manual review before merging.
+    if: >
+      github.event.pull_request.user.login == 'ebibibi' &&
+      github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.labels.*.name, 'external-issue')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Summary

- Add `!contains(..., 'external-issue')` condition to `auto-approve-and-merge` job
- PRs from the issue resolver sandbox carry the `external-issue` label
- These PRs must be manually reviewed before merging (they originate from external user Issues)

## Security model

| PR condition | Auto-merge? |
|-------------|------------|
| `user == ebibibi` + not draft + no `external-issue` label | ✅ Yes |
| `user == ebibibi` + `external-issue` label | ❌ No — manual review required |
| draft | ❌ No |
| external contributor | ❌ No |