### PR TITLE
feat: extract framework improvements from external PRs

### DIFF
--- a/claude_discord/claude/runner.py
+++ b/claude_discord/claude/runner.py
@@ -311,7 +311,10 @@ class ClaudeRunner:
         within 10 seconds.
         """
         if self._process and self._process.returncode is None:
-            self._process.send_signal(signal.SIGINT)
+            if os.name == "nt":
+                self._process.terminate()
+            else:
+                self._process.send_signal(signal.SIGINT)
             try:
                 await asyncio.wait_for(self._process.wait(), timeout=10)
             except (TimeoutError, asyncio.TimeoutError):  # noqa: UP041 — asyncio.TimeoutError != builtins.TimeoutError on Python 3.10

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -97,12 +97,15 @@ class ClaudeChatCog(commands.Cog):
         inline_reply_channel_ids: set[int] | None = None,
         chat_only_channel_ids: set[int] | None = None,
         auto_rename_threads: bool = False,
+        monitor_all_channels: bool = False,
     ) -> None:
         self.bot = bot
         self.repo = repo
         self.runner = runner
         self._max_concurrent = max_concurrent
         self._allowed_user_ids = allowed_user_ids
+        # When True, skip channel-ID filtering and accept all guild channels.
+        self._monitor_all_channels = monitor_all_channels
         # Set of channel IDs to listen on.  When provided, overrides bot.channel_id.
         # Falls back to {bot.channel_id} for backward compatibility.
         if channel_ids is not None:
@@ -201,7 +204,10 @@ class ClaudeChatCog(commands.Cog):
             return
 
         # Check if message is in one of the configured channels (new conversation)
-        if message.channel.id in self._channel_ids:
+        in_monitored_channel = (
+            self._monitor_all_channels and message.guild is not None
+        ) or message.channel.id in self._channel_ids
+        if in_monitored_channel:
             # In mention-only channels, only respond when the bot is @mentioned
             if (
                 message.channel.id in self._mention_only_channel_ids
@@ -212,10 +218,11 @@ class ClaudeChatCog(commands.Cog):
             return
 
         # Check if message is in a thread under one of the configured channels
-        if (
+        in_monitored_parent = (self._monitor_all_channels and message.guild is not None) or (
             isinstance(message.channel, discord.Thread)
             and message.channel.parent_id in self._channel_ids
-        ):
+        )
+        if isinstance(message.channel, discord.Thread) and in_monitored_parent:
             await self._handle_thread_reply(message)
 
     @app_commands.command(name="help", description="Show available commands and how to use the bot")

--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -141,7 +141,7 @@ class ApiServer:
         """Start the API server."""
         self._runner = web.AppRunner(self.app)
         await self._runner.setup()
-        site = web.TCPSite(self._runner, self.host, self.port)
+        site = web.TCPSite(self._runner, self.host, self.port, reuse_address=True)
         await site.start()
         logger.info("REST API started: http://%s:%d", self.host, self.port)
 

--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -81,6 +81,7 @@ async def setup_bridge(
     worktree_base_dir: str | None = None,
     enable_thread_inbox: bool = False,
     auto_rename_threads: bool | None = None,
+    monitor_all_channels: bool | None = None,
 ) -> BridgeComponents:
     """Initialize and register all ccdb Cogs in one call.
 
@@ -130,6 +131,11 @@ async def setup_bridge(
                              title derived from the first user message.  Runs as a
                              background task so it never delays the session start.
                              Defaults to THREAD_AUTO_RENAME env var (off by default).
+        monitor_all_channels: When True, the bot responds to messages in ALL guild
+                              text and forum channels without requiring explicit
+                              channel IDs.  New channels are automatically monitored.
+                              Defaults to CLAUDE_MONITOR_ALL_CHANNELS env var (off
+                              by default).
 
     Returns:
         BridgeComponents with references to initialized repositories.
@@ -191,6 +197,16 @@ async def setup_bridge(
     if auto_rename_threads:
         logger.info("Thread auto-rename enabled (THREAD_AUTO_RENAME)")
 
+    # Monitor all channels — fall back to CLAUDE_MONITOR_ALL_CHANNELS env var (off by default)
+    if monitor_all_channels is None:
+        monitor_all_channels = os.getenv("CLAUDE_MONITOR_ALL_CHANNELS", "").lower() in (
+            "true",
+            "1",
+            "yes",
+        )
+    if monitor_all_channels:
+        logger.info("Monitor all channels enabled (CLAUDE_MONITOR_ALL_CHANNELS)")
+
     # WorktreeManager — attach to bot so cogs can access it via bot.worktree_manager
     if worktree_base_dir is None:
         worktree_base_dir = os.getenv("WORKTREE_BASE_DIR")
@@ -236,6 +252,7 @@ async def setup_bridge(
         inline_reply_channel_ids=inline_reply_channel_ids or None,
         chat_only_channel_ids=chat_only_channel_ids or None,
         auto_rename_threads=auto_rename_threads,
+        monitor_all_channels=monitor_all_channels,
     )
     await bot.add_cog(chat_cog)
     logger.info("Registered ClaudeChatCog")


### PR DESCRIPTION
## Summary
Cherry-pick three framework-level improvements from tech-forward's external PRs (#323, #324), separated from ebibot-specific changes.

- **Windows SIGINT fix** (`runner.py`): Use `terminate()` instead of `SIGINT` on Windows, where `SIGINT` is not supported for subprocesses
- **`reuse_address=True`** (`api_server.py`): Prevents port-in-use errors on rapid restarts
- **`CLAUDE_MONITOR_ALL_CHANNELS`** (`claude_chat.py`, `setup.py`): New opt-in env var to auto-monitor all guild text/forum channels without explicit channel ID configuration

## Policy
ebibot-specific changes (`examples/ebibot/ceo_responder.py`, `dept_responder.py`) are not included — those belong in each deployer's own customization, not the framework.

## Test plan
- [ ] CI passes (lint, format, tests)
- [ ] Existing channel-ID-based routing still works (default behavior unchanged)
- [ ] `CLAUDE_MONITOR_ALL_CHANNELS=true` enables all-channel monitoring
- [ ] Windows: `interrupt()` uses `terminate()` instead of `SIGINT`