### PR TITLE
[docs-sync] Document format:text and poll options for /api/notify

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,11 +714,31 @@ uv add "claude-code-discord-bridge[api]"
 | POST | `/api/lounge` | Post a message to the AI Lounge (with optional `label`) |
 
 ```bash
-# Send notification
+# Send notification (embed format, default)
 curl -X POST http://localhost:8080/api/notify \
   -H "Authorization: Bearer your-secret" \
   -H "Content-Type: application/json" \
   -d '{"message": "Build succeeded!", "title": "CI/CD"}'
+
+# Send plain text notification (no embed)
+curl -X POST http://localhost:8080/api/notify \
+  -H "Authorization: Bearer your-secret" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Deployment done!", "format": "text"}'
+
+# Send a Discord Poll
+curl -X POST http://localhost:8080/api/notify \
+  -H "Authorization: Bearer your-secret" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "message": "Vote now",
+    "poll": {
+      "question": "Which release track?",
+      "answers": ["Stable", "Beta", "Nightly"],
+      "duration_hours": 24,
+      "allow_multiselect": false
+    }
+  }'
 
 # Register a recurring task
 curl -X POST http://localhost:8080/api/tasks \

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -715,11 +715,31 @@ uv add "claude-code-discord-bridge[api]"
 | POST | `/api/lounge` | AI Lounge にメッセージを投稿（`label` オプション） |
 
 ```bash
-# 通知の送信
+# 通知の送信（埋め込み形式、デフォルト）
 curl -X POST http://localhost:8080/api/notify \
   -H "Authorization: Bearer your-secret" \
   -H "Content-Type: application/json" \
   -d '{"message": "ビルド成功！", "title": "CI/CD"}'
+
+# プレーンテキスト通知の送信（埋め込みなし）
+curl -X POST http://localhost:8080/api/notify \
+  -H "Authorization: Bearer your-secret" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "デプロイ完了！", "format": "text"}'
+
+# Discord Poll の送信
+curl -X POST http://localhost:8080/api/notify \
+  -H "Authorization: Bearer your-secret" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "message": "投票してください",
+    "poll": {
+      "question": "次のリリーストラックは？",
+      "answers": ["安定版", "ベータ版", "ナイトリー"],
+      "duration_hours": 24,
+      "allow_multiselect": false
+    }
+  }'
 
 # 定期タスクの登録
 curl -X POST http://localhost:8080/api/tasks \


### PR DESCRIPTION
## Summary

- Add `format: "text"` example to `/api/notify` curl samples (PR #311)
- Add `poll` parameter examples to `/api/notify` curl samples (PR #312)
- Update Japanese translation (`docs/ja/README.md`) with same changes

## Changes

Both README.md and docs/ja/README.md updated with:
1. Plain text format example (`"format": "text"`)
2. Discord Poll example (`poll` object with `question`, `answers`, `duration_hours`, `allow_multiselect`)

## Test plan

- [ ] Verify curl examples are syntactically correct JSON
- [ ] Verify Japanese translation is accurate and natural

🤖 Generated with [Claude Code](https://claude.com/claude-code)
