### PR TITLE
fix: remove auto-pin of dashboard message

### DIFF
--- a/claude_discord/discord_ui/thread_dashboard.py
+++ b/claude_discord/discord_ui/thread_dashboard.py
@@ -100,17 +100,10 @@ class ThreadStatusDashboard:
     # ------------------------------------------------------------------
 
     async def initialize(self) -> None:
-        """Post the initial (empty) dashboard embed and pin it."""
+        """Post the initial (empty) dashboard embed."""
         async with self._lock:
             embed = self._build_embed()
             self._dashboard_message = await self._channel.send(embed=embed)
-            try:
-                await self._dashboard_message.pin()
-            except discord.HTTPException:
-                logger.debug(
-                    "Could not pin dashboard message "
-                    "(missing Manage Messages permission or pin limit reached)"
-                )
 
     async def set_state(
         self,

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -41,7 +41,6 @@ def repo(db_path):
 def _make_channel():
     channel = MagicMock(spec=discord.TextChannel)
     msg = MagicMock(spec=discord.Message)
-    msg.pin = AsyncMock()
     msg.edit = AsyncMock()
     channel.send = AsyncMock(return_value=msg)
     return channel

--- a/tests/test_thread_dashboard.py
+++ b/tests/test_thread_dashboard.py
@@ -27,7 +27,6 @@ def _make_channel() -> MagicMock:
     """Return a mocked discord.TextChannel."""
     channel = MagicMock(spec=discord.TextChannel)
     msg = MagicMock(spec=discord.Message)
-    msg.pin = AsyncMock()
     msg.edit = AsyncMock()
     channel.send = AsyncMock(return_value=msg)
     return channel
@@ -64,22 +63,6 @@ class TestInitialize:
         # Embed should be passed as keyword argument
         call_kwargs = channel.send.call_args.kwargs
         assert "embed" in call_kwargs
-
-    @pytest.mark.asyncio
-    async def test_initialize_attempts_pin(self) -> None:
-        dashboard, channel = _make_dashboard()
-        await dashboard.initialize()
-        msg = channel.send.return_value
-        msg.pin.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_initialize_survives_pin_failure(self) -> None:
-        """A failed pin (no permission) must not crash the dashboard."""
-        dashboard, channel = _make_dashboard()
-        msg = channel.send.return_value
-        msg.pin.side_effect = discord.HTTPException(MagicMock(), "Missing Permissions")
-        # Should not raise
-        await dashboard.initialize()
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "2.0.15"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- Remove automatic pinning of the thread status dashboard embed on bot startup
- Each bot restart was creating a new pinned message, causing pin accumulation
- The dashboard embed still works normally — it just won't be pinned

## Test plan
- [x] Existing dashboard tests pass (pin-related tests removed)
- [x] Inbox tests pass
- [ ] Verify bot starts without pinning after deploy

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)