### PR TITLE
feat: add plain text format to /api/notify

### DIFF
--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -184,9 +184,13 @@ class ApiServer:
         if not hasattr(raw_channel, "send"):
             return web.json_response({"error": "Channel is not messageable"}, status=400)
 
-        title = data.get("title")
-        embed = self._build_embed(message=message, title=title, color=data.get("color"))
-        await raw_channel.send(embed=embed)  # type: ignore[union-attr]
+        fmt = data.get("format", "embed")
+        if fmt == "text":
+            await raw_channel.send(message)  # type: ignore[union-attr]
+        else:
+            title = data.get("title")
+            embed = self._build_embed(message=message, title=title, color=data.get("color"))
+            await raw_channel.send(embed=embed)  # type: ignore[union-attr]
 
         return web.json_response({"status": "sent"})
 

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -97,6 +97,13 @@ class TestNotify:
         assert resp.status == 400
 
     @pytest.mark.asyncio
+    async def test_notify_text_format(self, client: TestClient, bot: MagicMock) -> None:
+        channel = bot.get_channel.return_value
+        resp = await client.post("/api/notify", json={"message": "Hello text!", "format": "text"})
+        assert resp.status == 200
+        channel.send.assert_called_once_with("Hello text!")
+
+    @pytest.mark.asyncio
     async def test_notify_no_channel(self, repo: NotificationRepository) -> None:
         bot = MagicMock()
         api = ApiServer(repo=repo, bot=bot, default_channel_id=None)

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "2.0.13"
+version = "2.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- `/api/notify` に `format: "text"` パラメータを追加
- Embed形式（カード）ではなくプレーンテキストとして送信できるようになる
- デフォルトは従来通り `embed` なので後方互換性あり

## Motivation
Discord Embed内の `<@ID>` メンションは通知が飛ばない仕様。goodmorning通知でメンションが機能しなかった問題を解決。

## Test plan
- [x] `test_notify_text_format` テスト追加・通過
- [x] 既存テスト全通過
- [x] ruff lint/format 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)