### PR TITLE
[docs-sync] Add CLI_SESSIONS_PATH to env vars table (all languages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ In inline-reply mode, Claude's response is sent directly as a message in the cha
 | `MENTION_ONLY_CHANNEL_IDS` | Comma-separated channel IDs where the bot only responds when @mentioned | (optional) |
 | `INLINE_REPLY_CHANNEL_IDS` | Comma-separated channel IDs where the bot replies inline (no thread created) | (optional) |
 | `WORKTREE_BASE_DIR` | Base directory to scan for session worktrees (enables automatic cleanup) | (optional) |
+| `CLI_SESSIONS_PATH` | Path to `~/.claude/projects` for CLI session discovery (enables `/sync-sessions`) | (optional) |
 | `CUSTOM_COGS_DIR` | Directory containing custom Cog files to load at startup (see [Custom Cogs](#custom-cogs-extend-without-forking)) | (optional) |
 | `CLAUDE_ALLOWED_TOOLS` | Comma-separated list of allowed tools for Claude CLI | (optional) |
 | `CLAUDE_CHANNEL_IDS` | Additional channel IDs (comma-separated) for multi-channel setup | (optional) |

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -297,6 +297,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `DISCORD_OWNER_ID` | ID de usuario para @mencionar cuando Claude necesita entrada | (opcional) |
 | `COORDINATION_CHANNEL_ID` | ID del canal utilizado como fallback predeterminado para el canal AI Lounge | (opcional) |
 | `WORKTREE_BASE_DIR` | Directorio base para escanear worktrees de sesión (activa limpieza automática) | (opcional) |
+| `CLI_SESSIONS_PATH` | Ruta a `~/.claude/projects` para descubrimiento de sesiones CLI (habilita `/sync-sessions`) | (opcional) |
 | `MENTION_ONLY_CHANNEL_IDS` | IDs de canal separadas por coma donde el bot solo responde cuando se le @menciona | (opcional) |
 | `INLINE_REPLY_CHANNEL_IDS` | IDs de canal separadas por coma donde el bot responde en línea (sin crear hilo) | (opcional) |
 | `THREAD_INBOX_ENABLED` | Habilita la bandeja de entrada persistente de hilos (clasifica sesiones como `waiting`/`done`/`ambiguous` via `claude -p`; mostrado en el panel de hilos) | `false` |

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -297,6 +297,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `DISCORD_OWNER_ID` | ID utilisateur à @mentionner quand Claude a besoin d'une saisie | (optionnel) |
 | `COORDINATION_CHANNEL_ID` | ID du canal utilisé comme valeur de repli par défaut pour le canal AI Lounge | (optionnel) |
 | `WORKTREE_BASE_DIR` | Répertoire de base pour scanner les worktrees de session (active le nettoyage automatique) | (optionnel) |
+| `CLI_SESSIONS_PATH` | Chemin vers `~/.claude/projects` pour la découverte de sessions CLI (active `/sync-sessions`) | (optionnel) |
 | `MENTION_ONLY_CHANNEL_IDS` | IDs de canal séparés par des virgules où le bot répond uniquement quand il est @mentionné | (optionnel) |
 | `INLINE_REPLY_CHANNEL_IDS` | IDs de canal séparés par des virgules où le bot répond en ligne (sans créer de fil) | (optionnel) |
 | `THREAD_INBOX_ENABLED` | Active la boîte de réception persistante des fils (classe les sessions en `waiting`/`done`/`ambiguous` via `claude -p` ; affiché dans le tableau de bord des fils) | `false` |

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -481,6 +481,7 @@ INLINE_REPLY_CHANNEL_IDS=333,444
 | `MENTION_ONLY_CHANNEL_IDS` | @メンション時のみ応答するチャンネル ID（カンマ区切り） | （オプション） |
 | `INLINE_REPLY_CHANNEL_IDS` | インライン返信チャンネル ID（カンマ区切り、スレッドを作成しない） | （オプション） |
 | `WORKTREE_BASE_DIR` | セッション Worktree のスキャン対象ディレクトリ（自動クリーンアップを有効化） | （オプション） |
+| `CLI_SESSIONS_PATH` | CLI セッション検出用のパス（`~/.claude/projects`）。`/sync-sessions` の有効化に必要 | （オプション） |
 | `CUSTOM_COGS_DIR` | 起動時に読み込むカスタム Cog ファイルを含むディレクトリ（[カスタム Cog](#カスタム-cogフォーク不要で機能拡張) 参照） | （オプション） |
 | `CLAUDE_ALLOWED_TOOLS` | Claude CLI に許可するツールのカンマ区切りリスト | （オプション） |
 | `CLAUDE_CHANNEL_IDS` | マルチチャンネル設定用の追加チャンネル ID（カンマ区切り） | （オプション） |

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -297,6 +297,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `DISCORD_OWNER_ID` | Claude가 입력이 필요할 때 @멘션할 사용자 ID | (선택) |
 | `COORDINATION_CHANNEL_ID` | AI Lounge 채널의 기본 폴백 채널 ID | (선택) |
 | `WORKTREE_BASE_DIR` | 세션 worktree 스캔 기본 디렉토리 (자동 정리 활성화) | (선택) |
+| `CLI_SESSIONS_PATH` | CLI 세션 탐색 경로 (`~/.claude/projects`), `/sync-sessions` 활성화에 필요 | (선택) |
 | `MENTION_ONLY_CHANNEL_IDS` | 봇이 @멘션될 때만 응답하는 채널 ID (쉼표로 구분) | (선택) |
 | `INLINE_REPLY_CHANNEL_IDS` | 인라인 답장 채널 ID (쉼표로 구분, 스레드 생성 없음) | (선택) |
 | `THREAD_INBOX_ENABLED` | 지속적인 스레드 수신함 활성화 (`claude -p`로 세션을 `waiting`/`done`/`ambiguous`로 분류; 스레드 대시보드에 표시) | `false` |

--- a/docs/pt-BR/README.md
+++ b/docs/pt-BR/README.md
@@ -297,6 +297,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `DISCORD_OWNER_ID` | ID do usuário para @mencionar quando o Claude precisa de input | (opcional) |
 | `COORDINATION_CHANNEL_ID` | ID do canal usado como fallback padrão para o canal AI Lounge | (opcional) |
 | `WORKTREE_BASE_DIR` | Diretório base para escanear worktrees de sessão (ativa limpeza automática) | (opcional) |
+| `CLI_SESSIONS_PATH` | Caminho para `~/.claude/projects` para descoberta de sessões CLI (habilita `/sync-sessions`) | (opcional) |
 | `MENTION_ONLY_CHANNEL_IDS` | IDs de canal separados por vírgula onde o bot responde apenas quando @mencionado | (opcional) |
 | `INLINE_REPLY_CHANNEL_IDS` | IDs de canal separados por vírgula onde o bot responde inline (sem criar thread) | (opcional) |
 | `THREAD_INBOX_ENABLED` | Ativa a caixa de entrada persistente de threads (classifica sessões como `waiting`/`done`/`ambiguous` via `claude -p`; exibido no painel de threads) | `false` |

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -315,6 +315,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `DISCORD_OWNER_ID` | Claude 需要输入时 @提及的用户 ID | （可选） |
 | `COORDINATION_CHANNEL_ID` | AI Lounge 频道的默认回退频道 ID | （可选） |
 | `WORKTREE_BASE_DIR` | 扫描会话 worktree 的基础目录（启用自动清理） | （可选） |
+| `CLI_SESSIONS_PATH` | CLI 会话发现的路径（`~/.claude/projects`），启用 `/sync-sessions` | （可选） |
 | `MENTION_ONLY_CHANNEL_IDS` | 仅在 @提及时响应的频道 ID（逗号分隔） | （可选） |
 | `INLINE_REPLY_CHANNEL_IDS` | 内联回复的频道 ID（逗号分隔，不创建线程） | （可选） |
 | `THREAD_INBOX_ENABLED` | 启用持久线程收件箱（通过 `claude -p` 将会话分类为 `waiting`/`done`/`ambiguous`；显示在线程面板中） | `false` |


### PR DESCRIPTION
## Summary

- Add `CLI_SESSIONS_PATH` to the environment variables reference table in all language docs
- This env var was wired in #302 (`fix: wire CLI_SESSIONS_PATH env, UTF-8 session files, working_dir on resume`) but was missing from the documentation
- Updated 7 files: `README.md` (English) + `docs/ja/`, `docs/es/`, `docs/fr/`, `docs/ko/`, `docs/pt-BR/`, `docs/zh-CN/`

## 変更内容（日本語）

PR #302 で実装済みだった `CLI_SESSIONS_PATH` 環境変数が、全言語の環境変数一覧テーブルに記載されていなかったため追加。

## Test plan

- [ ] Verify `CLI_SESSIONS_PATH` row appears correctly in each language's env var table
- [ ] Confirm placement is consistent (after `WORKTREE_BASE_DIR`, before `MENTION_ONLY_CHANNEL_IDS`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
