### PR TITLE
feat: add poll parameter to /api/notify endpoint

### DIFF
--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -19,7 +19,7 @@ import logging
 import os
 import re
 from collections.abc import Awaitable, Callable
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 from aiohttp import web
@@ -184,8 +184,19 @@ class ApiServer:
         if not hasattr(raw_channel, "send"):
             return web.json_response({"error": "Channel is not messageable"}, status=400)
 
+        # Build poll if specified
+        poll_data = data.get("poll")
+        poll_obj = None
+        if poll_data:
+            result = self._build_poll(poll_data)
+            if isinstance(result, web.Response):
+                return result
+            poll_obj = result
+
         fmt = data.get("format", "embed")
-        if fmt == "text":
+        if poll_obj:
+            await raw_channel.send(content=message, poll=poll_obj)  # type: ignore[union-attr]
+        elif fmt == "text":
             await raw_channel.send(message)  # type: ignore[union-attr]
         else:
             title = data.get("title")
@@ -627,6 +638,44 @@ class ApiServer:
                 await channel.send(f"**[{label}]** {message} *({timestamp})*")  # type: ignore[union-attr]
         except Exception:
             logger.warning("Failed to forward lounge message to Discord", exc_info=True)
+
+    @staticmethod
+    def _build_poll(poll_data: dict) -> discord.Poll | web.Response:
+        """Build a discord.Poll from API request data.
+
+        Returns a Poll on success, or a web.Response (400) on validation error.
+        """
+        import discord
+
+        question = poll_data.get("question")
+        if not question:
+            return web.json_response({"error": "poll.question is required"}, status=400)
+
+        answers = poll_data.get("answers")
+        if not answers or len(answers) < 2:
+            return web.json_response(
+                {"error": "poll.answers must have at least 2 items"}, status=400
+            )
+
+        duration_hours = poll_data.get("duration_hours", 24)
+        allow_multiselect = poll_data.get("allow_multiselect", False)
+
+        poll = discord.Poll(
+            question=question,
+            duration=timedelta(hours=duration_hours),
+            multiple=allow_multiselect,
+        )
+
+        for answer in answers:
+            if isinstance(answer, str):
+                poll.add_answer(text=answer)
+            elif isinstance(answer, dict):
+                kwargs: dict = {"text": answer["text"]}
+                if "emoji" in answer:
+                    kwargs["emoji"] = answer["emoji"]
+                poll.add_answer(**kwargs)
+
+        return poll
 
     @staticmethod
     def _build_embed(

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -117,6 +117,133 @@ class TestNotify:
             await client.close()
 
 
+class TestNotifyPoll:
+    """Tests for poll parameter in /api/notify."""
+
+    @pytest.mark.asyncio
+    async def test_notify_with_poll(self, client: TestClient, bot: MagicMock) -> None:
+        """Poll object is constructed and passed to channel.send()."""
+        channel = bot.get_channel.return_value
+        resp = await client.post(
+            "/api/notify",
+            json={
+                "message": "投票してね",
+                "poll": {
+                    "question": "好きな言語は？",
+                    "answers": ["Python", "Go", "Rust"],
+                    "duration_hours": 24,
+                },
+            },
+        )
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["status"] == "sent"
+        call_kwargs = channel.send.call_args.kwargs
+        assert "poll" in call_kwargs
+        poll = call_kwargs["poll"]
+        # discord.py may store question as str or PollMedia depending on version
+        q = poll.question
+        assert (q.text if hasattr(q, "text") else q) == "好きな言語は？"
+        assert len(poll.answers) == 3
+        assert poll.duration.total_seconds() == 24 * 3600
+
+    @pytest.mark.asyncio
+    async def test_notify_poll_with_multiselect(self, client: TestClient, bot: MagicMock) -> None:
+        """allow_multiselect flag is passed through."""
+        channel = bot.get_channel.return_value
+        resp = await client.post(
+            "/api/notify",
+            json={
+                "message": "複数選択OK",
+                "poll": {
+                    "question": "好きな食べ物は？",
+                    "answers": ["寿司", "ラーメン", "カレー"],
+                    "duration_hours": 48,
+                    "allow_multiselect": True,
+                },
+            },
+        )
+        assert resp.status == 200
+        poll = channel.send.call_args.kwargs["poll"]
+        assert poll.multiple is True
+
+    @pytest.mark.asyncio
+    async def test_notify_poll_default_duration(self, client: TestClient, bot: MagicMock) -> None:
+        """Default duration is 24 hours when not specified."""
+        channel = bot.get_channel.return_value
+        resp = await client.post(
+            "/api/notify",
+            json={
+                "message": "デフォルト期間テスト",
+                "poll": {
+                    "question": "テスト？",
+                    "answers": ["はい", "いいえ"],
+                },
+            },
+        )
+        assert resp.status == 200
+        poll = channel.send.call_args.kwargs["poll"]
+        assert poll.duration.total_seconds() == 24 * 3600
+
+    @pytest.mark.asyncio
+    async def test_notify_poll_missing_question(self, client: TestClient) -> None:
+        """Poll without question returns 400."""
+        resp = await client.post(
+            "/api/notify",
+            json={
+                "message": "テスト",
+                "poll": {"answers": ["A", "B"]},
+            },
+        )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_notify_poll_missing_answers(self, client: TestClient) -> None:
+        """Poll without answers returns 400."""
+        resp = await client.post(
+            "/api/notify",
+            json={
+                "message": "テスト",
+                "poll": {"question": "テスト？"},
+            },
+        )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_notify_poll_too_few_answers(self, client: TestClient) -> None:
+        """Poll with fewer than 2 answers returns 400."""
+        resp = await client.post(
+            "/api/notify",
+            json={
+                "message": "テスト",
+                "poll": {"question": "テスト？", "answers": ["ひとつだけ"]},
+            },
+        )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_notify_poll_with_emoji_answers(self, client: TestClient, bot: MagicMock) -> None:
+        """Answers with emoji objects are supported."""
+        channel = bot.get_channel.return_value
+        resp = await client.post(
+            "/api/notify",
+            json={
+                "message": "絵文字付き",
+                "poll": {
+                    "question": "どれがいい？",
+                    "answers": [
+                        {"text": "Python", "emoji": "🐍"},
+                        {"text": "Go", "emoji": "🐹"},
+                    ],
+                    "duration_hours": 24,
+                },
+            },
+        )
+        assert resp.status == 200
+        poll = channel.send.call_args.kwargs["poll"]
+        assert len(poll.answers) == 2
+
+
 class TestSchedule:
     @pytest.mark.asyncio
     async def test_schedule_creates_notification(self, client: TestClient) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "2.0.14"
+version = "2.0.15"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Add `poll` parameter to `POST /api/notify` to create Discord polls via REST API
- Uses discord.py's native `discord.Poll` (v2.6+) — no raw HTTP needed
- Supports: question, answers (string or {text, emoji}), duration_hours, allow_multiselect
- Validates: question required, minimum 2 answers
- 7 new tests covering all poll scenarios

## Usage

```bash
curl -s -X POST http://127.0.0.1:8099/api/notify \
  -H "Content-Type: application/json" \
  -d '{
    "message": "Vote!",
    "poll": {
      "question": "Favorite language?",
      "answers": ["Python", "Go", "Rust"],
      "duration_hours": 24,
      "allow_multiselect": true
    }
  }'
```

## Test plan

- [x] All 7 new poll tests pass
- [x] All 41 existing tests still pass
- [x] ruff check + format clean
- [ ] Manual test with EbiBot via dev worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)