### PR TITLE
feat: add auto_start parameter to /api/spawn

### DIFF
--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -479,8 +479,9 @@ class ClaudeChatCog(commands.Cog):
         thread_name: str | None = None,
         session_id: str | None = None,
         fork: bool = False,
+        auto_start: bool = True,
     ) -> discord.Thread:
-        """Create a new thread and start a Claude Code session without a user message.
+        """Create a new thread and optionally start a Claude Code session.
 
         This is the API-initiated equivalent of ``_handle_new_conversation``.
         It bypasses the ``on_message`` bot-author guard, enabling programmatic
@@ -497,6 +498,10 @@ class ClaudeChatCog(commands.Cog):
             session_id: Optional Claude session ID to resume via ``--resume``.
                         When supplied the new Claude process continues the
                         previous conversation rather than starting fresh.
+            auto_start: Whether to immediately start a Claude Code session.
+                        When ``False``, only the thread and seed message are
+                        created — a Claude session will start when a user
+                        replies in the thread.  Defaults to ``True``.
 
         Returns:
             The newly created :class:`discord.Thread`.
@@ -509,11 +514,12 @@ class ClaudeChatCog(commands.Cog):
         )
         # Post the prompt so StatusManager has a Message to add reactions to.
         seed_message = await thread.send(prompt)
-        # Run Claude in the background so /api/spawn returns immediately.
-        # The caller gets the thread reference without waiting for Claude to finish.
-        asyncio.create_task(
-            self._run_claude(seed_message, thread, prompt, session_id=session_id, fork=fork)
-        )
+        if auto_start:
+            # Run Claude in the background so /api/spawn returns immediately.
+            # The caller gets the thread reference without waiting for Claude to finish.
+            asyncio.create_task(
+                self._run_claude(seed_message, thread, prompt, session_id=session_id, fork=fork)
+            )
         return thread
 
     async def cog_unload(self) -> None:

--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -466,7 +466,7 @@ class ApiServer:
     # ------------------------------------------------------------------
 
     async def spawn(self, request: web.Request) -> web.Response:
-        """POST /api/spawn — create a new Discord thread and start Claude Code.
+        """POST /api/spawn — create a new Discord thread and optionally start Claude Code.
 
         Unlike posting a message to the channel directly, this endpoint
         bypasses the ``on_message`` bot-author guard and works even when
@@ -478,6 +478,10 @@ class ApiServer:
                 ``default_channel_id`` configured at startup).
             thread_name: Custom thread title (optional; defaults to the
                 first 100 characters of *prompt*).
+            auto_start: Whether to immediately start a Claude Code session
+                (optional; defaults to ``true``).  When ``false``, only the
+                thread and seed message are created — a Claude session will
+                start when a user replies in the thread.
 
         Returns (201):
             ``{"status": "spawned", "thread_id": "...", "thread_name": "..."}``
@@ -526,9 +530,15 @@ class ApiServer:
             )
 
         thread_name: str | None = data.get("thread_name") or None
+        auto_start: bool = data.get("auto_start", True)
 
         try:
-            thread = await cog.spawn_session(raw, prompt, thread_name=thread_name)
+            thread = await cog.spawn_session(
+                raw,
+                prompt,
+                thread_name=thread_name,
+                auto_start=auto_start,
+            )
         except Exception as exc:
             logger.error("spawn_session failed: %s", exc, exc_info=True)
             return web.json_response({"error": str(exc)}, status=500)

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -482,6 +482,25 @@ class TestSpawn:
             await client.close()
 
     @pytest.mark.asyncio
+    async def test_spawn_auto_start_defaults_to_true(
+        self, spawn_client: TestClient, mock_cog: MagicMock
+    ) -> None:
+        await spawn_client.post("/api/spawn", json={"prompt": "Hello"})
+        kwargs = mock_cog.spawn_session.call_args.kwargs
+        assert kwargs.get("auto_start") is True
+
+    @pytest.mark.asyncio
+    async def test_spawn_auto_start_false_passed_to_cog(
+        self, spawn_client: TestClient, mock_cog: MagicMock
+    ) -> None:
+        await spawn_client.post(
+            "/api/spawn",
+            json={"prompt": "Notify only", "auto_start": False},
+        )
+        kwargs = mock_cog.spawn_session.call_args.kwargs
+        assert kwargs.get("auto_start") is False
+
+    @pytest.mark.asyncio
     async def test_spawn_invalid_json_returns_400(self, spawn_client: TestClient) -> None:
         resp = await spawn_client.post(
             "/api/spawn",

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -399,6 +399,52 @@ class TestSpawnSession:
         user_msg_arg = mock_run.call_args.args[0]
         assert user_msg_arg is seed_msg
 
+    @pytest.mark.asyncio
+    async def test_spawn_auto_start_false_skips_run_claude(self) -> None:
+        """When auto_start=False, _run_claude is NOT called."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import discord
+
+        thread = MagicMock(spec=discord.Thread)
+        thread.send = AsyncMock()
+
+        channel = MagicMock()
+        channel.create_thread = AsyncMock(return_value=thread)
+
+        bot = MagicMock()
+        cog = ClaudeChatCog(bot=bot, repo=MagicMock(), runner=MagicMock())
+
+        mock_run = AsyncMock()
+        with patch.object(cog, "_run_claude", new=mock_run):
+            result = await cog.spawn_session(channel, "Just notify", auto_start=False)
+
+        assert result is thread
+        thread.send.assert_called_once_with("Just notify")
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_spawn_auto_start_true_calls_run_claude(self) -> None:
+        """When auto_start=True (default), _run_claude IS called."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import discord
+
+        thread = MagicMock(spec=discord.Thread)
+        thread.send = AsyncMock()
+
+        channel = MagicMock()
+        channel.create_thread = AsyncMock(return_value=thread)
+
+        bot = MagicMock()
+        cog = ClaudeChatCog(bot=bot, repo=MagicMock(), runner=MagicMock())
+
+        mock_run = AsyncMock()
+        with patch.object(cog, "_run_claude", new=mock_run):
+            await cog.spawn_session(channel, "Start session", auto_start=True)
+
+        mock_run.assert_called_once()
+
 
 class TestOnReady:
     """Tests for ClaudeChatCog.on_ready — startup session resume logic."""

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "2.0.15"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Add `auto_start` parameter (default: `true`) to `POST /api/spawn` and `spawn_session()`
- When `auto_start=false`, only the thread and seed message are created — no Claude session starts
- The user's reply in the thread triggers the session naturally via `on_message`
- Update `goodmorning_notify.py` to use `auto_start: false` — notification only, session starts when user replies

## Problem

When `goodmorning_notify.py` called `/api/spawn`, it would:
1. Create a thread + post the notification message
2. **Immediately start a Claude session** (Phase B)

But the notification said "返信したら Phase B を始めるよ！" — so when the user replied, a second process appeared to interleave with the already-running one.

## Test plan

- [x] `test_spawn_auto_start_defaults_to_true` — backward compatibility
- [x] `test_spawn_auto_start_false_passed_to_cog` — API passes param correctly
- [x] `test_spawn_auto_start_false_skips_run_claude` — no Claude session when false
- [x] `test_spawn_auto_start_true_calls_run_claude` — Claude session when true
- [x] All existing spawn tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)