### PR TITLE
feat: add thread_name parameter to /api/notify

### DIFF
--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -188,10 +188,10 @@ class ApiServer:
         poll_data = data.get("poll")
         poll_obj = None
         if poll_data:
-            result = self._build_poll(poll_data)
-            if isinstance(result, web.Response):
-                return result
-            poll_obj = result
+            poll_result = self._build_poll(poll_data)
+            if isinstance(poll_result, web.Response):
+                return poll_result
+            poll_obj = poll_result
 
         thread_name = data.get("thread_name")
         fmt = data.get("format", "text" if thread_name else "embed")
@@ -200,7 +200,9 @@ class ApiServer:
         if thread_name:
             if not hasattr(raw_channel, "create_thread"):
                 return web.json_response({"error": "Channel does not support threads"}, status=400)
-            thread = await raw_channel.create_thread(name=thread_name)  # type: ignore[union-attr]
+            thread_result = await raw_channel.create_thread(name=thread_name)  # type: ignore[union-attr]
+            # create_thread may return Thread or ThreadWithMessage depending on discord.py version
+            thread = thread_result.thread if hasattr(thread_result, "thread") else thread_result  # type: ignore[union-attr]
             target = thread
         else:
             target = raw_channel
@@ -217,8 +219,8 @@ class ApiServer:
 
         result: dict[str, str] = {"status": "sent"}
         if thread is not None:
-            result["thread_id"] = str(thread.id)
-            result["thread_name"] = thread.name
+            result["thread_id"] = str(thread.id)  # type: ignore[union-attr]
+            result["thread_name"] = thread.name  # type: ignore[union-attr]
         return web.json_response(result)
 
     async def schedule(self, request: web.Request) -> web.Response:

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -249,15 +249,22 @@ class TestNotifyThread:
 
     @pytest.fixture
     def bot_with_thread(self) -> MagicMock:
-        """Bot mock whose channel supports create_thread()."""
+        """Bot mock whose channel supports create_thread().
+
+        Simulates ThreadWithMessage (NamedTuple with .thread attribute)
+        returned by TextChannel.create_thread() in discord.py v2.
+        """
         b = MagicMock()
         channel = MagicMock()
         channel.send = AsyncMock()
-        thread = MagicMock()
+        thread = MagicMock(spec=["id", "name", "send"])
         thread.id = 111222333
         thread.name = "PR Review"
         thread.send = AsyncMock()
-        channel.create_thread = AsyncMock(return_value=thread)
+        # Wrap in ThreadWithMessage-like object
+        thread_with_msg = MagicMock(spec=["thread", "message"])
+        thread_with_msg.thread = thread
+        channel.create_thread = AsyncMock(return_value=thread_with_msg)
         b.get_channel.return_value = channel
         return b
 
@@ -282,7 +289,7 @@ class TestNotifyThread:
     ) -> None:
         """When thread_name is given, creates a thread and sends message as text."""
         channel = bot_with_thread.get_channel.return_value
-        thread = channel.create_thread.return_value
+        thread = channel.create_thread.return_value.thread
         resp = await thread_client.post(
             "/api/notify",
             json={
@@ -306,7 +313,7 @@ class TestNotifyThread:
     ) -> None:
         """When thread_name + embed format, embed goes to thread."""
         channel = bot_with_thread.get_channel.return_value
-        thread = channel.create_thread.return_value
+        thread = channel.create_thread.return_value.thread
         resp = await thread_client.post(
             "/api/notify",
             json={
@@ -327,7 +334,7 @@ class TestNotifyThread:
     ) -> None:
         """When thread_name is given without format, default to text (not embed)."""
         channel = bot_with_thread.get_channel.return_value
-        thread = channel.create_thread.return_value
+        thread = channel.create_thread.return_value.thread
         resp = await thread_client.post(
             "/api/notify",
             json={


### PR DESCRIPTION
## Summary
- `/api/notify` に `thread_name` パラメータを追加。指定時は新規Discordスレッドを作成してそこにメッセージを送信
- `thread_name` 指定時のデフォルト `format` を `"text"` に変更（embed カードではなく通常テキスト）
- レスポンスに `thread_id` と `thread_name` を含める（スレッド作成時のみ）
- 後方互換性: `thread_name` なしの場合は従来通りの動作

## Test plan
- [x] `thread_name` 指定時にスレッドが作成されてテキストメッセージが送信される
- [x] `thread_name` + `format: embed` でスレッドにembed送信
- [x] `thread_name` 指定時のデフォルトformatがtextになる
- [x] `thread_name` なしの場合は従来通りチャンネルに直接送信
- [x] レスポンスに `thread_id` / `thread_name` が含まれる
- [x] 既存テスト全46件 PASSED