### PR TITLE
feat: adopt framework improvements from external PRs

### DIFF
--- a/claude_discord/claude/runner.py
+++ b/claude_discord/claude/runner.py
@@ -311,7 +311,10 @@ class ClaudeRunner:
         within 10 seconds.
         """
         if self._process and self._process.returncode is None:
-            self._process.send_signal(signal.SIGINT)
+            if os.name == "nt":
+                self._process.terminate()
+            else:
+                self._process.send_signal(signal.SIGINT)
             try:
                 await asyncio.wait_for(self._process.wait(), timeout=10)
             except (TimeoutError, asyncio.TimeoutError):  # noqa: UP041 — asyncio.TimeoutError != builtins.TimeoutError on Python 3.10

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -97,12 +97,15 @@ class ClaudeChatCog(commands.Cog):
         inline_reply_channel_ids: set[int] | None = None,
         chat_only_channel_ids: set[int] | None = None,
         auto_rename_threads: bool = False,
+        monitor_all_channels: bool = False,
     ) -> None:
         self.bot = bot
         self.repo = repo
         self.runner = runner
         self._max_concurrent = max_concurrent
         self._allowed_user_ids = allowed_user_ids
+        # When True, skip channel-ID filtering and accept all guild channels.
+        self._monitor_all_channels = monitor_all_channels
         # Set of channel IDs to listen on.  When provided, overrides bot.channel_id.
         # Falls back to {bot.channel_id} for backward compatibility.
         if channel_ids is not None:
@@ -200,8 +203,28 @@ class ClaudeChatCog(commands.Cog):
         if self._allowed_user_ids is not None and message.author.id not in self._allowed_user_ids:
             return
 
+        # Determine whether this channel/thread is a valid target.
+        # When monitor_all_channels is True, accept any guild text/forum channel.
+        is_target_channel = message.channel.id in self._channel_ids
+        is_target_thread = (
+            isinstance(message.channel, discord.Thread)
+            and message.channel.parent_id in self._channel_ids
+        )
+
+        if (
+            self._monitor_all_channels
+            and not is_target_channel
+            and not is_target_thread
+            and hasattr(message.channel, "guild")
+            and message.channel.guild is not None
+        ):
+            if isinstance(message.channel, discord.Thread):
+                is_target_thread = True
+            else:
+                is_target_channel = True
+
         # Check if message is in one of the configured channels (new conversation)
-        if message.channel.id in self._channel_ids:
+        if is_target_channel:
             # In mention-only channels, only respond when the bot is @mentioned
             if (
                 message.channel.id in self._mention_only_channel_ids
@@ -212,10 +235,7 @@ class ClaudeChatCog(commands.Cog):
             return
 
         # Check if message is in a thread under one of the configured channels
-        if (
-            isinstance(message.channel, discord.Thread)
-            and message.channel.parent_id in self._channel_ids
-        ):
+        if is_target_thread:
             await self._handle_thread_reply(message)
 
     @app_commands.command(name="help", description="Show available commands and how to use the bot")

--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -141,7 +141,7 @@ class ApiServer:
         """Start the API server."""
         self._runner = web.AppRunner(self.app)
         await self._runner.setup()
-        site = web.TCPSite(self._runner, self.host, self.port)
+        site = web.TCPSite(self._runner, self.host, self.port, reuse_address=True)
         await site.start()
         logger.info("REST API started: http://%s:%d", self.host, self.port)
 

--- a/claude_discord/main.py
+++ b/claude_discord/main.py
@@ -58,6 +58,7 @@ def load_config() -> dict[str, str]:
         "custom_cogs_dir": os.getenv("CUSTOM_COGS_DIR", ""),
         "cli_sessions_path": os.getenv("CLI_SESSIONS_PATH", ""),
         "thread_inbox_enabled": os.getenv("THREAD_INBOX_ENABLED", "false"),
+        "monitor_all_channels": os.getenv("CLAUDE_MONITOR_ALL_CHANNELS", "false"),
     }
 
 
@@ -126,6 +127,7 @@ async def main() -> None:
             claude_channel_ids=claude_channel_ids,
             cli_sessions_path=config["cli_sessions_path"] or None,
             enable_thread_inbox=config["thread_inbox_enabled"].lower() == "true",
+            monitor_all_channels=config["monitor_all_channels"].lower() in ("true", "1", "yes"),
         )
 
         # Load custom Cogs from external directory

--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -81,6 +81,7 @@ async def setup_bridge(
     worktree_base_dir: str | None = None,
     enable_thread_inbox: bool = False,
     auto_rename_threads: bool | None = None,
+    monitor_all_channels: bool | None = None,
 ) -> BridgeComponents:
     """Initialize and register all ccdb Cogs in one call.
 
@@ -191,6 +192,16 @@ async def setup_bridge(
     if auto_rename_threads:
         logger.info("Thread auto-rename enabled (THREAD_AUTO_RENAME)")
 
+    # Monitor-all-channels — fall back to CLAUDE_MONITOR_ALL_CHANNELS env var
+    if monitor_all_channels is None:
+        monitor_all_channels = os.getenv("CLAUDE_MONITOR_ALL_CHANNELS", "").lower() in (
+            "true",
+            "1",
+            "yes",
+        )
+    if monitor_all_channels:
+        logger.info("Monitor-all-channels enabled — bot will respond in ANY guild channel")
+
     # WorktreeManager — attach to bot so cogs can access it via bot.worktree_manager
     if worktree_base_dir is None:
         worktree_base_dir = os.getenv("WORKTREE_BASE_DIR")
@@ -236,6 +247,7 @@ async def setup_bridge(
         inline_reply_channel_ids=inline_reply_channel_ids or None,
         chat_only_channel_ids=chat_only_channel_ids or None,
         auto_rename_threads=auto_rename_threads,
+        monitor_all_channels=monitor_all_channels,
     )
     await bot.add_cog(chat_cog)
     logger.info("Registered ClaudeChatCog")

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "2.0.15"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
Cherry-pick framework-level improvements from tech-forward's PRs (#323, #324):

- **Windows SIGINT fix** (`runner.py`): Use `terminate()` instead of `send_signal(SIGINT)` on Windows where SIGINT is not available
- **API server `reuse_address=True`** (`api_server.py`): Prevent port-in-use errors on bot restart
- **`CLAUDE_MONITOR_ALL_CHANNELS`** (`claude_chat.py`, `setup.py`, `main.py`): Opt-in env var to auto-monitor all guild text/forum channels without listing channel IDs

### Intentionally excluded
- `examples/ebibot/` cogs (ceo_responder, dept_responder) — instance-specific
- cp932 encoding fallback — Windows-specific hack that could mask data issues
- Singleton PID lock — useful but needs design discussion
- Thread completion marking ("済✅") — hardcoded string, needs to be configurable
- `start-loop.bat` — Windows convenience script

## Test plan
- [ ] CI passes (ruff + pytest)
- [ ] Verify `CLAUDE_MONITOR_ALL_CHANNELS=true` enables monitoring of all guild channels
- [ ] Verify default behavior (env var unset) is unchanged
- [ ] Verify bot restart works without port-in-use errors (`reuse_address`)