### PR TITLE
feat: add chat_only mode for public channels

### DIFF
--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -95,6 +95,7 @@ class ClaudeChatCog(commands.Cog):
         channel_ids: set[int] | None = None,
         mention_only_channel_ids: set[int] | None = None,
         inline_reply_channel_ids: set[int] | None = None,
+        chat_only_channel_ids: set[int] | None = None,
         auto_rename_threads: bool = False,
     ) -> None:
         self.bot = bot
@@ -114,6 +115,8 @@ class ClaudeChatCog(commands.Cog):
         self._mention_only_channel_ids: set[int] = mention_only_channel_ids or set()
         # Channels where the bot replies directly (no thread created).
         self._inline_reply_channel_ids: set[int] = inline_reply_channel_ids or set()
+        # Channels where only text responses are shown (no tool embeds, thinking, etc.).
+        self._chat_only_channel_ids: set[int] = chat_only_channel_ids or set()
         self._registry = registry or getattr(bot, "session_registry", None)
         self._semaphore = asyncio.Semaphore(max_concurrent)
         self._active_runners: dict[int, ClaudeRunner] = {}
@@ -423,20 +426,33 @@ class ClaudeChatCog(commands.Cog):
     async def _handle_new_conversation(self, message: discord.Message) -> None:
         """Start a Claude Code session, creating a thread unless inline-reply mode is active."""
         prompt, image_urls = await self._build_prompt_and_images(message)
+        chat_only = message.channel.id in self._chat_only_channel_ids
         if (
             isinstance(message.channel, discord.TextChannel)
             and message.channel.id in self._inline_reply_channel_ids
         ):
             # Inline-reply mode: respond directly in the channel without creating a thread.
             await self._run_claude(
-                message, message.channel, prompt, session_id=None, image_urls=image_urls
+                message,
+                message.channel,
+                prompt,
+                session_id=None,
+                image_urls=image_urls,
+                chat_only=chat_only,
             )
         else:
             thread_name = message.content[:100] if message.content else "Claude Chat"
             thread = await message.create_thread(name=thread_name)
             if self._auto_rename_threads and message.content:
                 asyncio.create_task(self._background_rename_thread(thread, message.content))
-            await self._run_claude(message, thread, prompt, session_id=None, image_urls=image_urls)
+            await self._run_claude(
+                message,
+                thread,
+                prompt,
+                session_id=None,
+                image_urls=image_urls,
+                chat_only=chat_only,
+            )
 
     async def _background_rename_thread(
         self,
@@ -677,6 +693,8 @@ class ClaudeChatCog(commands.Cog):
                 with contextlib.suppress(Exception):
                     await existing_task
 
+        # Determine chat_only from the parent channel of this thread.
+        chat_only = (thread.parent_id or 0) in self._chat_only_channel_ids
         await self._run_claude(
             message,
             thread,
@@ -684,6 +702,7 @@ class ClaudeChatCog(commands.Cog):
             session_id=session_id,
             image_urls=image_urls,
             working_dir_override=record.working_dir if record else None,
+            chat_only=chat_only,
         )
 
     async def _build_prompt_and_images(self, message: discord.Message) -> tuple[str, list[str]]:
@@ -699,6 +718,7 @@ class ClaudeChatCog(commands.Cog):
         image_urls: list[str] | None = None,
         fork: bool = False,
         working_dir_override: str | None = None,
+        chat_only: bool = False,
     ) -> None:
         """Execute Claude Code CLI and stream results to the thread."""
         if self._semaphore.locked():
@@ -755,9 +775,12 @@ class ClaudeChatCog(commands.Cog):
             )
             self._active_runners[thread.id] = runner
 
-            stop_view = StopView(runner)
-            stop_msg = await thread.send("-# ⏺ Session running", view=stop_view)
-            stop_view.set_message(stop_msg)
+            # In chat_only mode, skip the "Session running" message and stop button.
+            stop_view: StopView | None = None
+            if not chat_only:
+                stop_view = StopView(runner)
+                stop_msg = await thread.send("-# ⏺ Session running", view=stop_view)
+                stop_view.set_message(stop_msg)
 
             try:
                 await run_claude_with_config(
@@ -778,10 +801,12 @@ class ClaudeChatCog(commands.Cog):
                         inbox_repo=getattr(self.bot, "inbox_repo", None),
                         inbox_dashboard=dashboard,
                         claude_command=runner.command,
+                        chat_only=chat_only,
                     )
                 )
             finally:
-                await stop_view.disable()
+                if stop_view is not None:
+                    await stop_view.disable()
                 self._active_runners.pop(thread.id, None)
                 self._active_tasks.pop(thread.id, None)
 

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -206,19 +206,25 @@ class EventProcessor:
     # Event handlers
     # ------------------------------------------------------------------
 
+    @property
+    def _chat_only(self) -> bool:
+        """Shorthand for the chat_only flag on the config."""
+        return self._config.chat_only
+
     async def _on_system(self, event: StreamEvent) -> None:
         """Handle SYSTEM events — capture session_id, post start embed, compact notification."""
-        # Context compaction notification
+        # Context compaction notification (skip display in chat_only mode)
         if event.is_compact:
             if self._config.status:
                 await self._config.status.set_compact()
-            pre = event.compact_pre_tokens
-            trigger = event.compact_trigger or "auto"
-            label = f"\U0001f5dc\ufe0f Context compacted ({trigger})"
-            if pre:
-                label += f" \u2014 was {pre:,} tokens"
-            with contextlib.suppress(discord.HTTPException):
-                await self._config.thread.send(f"-# {label}")
+            if not self._chat_only:
+                pre = event.compact_pre_tokens
+                trigger = event.compact_trigger or "auto"
+                label = f"\U0001f5dc\ufe0f Context compacted ({trigger})"
+                if pre:
+                    label += f" \u2014 was {pre:,} tokens"
+                with contextlib.suppress(discord.HTTPException):
+                    await self._config.thread.send(f"-# {label}")
 
             # Interrupt the runner so _run_helper can rerun with a guardrail.
             # Skip when post_compact_rerun=True (guardrail already active; avoid loops).
@@ -226,12 +232,12 @@ class EventProcessor:
                 self._compact_occurred = True
                 await self._config.runner.interrupt()
 
-        # Permission request — show Allow/Deny buttons
+        # Permission request — show Allow/Deny buttons (always shown, even in chat_only)
         if event.permission_request is not None:
             await self._handle_permission_request(event)
             return
 
-        # MCP elicitation — show form or URL button
+        # MCP elicitation — show form or URL button (always shown, even in chat_only)
         if event.elicitation is not None:
             await self._handle_elicitation(event)
             return
@@ -244,37 +250,48 @@ class EventProcessor:
             await self._config.repo.save(self._config.thread.id, self._state.session_id)
 
         # Guard: post session_start_embed only once (Claude can emit multiple SYSTEM events).
-        if not self._config.session_id and not self._session_start_sent:
+        # Skip in chat_only mode — no session start embed.
+        if not self._chat_only and not self._config.session_id and not self._session_start_sent:
             await self._config.thread.send(embed=session_start_embed(self._state.session_id))
             self._session_start_sent = True
 
     async def _on_assistant(self, event: StreamEvent) -> None:
         """Handle ASSISTANT events — thinking, streaming text, tool use."""
         # Extended thinking — only post on complete events (not partials).
-        if event.thinking and not event.is_partial:
+        # Skip in chat_only mode.
+        if event.thinking and not event.is_partial and not self._chat_only:
             await self._config.thread.send(embed=thinking_embed(event.thinking))
 
-        # Redacted thinking — only post on complete events.
-        if event.has_redacted_thinking and not event.is_partial:
+        # Redacted thinking — only post on complete events. Skip in chat_only mode.
+        if event.has_redacted_thinking and not event.is_partial and not self._chat_only:
             await self._config.thread.send(embed=redacted_thinking_embed())
 
         # Text streaming — compute delta from last partial, edit in place.
+        # Always shown — this IS the chat content.
         if event.text:
             await self._handle_text(event)
 
-        # Tool use — post embed and start live timer.
+        # Tool use — post embed and start live timer. Skip in chat_only mode.
         if event.tool_use:
-            await self._handle_tool_use(event)
+            if self._chat_only:
+                # Still track tool use count and update status, but don't post embeds.
+                self._state.tool_use_count += 1
+                if self._config.status:
+                    await self._config.status.set_tool(event.tool_use.category)
+            else:
+                await self._handle_tool_use(event)
 
-        # TodoWrite — post or edit the live todo progress embed.
-        if event.todo_list is not None:
+        # TodoWrite — post or edit the live todo progress embed. Skip in chat_only mode.
+        if event.todo_list is not None and not self._chat_only:
             await self._handle_todo_write(event)
 
         # ExitPlanMode — show plan embed with Approve/Cancel buttons.
-        if event.is_plan_approval and not event.is_partial:
+        # Skip in chat_only mode.
+        if event.is_plan_approval and not event.is_partial and not self._chat_only:
             await self._handle_plan_approval(event)
 
         # AskUserQuestion — set pending and signal caller to interrupt runner.
+        # Always handled — interactive flow is needed regardless of mode.
         if event.ask_questions:
             self._pending_ask = event.ask_questions
             await self._config.runner.interrupt()
@@ -282,6 +299,12 @@ class EventProcessor:
     async def _on_tool_result(self, event: StreamEvent) -> None:
         """Handle USER events (tool results) — cancel timer, update embed."""
         if not event.tool_result_id:
+            return
+
+        # In chat_only mode, no tool embeds were posted — just reset status.
+        if self._chat_only:
+            if self._config.status:
+                await self._config.status.set_thinking()
             return
 
         if self._config.status:
@@ -375,49 +398,55 @@ class EventProcessor:
                 self._config.runner.working_dir,
             )
 
-            await self._config.thread.send(
-                embed=session_complete_embed(
-                    event.cost_usd,
-                    event.duration_ms,
-                    event.input_tokens,
-                    event.output_tokens,
-                    event.cache_read_tokens,
-                    event.context_window,
-                    event.cache_creation_tokens,
+            # In chat_only mode, skip session_complete embed, statusline, and inbox.
+            # Just set the done status emoji.
+            if self._chat_only:
+                if self._config.status:
+                    await self._config.status.set_done()
+            else:
+                await self._config.thread.send(
+                    embed=session_complete_embed(
+                        event.cost_usd,
+                        event.duration_ms,
+                        event.input_tokens,
+                        event.output_tokens,
+                        event.cache_read_tokens,
+                        event.context_window,
+                        event.cache_creation_tokens,
+                    )
                 )
-            )
-            if self._config.status:
-                await self._config.status.set_done()
+                if self._config.status:
+                    await self._config.status.set_done()
 
-            # Post the user's configured statusLine as Discord subtext.
-            # Runs only when statusLine.command is set in ~/.claude/settings.json.
-            asyncio.create_task(
-                _post_statusline_footer(
-                    thread=self._config.thread,
-                    working_dir=self._config.runner.working_dir,
-                    model=self._config.runner.model,
-                    context_window=event.context_window,
-                    input_tokens=event.input_tokens,
-                    cache_creation_tokens=event.cache_creation_tokens,
-                    cache_read_tokens=event.cache_read_tokens,
-                ),
-                name=f"statusline-{self._config.thread.id}",
-            )
-
-            # Schedule inbox classification as a background task (non-blocking).
-            # Only runs when inbox_repo is wired in (THREAD_INBOX_ENABLED=true).
-            if self._config.inbox_repo is not None and last_assistant_text:
+                # Post the user's configured statusLine as Discord subtext.
+                # Runs only when statusLine.command is set in ~/.claude/settings.json.
                 asyncio.create_task(
-                    _classify_and_update_inbox(
-                        thread_id=self._config.thread.id,
-                        last_text=last_assistant_text,
-                        last_message_url=last_assistant_url,
-                        inbox_repo=self._config.inbox_repo,
-                        dashboard=self._config.inbox_dashboard,
-                        claude_command=self._config.claude_command,
+                    _post_statusline_footer(
+                        thread=self._config.thread,
+                        working_dir=self._config.runner.working_dir,
+                        model=self._config.runner.model,
+                        context_window=event.context_window,
+                        input_tokens=event.input_tokens,
+                        cache_creation_tokens=event.cache_creation_tokens,
+                        cache_read_tokens=event.cache_read_tokens,
                     ),
-                    name=f"inbox-classify-{self._config.thread.id}",
+                    name=f"statusline-{self._config.thread.id}",
                 )
+
+                # Schedule inbox classification as a background task (non-blocking).
+                # Only runs when inbox_repo is wired in (THREAD_INBOX_ENABLED=true).
+                if self._config.inbox_repo is not None and last_assistant_text:
+                    asyncio.create_task(
+                        _classify_and_update_inbox(
+                            thread_id=self._config.thread.id,
+                            last_text=last_assistant_text,
+                            last_message_url=last_assistant_url,
+                            inbox_repo=self._config.inbox_repo,
+                            dashboard=self._config.inbox_dashboard,
+                            claude_command=self._config.claude_command,
+                        ),
+                        name=f"inbox-classify-{self._config.thread.id}",
+                    )
 
         if event.session_id:
             if self._config.repo:

--- a/claude_discord/cogs/run_config.py
+++ b/claude_discord/cogs/run_config.py
@@ -81,6 +81,10 @@ class RunConfig:
     # When True, a compact guardrail was already injected into --append-system-prompt
     # for this run. Prevents infinite interrupt→rerun loops if compact fires again.
     post_compact_rerun: bool = False
+    # When True, only text responses are shown to Discord. Tool embeds, thinking
+    # blocks, session start/complete embeds, and other technical details are hidden.
+    # Useful for public channels where non-technical users are watching.
+    chat_only: bool = False
 
     # Prevent accidental field mutation — RunConfig is a value object.
     # Use dataclasses.replace() to create modified copies.

--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -73,6 +73,7 @@ async def setup_bridge(
     claude_channel_ids: set[int] | None = None,
     mention_only_channel_ids: set[int] | None = None,
     inline_reply_channel_ids: set[int] | None = None,
+    chat_only_channel_ids: set[int] | None = None,
     cli_sessions_path: str | None = None,
     enable_scheduler: bool = True,
     task_db_path: str = "data/tasks.db",
@@ -110,6 +111,11 @@ async def setup_bridge(
                                   affected (they are already within an active session).
                                   Defaults to MENTION_ONLY_CHANNEL_IDS env var
                                   (comma-separated).
+        chat_only_channel_ids: Channel IDs where only text responses are shown.
+                               Tool embeds, thinking blocks, and session chrome are
+                               hidden.  Useful for public channels where non-technical
+                               users are watching.  Defaults to CHAT_ONLY_CHANNEL_IDS
+                               env var (comma-separated).
         cli_sessions_path: Path to ~/.claude/projects for session sync.
         enable_scheduler: Whether to enable SchedulerCog.
         task_db_path: Path for scheduled tasks SQLite DB.
@@ -161,6 +167,13 @@ async def setup_bridge(
         _env_inline = os.getenv("INLINE_REPLY_CHANNEL_IDS", "")
         inline_reply_channel_ids = {
             int(x.strip()) for x in _env_inline.split(",") if x.strip().isdigit()
+        } or None
+
+    # Chat-only channels — fall back to CHAT_ONLY_CHANNEL_IDS env var
+    if chat_only_channel_ids is None:
+        _env_chat_only = os.getenv("CHAT_ONLY_CHANNEL_IDS", "")
+        chat_only_channel_ids = {
+            int(x.strip()) for x in _env_chat_only.split(",") if x.strip().isdigit()
         } or None
 
     # Lounge channel — fall back to COORDINATION_CHANNEL_ID env var for backward compat
@@ -221,6 +234,7 @@ async def setup_bridge(
         channel_ids=_all_channel_ids or None,
         mention_only_channel_ids=mention_only_channel_ids or None,
         inline_reply_channel_ids=inline_reply_channel_ids or None,
+        chat_only_channel_ids=chat_only_channel_ids or None,
         auto_rename_threads=auto_rename_threads,
     )
     await bot.add_cog(chat_cog)

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -1062,3 +1062,140 @@ class TestRateLimitEventProcessing:
             ),
         )
         await p.process(event)  # should not raise
+
+
+class TestChatOnlyMode:
+    """chat_only mode hides tool embeds, thinking, session chrome but keeps text."""
+
+    def _make_chat_only_config(self, thread: MagicMock, runner: MagicMock, **kwargs) -> RunConfig:
+        return _make_config(thread, runner, chat_only=True, **kwargs)
+
+    @pytest.mark.asyncio
+    async def test_no_session_start_embed(self, thread: MagicMock, runner: MagicMock) -> None:
+        """chat_only skips the session_start embed for new sessions."""
+        config = self._make_chat_only_config(thread, runner)
+        p = EventProcessor(config)
+
+        await p.process(StreamEvent(message_type=MessageType.SYSTEM, session_id="s1"))
+
+        # No embed should be sent
+        embed_sends = [c for c in thread.send.call_args_list if "embed" in c.kwargs]
+        assert len(embed_sends) == 0
+
+    @pytest.mark.asyncio
+    async def test_thinking_not_shown(self, thread: MagicMock, runner: MagicMock) -> None:
+        """chat_only hides thinking embeds."""
+        config = self._make_chat_only_config(thread, runner)
+        p = EventProcessor(config)
+
+        event = StreamEvent(
+            message_type=MessageType.ASSISTANT,
+            thinking="I am thinking...",
+            is_partial=False,
+        )
+        await p.process(event)
+
+        embed_sends = [c for c in thread.send.call_args_list if "embed" in c.kwargs]
+        assert len(embed_sends) == 0
+
+    @pytest.mark.asyncio
+    async def test_tool_use_no_embed(self, thread: MagicMock, runner: MagicMock) -> None:
+        """chat_only does not post tool use embeds but still counts them."""
+        config = self._make_chat_only_config(thread, runner)
+        p = EventProcessor(config)
+
+        await p.process(_make_tool_event("t1"))
+
+        # No embed sent
+        embed_sends = [c for c in thread.send.call_args_list if "embed" in c.kwargs]
+        assert len(embed_sends) == 0
+        # But tool_use_count is incremented
+        assert p._state.tool_use_count == 1
+
+    @pytest.mark.asyncio
+    async def test_text_still_shown(self, thread: MagicMock, runner: MagicMock) -> None:
+        """chat_only still sends text responses."""
+        config = self._make_chat_only_config(thread, runner)
+        p = EventProcessor(config)
+
+        event = StreamEvent(message_type=MessageType.ASSISTANT, text="Hello!", is_partial=False)
+        await p.process(event)
+
+        text_sends = [
+            c for c in thread.send.call_args_list if c.args and isinstance(c.args[0], str)
+        ]
+        assert any("Hello!" in c.args[0] for c in text_sends)
+
+    @pytest.mark.asyncio
+    async def test_tool_result_resets_status_only(
+        self, thread: MagicMock, runner: MagicMock
+    ) -> None:
+        """chat_only tool result resets status without updating embeds."""
+        status = MagicMock()
+        status.set_thinking = AsyncMock()
+        status.set_tool = AsyncMock()
+        config = self._make_chat_only_config(thread, runner, status=status)
+        p = EventProcessor(config)
+
+        result_event = StreamEvent(
+            message_type=MessageType.USER,
+            tool_result_id="t1",
+            tool_result_content="output",
+        )
+        await p.process(result_event)
+
+        status.set_thinking.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_complete_no_session_embed(self, thread: MagicMock, runner: MagicMock) -> None:
+        """chat_only skips session_complete embed on RESULT."""
+        status = MagicMock()
+        status.set_done = AsyncMock()
+        config = self._make_chat_only_config(thread, runner, status=status)
+        p = EventProcessor(config)
+
+        await p.process(_make_result_event(session_id="s1"))
+
+        # No session_complete embed sent
+        embed_sends = [c for c in thread.send.call_args_list if "embed" in c.kwargs]
+        assert len(embed_sends) == 0
+        # But done status is set
+        status.set_done.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_ask_user_question_still_handled(
+        self, thread: MagicMock, runner: MagicMock
+    ) -> None:
+        """AskUserQuestion is always processed even in chat_only mode."""
+        runner.interrupt = AsyncMock()
+        config = self._make_chat_only_config(thread, runner)
+        p = EventProcessor(config)
+
+        ask = AskQuestion(
+            question="Which option?",
+            options=[AskOption(label="A"), AskOption(label="B")],
+        )
+        event = StreamEvent(
+            message_type=MessageType.ASSISTANT,
+            ask_questions=[ask],
+        )
+        await p.process(event)
+
+        assert p.pending_ask == [ask]
+        runner.interrupt.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_compact_notification_hidden(self, thread: MagicMock, runner: MagicMock) -> None:
+        """chat_only hides the compact notification message."""
+        runner.interrupt = AsyncMock()
+        thread.send = AsyncMock(return_value=MagicMock(embeds=[]))
+        config = self._make_chat_only_config(thread, runner)
+        p = EventProcessor(config)
+
+        await p.process(StreamEvent(message_type=MessageType.SYSTEM, is_compact=True))
+
+        # No compact message sent to thread (only interrupt happened)
+        text_sends = [
+            c for c in thread.send.call_args_list if c.args and isinstance(c.args[0], str)
+        ]
+        assert not any("compact" in str(c).lower() for c in text_sends)

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "2.0.14"
+version = "2.0.15"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- Add `chat_only` mode that shows only text responses in Discord, hiding tool embeds, thinking blocks, session chrome, and other technical details
- Configured via `CHAT_ONLY_CHANNEL_IDS` env var or `setup_bridge()` parameter
- Permission requests and AskUserQuestion are always shown regardless of mode
- Threads created in chat_only channels inherit the mode

## Changes
- `RunConfig`: add `chat_only: bool` field
- `EventProcessor`: skip embeds/chrome when `chat_only` is True
- `ClaudeChatCog`: determine `chat_only` from channel ID or parent channel ID
- `setup_bridge()`: add `chat_only_channel_ids` parameter with env var fallback
- 8 new tests covering all chat_only behavior

## Test plan
- [x] 8 unit tests for EventProcessor chat_only behavior
- [ ] Set `CHAT_ONLY_CHANNEL_IDS` in .env and verify in Discord
- [ ] Verify text responses appear normally
- [ ] Verify tool embeds are hidden
- [ ] Verify permission requests still appear

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)