### PR TITLE
[docs-sync] Update test count from 906+ to 1050+ (all languages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -816,7 +816,7 @@ examples/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-906+ tests covering parser, chunker, repository, runner, streaming, webhook triggers, auto-upgrade (including `/upgrade` slash command, thread-invocation, and approval button), REST API, AskUserQuestion UI, thread dashboard, scheduled tasks, session sync, AI Lounge, startup resume, model switching, compact detection, TodoWrite progress embeds, custom Cog loader, permission/elicitation/plan-mode event parsing, and thread inbox classification.
+1050+ tests covering parser, chunker, repository, runner, streaming, webhook triggers, auto-upgrade (including `/upgrade` slash command, thread-invocation, and approval button), REST API, AskUserQuestion UI, thread dashboard, scheduled tasks, session sync, AI Lounge, startup resume, model switching, compact detection, TodoWrite progress embeds, custom Cog loader, permission/elicitation/plan-mode event parsing, and thread inbox classification.
 
 ---
 

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -609,7 +609,7 @@ claude_discord/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-906+ pruebas cubriendo parser, chunker, repositorio, runner, streaming, disparadores webhook, auto-actualización (incluyendo el comando `/upgrade`, invocación desde hilo y botón de aprobación), REST API, UI de AskUserQuestion, panel de hilos, tareas programadas, sincronización de sesiones, AI Lounge, reanudación al inicio, cambio de modelo, detección de compactado, embeds de progreso de TodoWrite, y análisis de eventos de permiso/elicitation/plan-mode.
+1050+ pruebas cubriendo parser, chunker, repositorio, runner, streaming, disparadores webhook, auto-actualización (incluyendo el comando `/upgrade`, invocación desde hilo y botón de aprobación), REST API, UI de AskUserQuestion, panel de hilos, tareas programadas, sincronización de sesiones, AI Lounge, reanudación al inicio, cambio de modelo, detección de compactado, embeds de progreso de TodoWrite, y análisis de eventos de permiso/elicitation/plan-mode.
 
 ---
 

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -609,7 +609,7 @@ claude_discord/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-906+ tests couvrant le parseur, le découpage, le référentiel, le runner, le streaming, les déclencheurs webhook, la mise à jour automatique (incluant la commande `/upgrade`, l'invocation depuis un fil et le bouton d'approbation), l'API REST, l'UI AskUserQuestion, le tableau de bord des fils, les tâches planifiées, la synchronisation de sessions, AI Lounge, la reprise au démarrage, le changement de modèle, la détection de compactage, les embeds de progression TodoWrite, et l'analyse d'événements permission/elicitation/plan-mode.
+1050+ tests couvrant le parseur, le découpage, le référentiel, le runner, le streaming, les déclencheurs webhook, la mise à jour automatique (incluant la commande `/upgrade`, l'invocation depuis un fil et le bouton d'approbation), l'API REST, l'UI AskUserQuestion, le tableau de bord des fils, les tâches planifiées, la synchronisation de sessions, AI Lounge, la reprise au démarrage, le changement de modèle, la détection de compactage, les embeds de progression TodoWrite, et l'analyse d'événements permission/elicitation/plan-mode.
 
 ---
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -817,7 +817,7 @@ examples/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-906 件以上のテストがパーサー、チャンカー、リポジトリ、ランナー、ストリーミング、Webhook トリガー、自動アップグレード（`/upgrade` スラッシュコマンド、スレッド内実行、承認ボタン含む）、REST API、AskUserQuestion UI、スレッドダッシュボード、スケジュールタスク、セッション同期、AI Lounge、スタートアップリジューム、モデル切り替え、コンパクト検出、TodoWrite 進捗 embed、カスタム Cog ローダー、許可／Elicitation／Plan Mode イベントパース、スレッドインボックス分類をカバーしています。
+1050 件以上のテストがパーサー、チャンカー、リポジトリ、ランナー、ストリーミング、Webhook トリガー、自動アップグレード（`/upgrade` スラッシュコマンド、スレッド内実行、承認ボタン含む）、REST API、AskUserQuestion UI、スレッドダッシュボード、スケジュールタスク、セッション同期、AI Lounge、スタートアップリジューム、モデル切り替え、コンパクト検出、TodoWrite 進捗 embed、カスタム Cog ローダー、許可／Elicitation／Plan Mode イベントパース、スレッドインボックス分類をカバーしています。
 
 ---
 

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -349,7 +349,7 @@ CLAUDE_ALLOWED_TOOLS=Read,Glob,Grep
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-906+ 테스트가 파서, 분할기, 저장소, 러너, 스트리밍, 웹훅 트리거, 자동 업그레이드(`/upgrade` 슬래시 명령, 스레드 호출 및 승인 버튼 포함), REST API, AskUserQuestion UI, 스레드 대시보드, 예약 작업, 세션 동기화, AI Lounge, 시작 시 재개, 모델 전환, 압축 감지, TodoWrite 진행 embed, 권한/elicitation/plan-mode 이벤트 파싱을 커버합니다.
+1050+ 테스트가 파서, 분할기, 저장소, 러너, 스트리밍, 웹훅 트리거, 자동 업그레이드(`/upgrade` 슬래시 명령, 스레드 호출 및 승인 버튼 포함), REST API, AskUserQuestion UI, 스레드 대시보드, 예약 작업, 세션 동기화, AI Lounge, 시작 시 재개, 모델 전환, 압축 감지, TodoWrite 진행 embed, 권한/elicitation/plan-mode 이벤트 파싱을 커버합니다.
 
 ---
 

--- a/docs/pt-BR/README.md
+++ b/docs/pt-BR/README.md
@@ -609,7 +609,7 @@ claude_discord/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-906+ testes cobrindo parser, chunker, repositório, runner, streaming, disparadores webhook, auto-atualização (incluindo o comando `/upgrade`, invocação de thread e botão de aprovação), REST API, UI do AskUserQuestion, painel de threads, tarefas agendadas, sincronização de sessões, AI Lounge, retomada na inicialização, troca de modelo, detecção de compactação, embeds de progresso do TodoWrite, e análise de eventos de permissão/elicitation/plan-mode.
+1050+ testes cobrindo parser, chunker, repositório, runner, streaming, disparadores webhook, auto-atualização (incluindo o comando `/upgrade`, invocação de thread e botão de aprovação), REST API, UI do AskUserQuestion, painel de threads, tarefas agendadas, sincronização de sessões, AI Lounge, retomada na inicialização, troca de modelo, detecção de compactação, embeds de progresso do TodoWrite, e análise de eventos de permissão/elicitation/plan-mode.
 
 ---
 

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -629,7 +629,7 @@ claude_discord/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-906+ 个测试覆盖解析器、分块器、仓库、运行器、流式传输、webhook 触发、自动升级（含 `/upgrade` 斜杠命令、线程调用和批准按钮）、REST API、AskUserQuestion UI、线程面板、计划任务、会话同步、AI Lounge、启动恢复、模型切换、压缩检测、TodoWrite 进度 embed，以及权限/elicitation/plan-mode 事件解析。
+1050+ 个测试覆盖解析器、分块器、仓库、运行器、流式传输、webhook 触发、自动升级（含 `/upgrade` 斜杠命令、线程调用和批准按钮）、REST API、AskUserQuestion UI、线程面板、计划任务、会话同步、AI Lounge、启动恢复、模型切换、压缩检测、TodoWrite 进度 embed，以及权限/elicitation/plan-mode 事件解析。
 
 ---
 


### PR DESCRIPTION
## Summary

- Update test count from 906+ to 1050+ across all language READMEs (EN, JA, ZH-CN, KO, ES, FR, PT-BR)
- Reflects new tests added in recent PRs (#305, #307)

## Changes

| File | Change |
|------|--------|
| `README.md` | 906+ → 1050+ |
| `docs/ja/README.md` | 906件以上 → 1050件以上 |
| `docs/zh-CN/README.md` | 906+ → 1050+ |
| `docs/ko/README.md` | 906+ → 1050+ |
| `docs/es/README.md` | 906+ → 1050+ |
| `docs/fr/README.md` | 906+ → 1050+ |
| `docs/pt-BR/README.md` | 906+ → 1050+ |

## Test plan

- [x] Verify actual test count: `uv run pytest tests/ --co -q` → 1054 tests collected
- [x] All language files updated consistently
- [x] No other documentation changes required (recent fixes are internal bug fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
