### PR TITLE
fix: show exception detail in error embed and handle non-dict todo items

### DIFF
--- a/claude_discord/claude/parser.py
+++ b/claude_discord/claude/parser.py
@@ -264,6 +264,8 @@ def _parse_todo_items(tool_input: dict[str, Any]) -> list[TodoItem]:
     todos_raw = tool_input.get("todos", [])
     result: list[TodoItem] = []
     for t in todos_raw:
+        if not isinstance(t, dict):
+            continue
         content = t.get("content", "")
         if not content:
             continue

--- a/claude_discord/cogs/_run_helper.py
+++ b/claude_discord/cogs/_run_helper.py
@@ -211,12 +211,15 @@ async def run_claude_with_config(config: RunConfig) -> str | None:
             if processor.should_drain:
                 continue
             await processor.process(event)
-    except Exception:
+    except Exception as exc:
         logger.exception("Error running Claude CLI for thread %d", config.thread.id)
         # Wrap Discord sends in suppress — the connection may already be closed
         # (e.g. ServerDisconnectedError on bot shutdown), and sending would fail too.
         with contextlib.suppress(Exception):
-            await config.thread.send(embed=error_embed("An unexpected error occurred."))
+            detail = f"{type(exc).__name__}: {exc}"
+            await config.thread.send(
+                embed=error_embed(f"An unexpected error occurred.\n```\n{detail}\n```")
+            )
         if config.status:
             with contextlib.suppress(Exception):
                 await config.status.set_error()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -485,6 +485,22 @@ class TestTodoWriteParsing:
         assert event.todo_list is not None
         assert event.todo_list[0].active_form == ""
 
+    def test_todo_write_string_items_skipped(self):
+        """String items in todos array should be skipped, not crash."""
+        todos = ["some string item", {"content": "Real task", "status": "pending"}]
+        event = parse_line(self._make_todo_line(todos))
+        assert event is not None
+        assert event.todo_list is not None
+        assert len(event.todo_list) == 1
+        assert event.todo_list[0].content == "Real task"
+
+    def test_todo_write_all_string_items(self):
+        """All-string todos array should return empty list, not crash."""
+        todos = ["task 1", "task 2"]
+        event = parse_line(self._make_todo_line(todos))
+        assert event is not None
+        assert event.todo_list == []
+
     def test_exit_plan_mode_sets_is_plan_approval(self):
         import json
 

--- a/tests/test_run_helper.py
+++ b/tests/test_run_helper.py
@@ -481,6 +481,25 @@ class TestRunClaudeInThread:
         assert any("Error" in (c.kwargs["embed"].title or "") for c in embed_calls)
 
     @pytest.mark.asyncio
+    async def test_unexpected_exception_includes_detail_in_embed(
+        self, thread: MagicMock, runner: MagicMock, repo: MagicMock
+    ) -> None:
+        """When an unexpected exception occurs, the error embed should include the detail."""
+
+        async def _failing_run(*args, **kwargs):
+            raise AttributeError("'str' object has no attribute 'get'")
+            yield  # make it an async generator  # noqa: RUF028
+
+        runner.run = _failing_run
+
+        await run_claude_in_thread(thread, runner, repo, "test", None)
+
+        embed_calls = [c for c in thread.send.call_args_list if "embed" in c.kwargs]
+        descriptions = [c.kwargs["embed"].description or "" for c in embed_calls]
+        assert any("AttributeError" in d for d in descriptions)
+        assert any("'str' object has no attribute 'get'" in d for d in descriptions)
+
+    @pytest.mark.asyncio
     async def test_error_embed_send_failure_does_not_raise(
         self, thread: MagicMock, runner: MagicMock, repo: MagicMock
     ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "2.0.12"
+version = "2.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- **Error embed now shows exception detail** instead of just "An unexpected error occurred." — the exception type and message are included in a code block so users can see what actually went wrong
- **Fixed `_parse_todo_items` crash** when Claude sends string items in the `todos` array (was `AttributeError: 'str' object has no attribute 'get'`). Non-dict items are now skipped gracefully
- Root cause of thread 1482156563228790936 failure: Claude sent malformed TodoWrite data → parser crashed → generic error shown

## Test plan

- [x] Added `test_todo_write_string_items_skipped` — mixed string/dict todos
- [x] Added `test_todo_write_all_string_items` — all-string todos returns empty list
- [x] Added `test_unexpected_exception_includes_detail_in_embed` — verifies exception detail in embed
- [x] All existing parser and run_helper tests pass
- [x] ruff check + format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)