### PR TITLE
feat: add thread_id to lounge messages for self-identification

### DIFF
--- a/claude_discord/cogs/_run_helper.py
+++ b/claude_discord/cogs/_run_helper.py
@@ -64,7 +64,7 @@ async def _build_system_context(config: RunConfig) -> str | None:
     if config.lounge_repo is not None:
         try:
             recent = await config.lounge_repo.get_recent(limit=10)
-            lounge_context = build_lounge_prompt(recent)
+            lounge_context = build_lounge_prompt(recent, current_thread_id=config.thread.id)
             parts.append(lounge_context)
             logger.debug("Lounge context built (%d recent message(s))", len(recent))
         except Exception:

--- a/claude_discord/database/lounge_repo.py
+++ b/claude_discord/database/lounge_repo.py
@@ -14,7 +14,7 @@ file dependency.  Old messages are pruned automatically to keep the table small.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import aiosqlite
 
@@ -32,6 +32,7 @@ class LoungeMessage:
     label: str
     message: str
     posted_at: str  # ISO datetime string (localtime)
+    thread_id: int | None = field(default=None)  # Discord thread that posted this
 
 
 class LoungeRepository:
@@ -44,7 +45,9 @@ class LoungeRepository:
     def __init__(self, db_path: str) -> None:
         self._db_path = db_path
 
-    async def post(self, message: str, label: str = "AI") -> LoungeMessage:
+    async def post(
+        self, message: str, label: str = "AI", *, thread_id: int | None = None
+    ) -> LoungeMessage:
         """Insert a new lounge message and return it.
 
         Prunes messages exceeding _MAX_STORED_MESSAGES after insert.
@@ -55,15 +58,15 @@ class LoungeRepository:
         async with aiosqlite.connect(self._db_path) as db:
             db.row_factory = aiosqlite.Row
             cursor = await db.execute(
-                "INSERT INTO lounge_messages (label, message) VALUES (?, ?)",
-                (label, message),
+                "INSERT INTO lounge_messages (label, message, thread_id) VALUES (?, ?, ?)",
+                (label, message, thread_id),
             )
             row_id = cursor.lastrowid
             await db.commit()
 
             # Fetch the inserted row (to get server-generated posted_at)
             cur = await db.execute(
-                "SELECT id, label, message, posted_at FROM lounge_messages WHERE id = ?",
+                "SELECT id, label, message, thread_id, posted_at FROM lounge_messages WHERE id = ?",
                 (row_id,),
             )
             row = await cur.fetchone()
@@ -84,6 +87,7 @@ class LoungeRepository:
             label=row["label"],
             message=row["message"],
             posted_at=row["posted_at"],
+            thread_id=row["thread_id"],
         )
         logger.info("Lounge message posted by %r (id=%d)", label, result.id)
         return result
@@ -98,8 +102,8 @@ class LoungeRepository:
             db.row_factory = aiosqlite.Row
             # Pick the N newest via subquery, then sort ascending for display
             rows = await db.execute_fetchall(
-                "SELECT id, label, message, posted_at FROM ("
-                "  SELECT id, label, message, posted_at FROM lounge_messages"
+                "SELECT id, label, message, thread_id, posted_at FROM ("
+                "  SELECT id, label, message, thread_id, posted_at FROM lounge_messages"
                 "  ORDER BY id DESC LIMIT ?"
                 ") ORDER BY id ASC",
                 (limit,),
@@ -111,6 +115,7 @@ class LoungeRepository:
                 label=row["label"],
                 message=row["message"],
                 posted_at=row["posted_at"],
+                thread_id=row["thread_id"],
             )
             for row in rows
         ]

--- a/claude_discord/database/models.py
+++ b/claude_discord/database/models.py
@@ -41,6 +41,7 @@ CREATE TABLE IF NOT EXISTS lounge_messages (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     label TEXT NOT NULL DEFAULT 'AI',
     message TEXT NOT NULL,
+    thread_id INTEGER,
     posted_at TEXT NOT NULL DEFAULT (datetime('now', 'localtime'))
 );
 
@@ -133,6 +134,8 @@ _MIGRATIONS = [
         "is_using_overage INTEGER NOT NULL DEFAULT 0, "
         "recorded_at TEXT NOT NULL DEFAULT (datetime('now', 'localtime')))"
     ),
+    # thread_id column on lounge_messages — tracks which Discord thread posted the message
+    "ALTER TABLE lounge_messages ADD COLUMN thread_id INTEGER",
 ]
 
 

--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -13,6 +13,7 @@ Security:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -388,6 +389,7 @@ class ApiServer:
                         "id": m.id,
                         "label": m.label,
                         "message": m.message,
+                        "thread_id": m.thread_id,
                         "posted_at": m.posted_at,
                     }
                     for m in messages
@@ -419,7 +421,14 @@ class ApiServer:
 
         label = str(data.get("label", "AI")).strip() or "AI"
 
-        stored = await self.lounge_repo.post(message=message, label=label)  # type: ignore[union-attr]
+        # thread_id is optional — allows tracing which Discord thread posted the message
+        raw_thread_id = data.get("thread_id")
+        thread_id: int | None = None
+        if raw_thread_id is not None:
+            with contextlib.suppress(ValueError, TypeError):
+                thread_id = int(raw_thread_id)
+
+        stored = await self.lounge_repo.post(message=message, label=label, thread_id=thread_id)  # type: ignore[union-attr]
 
         # Forward to Discord lounge channel if configured
         if self.lounge_channel_id:
@@ -431,6 +440,7 @@ class ApiServer:
                 "id": stored.id,
                 "label": stored.label,
                 "message": stored.message,
+                "thread_id": stored.thread_id,
                 "posted_at": stored.posted_at,
             },
             status=201,

--- a/claude_discord/lounge.py
+++ b/claude_discord/lounge.py
@@ -34,7 +34,8 @@ Post command:
 ```bash
 curl -s -X POST "$CCDB_API_URL/api/lounge" \\
   -H "Content-Type: application/json" \\
-  -d '{"message": "your note here", "label": "your nickname"}'
+  -d '{{"message": "your note here", "label": "your nickname", \\
+       "thread_id": "'$DISCORD_THREAD_ID'"}}'
 ```
 
 Labels are free-form. Examples: "bug-hunter", "night-shift", "frontend", "careful"
@@ -53,12 +54,21 @@ _NO_MESSAGES = "\n(No messages yet — be the first to say hello!)\n"
 _INVITE_CLOSE = "\n---\n"
 
 
-def build_lounge_prompt(recent_messages: list[LoungeMessage]) -> str:
+def build_lounge_prompt(
+    recent_messages: list[LoungeMessage],
+    *,
+    current_thread_id: int | None = None,
+) -> str:
     """Return the full lounge context string to prepend to Claude's prompt.
 
     Args:
         recent_messages: Recent messages from LoungeRepository.get_recent(),
                          in chronological order (oldest first).
+        current_thread_id: The Discord thread ID of the current session.
+                           Messages from this thread are annotated with
+                           ``[this thread]`` so the AI can distinguish its
+                           own earlier posts from other sessions' posts
+                           (critical after context compaction).
     """
     parts = [_LOUNGE_INVITE]
 
@@ -68,7 +78,16 @@ def build_lounge_prompt(recent_messages: list[LoungeMessage]) -> str:
             # Truncate the timestamp to HH:MM for readability (posted_at is
             # "YYYY-MM-DD HH:MM:SS" from SQLite datetime('now', 'localtime')).
             timestamp = msg.posted_at[11:16] if len(msg.posted_at) >= 16 else msg.posted_at
-            parts.append(f"  [{timestamp}] {msg.label}: {msg.message}")
+            # Annotate messages from the current thread so the AI knows
+            # "this was me in a previous context window, not another session".
+            marker = ""
+            if (
+                current_thread_id is not None
+                and msg.thread_id is not None
+                and msg.thread_id == current_thread_id
+            ):
+                marker = " [this thread]"
+            parts.append(f"  [{timestamp}] {msg.label}{marker}: {msg.message}")
     else:
         parts.append(_NO_MESSAGES)
 

--- a/tests/test_lounge.py
+++ b/tests/test_lounge.py
@@ -114,10 +114,24 @@ class TestLoungeRepository:
         assert msg.label == "TestBot"
         assert msg.message == "Hello from AI!"
         assert msg.posted_at  # non-empty datetime string
+        assert msg.thread_id is None  # no thread_id by default
 
         recent = await lounge_repo.get_recent(limit=10)
         assert len(recent) == 1
         assert recent[0].id == msg.id
+
+    async def test_post_with_thread_id(self, lounge_repo: LoungeRepository) -> None:
+        """thread_id is stored and returned correctly."""
+        msg = await lounge_repo.post("Working on it", label="Bot", thread_id=123456789)
+        assert msg.thread_id == 123456789
+
+        recent = await lounge_repo.get_recent(limit=10)
+        assert recent[0].thread_id == 123456789
+
+    async def test_post_without_thread_id(self, lounge_repo: LoungeRepository) -> None:
+        """thread_id defaults to None when not provided."""
+        msg = await lounge_repo.post("No thread", label="Bot")
+        assert msg.thread_id is None
 
     async def test_get_recent_oldest_first(self, lounge_repo: LoungeRepository) -> None:
         """Messages returned in chronological (oldest-first) order."""
@@ -213,6 +227,86 @@ class TestBuildLoungePrompt:
         assert "CCDB_API_URL" in result
         assert "/api/lounge" in result
 
+    def test_curl_includes_thread_id(self) -> None:
+        """The curl example includes thread_id in the JSON body."""
+        result = build_lounge_prompt([])
+        assert "thread_id" in result
+        assert "DISCORD_THREAD_ID" in result
+
+    def test_this_thread_marker_for_matching_thread(self) -> None:
+        """Messages from current thread are annotated with [this thread]."""
+        messages = [
+            LoungeMessage(
+                id=1,
+                label="BotA",
+                message="My earlier work",
+                posted_at="2026-03-14 09:00:00",
+                thread_id=42,
+            ),
+            LoungeMessage(
+                id=2,
+                label="BotB",
+                message="Other work",
+                posted_at="2026-03-14 09:01:00",
+                thread_id=99,
+            ),
+        ]
+        result = build_lounge_prompt(messages, current_thread_id=42)
+        # Message from thread 42 should have [this thread]
+        assert "[this thread]" in result
+        # Only the first message line should have the marker
+        lines = result.split("\n")
+        thread_marker_lines = [line for line in lines if "[this thread]" in line]
+        assert len(thread_marker_lines) == 1
+        assert "BotA" in thread_marker_lines[0]
+        assert "My earlier work" in thread_marker_lines[0]
+
+    def test_no_marker_when_no_current_thread_id(self) -> None:
+        """Without current_thread_id, no [this thread] markers appear."""
+        messages = [
+            LoungeMessage(
+                id=1,
+                label="BotA",
+                message="work",
+                posted_at="2026-03-14 09:00:00",
+                thread_id=42,
+            ),
+        ]
+        result = build_lounge_prompt(messages)  # no current_thread_id
+        assert "[this thread]" not in result
+
+    def test_no_marker_when_thread_id_is_none(self) -> None:
+        """Messages without thread_id are never annotated."""
+        messages = [
+            LoungeMessage(
+                id=1,
+                label="BotA",
+                message="old message",
+                posted_at="2026-03-14 09:00:00",
+                thread_id=None,
+            ),
+        ]
+        result = build_lounge_prompt(messages, current_thread_id=42)
+        assert "[this thread]" not in result
+
+    def test_all_matching_messages_get_marker(self) -> None:
+        """All messages from the current thread get [this thread]."""
+        messages = [
+            LoungeMessage(
+                id=1, label="A", message="m1", posted_at="2026-03-14 09:00:00", thread_id=42
+            ),
+            LoungeMessage(
+                id=2, label="B", message="m2", posted_at="2026-03-14 09:01:00", thread_id=99
+            ),
+            LoungeMessage(
+                id=3, label="C", message="m3", posted_at="2026-03-14 09:02:00", thread_id=42
+            ),
+        ]
+        result = build_lounge_prompt(messages, current_thread_id=42)
+        lines = result.split("\n")
+        thread_marker_lines = [line for line in lines if "[this thread]" in line]
+        assert len(thread_marker_lines) == 2
+
 
 # ---------------------------------------------------------------------------
 # API endpoint tests
@@ -242,6 +336,43 @@ class TestLoungeApiEndpoints:
         data = await get_resp.json()
         assert len(data["messages"]) == 1
         assert data["messages"][0]["label"] == "TestAI"
+
+    async def test_post_lounge_with_thread_id(self, api_client_with_lounge: TestClient) -> None:
+        """POST with thread_id stores and returns it."""
+        resp = await api_client_with_lounge.post(
+            "/api/lounge",
+            json={"message": "From thread", "label": "Bot", "thread_id": 987654321},
+        )
+        assert resp.status == 201
+        body = await resp.json()
+        assert body["thread_id"] == 987654321
+
+        # GET also returns thread_id
+        get_resp = await api_client_with_lounge.get("/api/lounge")
+        data = await get_resp.json()
+        assert data["messages"][0]["thread_id"] == 987654321
+
+    async def test_post_lounge_without_thread_id(self, api_client_with_lounge: TestClient) -> None:
+        """POST without thread_id returns null."""
+        resp = await api_client_with_lounge.post(
+            "/api/lounge",
+            json={"message": "No thread", "label": "Bot"},
+        )
+        assert resp.status == 201
+        body = await resp.json()
+        assert body["thread_id"] is None
+
+    async def test_post_lounge_invalid_thread_id_ignored(
+        self, api_client_with_lounge: TestClient
+    ) -> None:
+        """Invalid thread_id is silently ignored (stored as null)."""
+        resp = await api_client_with_lounge.post(
+            "/api/lounge",
+            json={"message": "Bad thread", "label": "Bot", "thread_id": "not-a-number"},
+        )
+        assert resp.status == 201
+        body = await resp.json()
+        assert body["thread_id"] is None
 
     async def test_post_lounge_missing_message(self, api_client_with_lounge: TestClient) -> None:
         resp = await api_client_with_lounge.post("/api/lounge", json={"label": "Bot"})


### PR DESCRIPTION
## Summary

- Add `thread_id` column to `lounge_messages` table (nullable, backward-compatible migration)
- Accept optional `thread_id` in `POST /api/lounge` request body
- Return `thread_id` in both GET and POST responses
- Annotate messages from the current thread with `[this thread]` marker in the prompt
- Update curl example to include `$DISCORD_THREAD_ID`

## Problem

When a long conversation in a single Discord thread causes Claude Code's context to compact, the resumed session sees its own earlier lounge posts and mistakes them for messages from other sessions. This leads to:
- "Another session already did this work!" (when it was actually the same thread)
- Duplicate pipeline runs and confused status reporting

## How it works

1. Claude posts to lounge with `thread_id` from `$DISCORD_THREAD_ID` env var
2. When building the lounge prompt, messages matching the current thread get `[this thread]` annotation
3. After context compaction, the AI sees `[this thread]` and knows "that was me in a previous context window"

## Test plan

- [x] 33 lounge tests pass (7 new tests added)
- [x] Full test suite passes (968 tests)
- [x] ruff check + format pass
- [x] Backward compatible: existing messages have `thread_id = NULL` (no marker)

Closes #304