### PR TITLE
feat: wall-clock anchoring for scheduled tasks

### DIFF
--- a/claude_discord/database/task_repo.py
+++ b/claude_discord/database/task_repo.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import time
+from datetime import datetime, timedelta, timezone
 
 import aiosqlite
 
@@ -31,6 +32,12 @@ CREATE INDEX IF NOT EXISTS idx_tasks_next_run
     ON scheduled_tasks(next_run_at, enabled);
 """
 
+# Migration: add anchor columns (nullable, backward compatible)
+_MIGRATION_ANCHOR = """
+ALTER TABLE scheduled_tasks ADD COLUMN anchor_hour INTEGER;
+ALTER TABLE scheduled_tasks ADD COLUMN anchor_minute INTEGER DEFAULT 0;
+"""
+
 
 class TaskRepository:
     """Async CRUD for scheduled_tasks table."""
@@ -39,15 +46,40 @@ class TaskRepository:
         self.db_path = db_path
 
     async def init_db(self) -> None:
-        """Initialize the task schema."""
+        """Initialize the task schema and run migrations."""
         async with aiosqlite.connect(self.db_path) as db:
             await db.executescript(TASK_SCHEMA)
+            # Migration: add anchor columns if they don't exist yet
+            cursor = await db.execute("PRAGMA table_info(scheduled_tasks)")
+            columns = {row[1] for row in await cursor.fetchall()}
+            if "anchor_hour" not in columns:
+                for stmt in _MIGRATION_ANCHOR.strip().split(";"):
+                    stmt = stmt.strip()
+                    if stmt:
+                        await db.execute(stmt)
+                logger.info("Migrated scheduled_tasks: added anchor_hour, anchor_minute")
             await db.commit()
         logger.info("Task DB initialized at %s", self.db_path)
 
     # ------------------------------------------------------------------
-    # Internal helper
+    # Internal helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _next_anchor(anchor_hour: int, anchor_minute: int, interval_seconds: int) -> float:
+        """Calculate the next future wall-clock occurrence of anchor_hour:anchor_minute.
+
+        Advances by ``interval_seconds`` from the anchor time until the result
+        is strictly in the future.  This prevents drift — the schedule always
+        snaps to the anchor regardless of how long the previous run took.
+        """
+        local_tz = datetime.now(timezone.utc).astimezone().tzinfo  # noqa: UP017
+        now = datetime.now(local_tz)
+        candidate = now.replace(hour=anchor_hour, minute=anchor_minute, second=0, microsecond=0)
+        interval = timedelta(seconds=interval_seconds)
+        while candidate <= now:
+            candidate += interval
+        return candidate.timestamp()
 
     async def _db_execute(self, sql: str, params: tuple = ()) -> None:
         """Execute a DML statement (for tests and internal use)."""
@@ -116,6 +148,8 @@ class TaskRepository:
         *,
         working_dir: str | None = None,
         run_immediately: bool = True,
+        anchor_hour: int | None = None,
+        anchor_minute: int | None = None,
     ) -> int:
         """Create a new scheduled task. Returns the created ID.
 
@@ -124,16 +158,35 @@ class TaskRepository:
                 task fires on the next master-loop tick. If False, delay by
                 interval_seconds (useful for tasks that should wait one full
                 cycle before the first run).
+            anchor_hour: Optional wall-clock hour (0-23) to snap to.
+            anchor_minute: Optional wall-clock minute (0-59) to snap to.
+                When anchor_hour is set, next_run_at is calculated as the
+                next future occurrence of that time, preventing drift.
         """
         now = time.time()
-        next_run = now if run_immediately else now + interval_seconds
+        if anchor_hour is not None and not run_immediately:
+            next_run = self._next_anchor(anchor_hour, anchor_minute or 0, interval_seconds)
+        elif run_immediately:
+            next_run = now
+        else:
+            next_run = now + interval_seconds
         async with aiosqlite.connect(self.db_path) as db:
             cursor = await db.execute(
                 """INSERT INTO scheduled_tasks
                    (name, prompt, interval_seconds, channel_id, working_dir,
-                    enabled, next_run_at, created_at)
-                   VALUES (?, ?, ?, ?, ?, 1, ?, ?)""",
-                (name, prompt, interval_seconds, channel_id, working_dir, next_run, now),
+                    enabled, next_run_at, created_at, anchor_hour, anchor_minute)
+                   VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?)""",
+                (
+                    name,
+                    prompt,
+                    interval_seconds,
+                    channel_id,
+                    working_dir,
+                    next_run,
+                    now,
+                    anchor_hour,
+                    anchor_minute,
+                ),
             )
             await db.commit()
             row_id = cursor.lastrowid
@@ -144,14 +197,31 @@ class TaskRepository:
         return row_id
 
     async def update_next_run(self, task_id: int, interval_seconds: int) -> None:
-        """Advance next_run_at by interval_seconds and record last_run_at."""
+        """Advance next_run_at and record last_run_at.
+
+        When the task has anchor_hour set, snaps to the next wall-clock
+        occurrence instead of using ``now + interval_seconds``.
+        """
         now = time.time()
+        # Check if this task has an anchor
         async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
+                "SELECT anchor_hour, anchor_minute FROM scheduled_tasks WHERE id = ?",
+                (task_id,),
+            )
+            row = await cursor.fetchone()
+            if row is not None and row["anchor_hour"] is not None:
+                next_run = self._next_anchor(
+                    row["anchor_hour"], row["anchor_minute"] or 0, interval_seconds
+                )
+            else:
+                next_run = now + interval_seconds
             await db.execute(
                 """UPDATE scheduled_tasks
                    SET next_run_at = ?, last_run_at = ?
                    WHERE id = ?""",
-                (now + interval_seconds, now, task_id),
+                (next_run, now, task_id),
             )
             await db.commit()
 
@@ -179,8 +249,13 @@ class TaskRepository:
         prompt: str | None = None,
         interval_seconds: int | None = None,
         working_dir: str | None = None,
+        anchor_hour: int | None = None,
+        anchor_minute: int | None = None,
     ) -> bool:
-        """Partially update a task. Returns True if updated."""
+        """Partially update a task. Returns True if updated.
+
+        Set ``anchor_hour=-1`` to clear the anchor (reset to relative mode).
+        """
         fields: list[str] = []
         values: list[object] = []
         if prompt is not None:
@@ -192,6 +267,18 @@ class TaskRepository:
         if working_dir is not None:
             fields.append("working_dir = ?")
             values.append(working_dir)
+        if anchor_hour is not None:
+            if anchor_hour < 0:
+                # Sentinel: clear anchor
+                fields.append("anchor_hour = ?")
+                values.append(None)
+                fields.append("anchor_minute = ?")
+                values.append(None)
+            else:
+                fields.append("anchor_hour = ?")
+                values.append(anchor_hour)
+                fields.append("anchor_minute = ?")
+                values.append(anchor_minute if anchor_minute is not None else 0)
         if not fields:
             return False
         values.append(task_id)

--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -273,6 +273,16 @@ class ApiServer:
             )
         return None
 
+    @staticmethod
+    def _parse_anchor_time(raw: str | None) -> tuple[int | None, int | None]:
+        """Parse ``"HH:MM"`` into (hour, minute).  Returns (None, None) if absent."""
+        if not raw:
+            return None, None
+        parts = raw.split(":")
+        if len(parts) != 2:  # noqa: PLR2004
+            raise ValueError(f"anchor_time must be HH:MM, got {raw!r}")
+        return int(parts[0]), int(parts[1])
+
     async def create_task(self, request: web.Request) -> web.Response:
         """POST /api/tasks — register a scheduled Claude Code task.
 
@@ -283,6 +293,9 @@ class ApiServer:
             channel_id: Discord channel ID for thread creation.
             working_dir: (optional) Working directory for Claude.
             run_immediately: (optional, default true) Fire on next loop tick.
+            anchor_time: (optional) Wall-clock time ``"HH:MM"`` to snap to,
+                preventing time drift. When set, next_run_at is calculated as
+                the next future occurrence of that time.
         """
         if err := self._require_task_repo():
             return err
@@ -296,6 +309,11 @@ class ApiServer:
                 return web.json_response({"error": f"{field} is required"}, status=400)
 
         try:
+            anchor_hour, anchor_minute = self._parse_anchor_time(data.get("anchor_time"))
+        except ValueError as exc:
+            return web.json_response({"error": str(exc)}, status=400)
+
+        try:
             task_id = await self.task_repo.create(  # type: ignore[union-attr]
                 name=str(data["name"]),
                 prompt=str(data["prompt"]),
@@ -303,6 +321,8 @@ class ApiServer:
                 channel_id=int(data["channel_id"]),
                 working_dir=data.get("working_dir"),
                 run_immediately=bool(data.get("run_immediately", True)),
+                anchor_hour=anchor_hour,
+                anchor_minute=anchor_minute,
             )
         except Exception as exc:
             # Most likely a UNIQUE constraint violation on name
@@ -334,7 +354,16 @@ class ApiServer:
         return web.json_response({"error": "Task not found"}, status=404)
 
     async def patch_task(self, request: web.Request) -> web.Response:
-        """PATCH /api/tasks/{id} — update a task (enable/disable, prompt, interval)."""
+        """PATCH /api/tasks/{id} — update a task.
+
+        Body (JSON, all optional):
+            enabled: bool
+            prompt: str
+            interval_seconds: int
+            working_dir: str
+            anchor_time: ``"HH:MM"`` to set, or ``null`` to clear
+            next_run_at: float (epoch) — manual schedule reset
+        """
         if err := self._require_task_repo():
             return err
         try:
@@ -360,9 +389,30 @@ class ApiServer:
         if "working_dir" in data:
             patch_kwargs["working_dir"] = str(data["working_dir"])
 
+        # anchor_time: "HH:MM" to set, null to clear
+        if "anchor_time" in data:
+            raw_anchor = data["anchor_time"]
+            if raw_anchor is None:
+                patch_kwargs["anchor_hour"] = -1  # sentinel: clear
+            else:
+                try:
+                    h, m = self._parse_anchor_time(raw_anchor)
+                except ValueError as exc:
+                    return web.json_response({"error": str(exc)}, status=400)
+                patch_kwargs["anchor_hour"] = h
+                patch_kwargs["anchor_minute"] = m
+
         if patch_kwargs:
             result = await self.task_repo.update(task_id, **patch_kwargs)  # type: ignore[union-attr]
             updated = updated or result
+
+        # Manual next_run_at override
+        if "next_run_at" in data:
+            await self.task_repo._db_execute(  # type: ignore[union-attr]
+                "UPDATE scheduled_tasks SET next_run_at = ? WHERE id = ?",
+                (float(data["next_run_at"]), task_id),
+            )
+            updated = True
 
         if updated:
             return web.json_response({"status": "updated"})

--- a/tests/test_task_repo.py
+++ b/tests/test_task_repo.py
@@ -64,6 +64,54 @@ class TestTaskRepoCreate:
         assert task is not None
         assert task["working_dir"] == "/home/user/project"
 
+    async def test_create_with_anchor_time(self, repo: TaskRepository) -> None:
+        task_id = await repo.create(
+            name="anchored",
+            prompt="prompt",
+            interval_seconds=86400,
+            channel_id=1,
+            anchor_hour=18,
+            anchor_minute=30,
+        )
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["anchor_hour"] == 18
+        assert task["anchor_minute"] == 30
+
+    async def test_create_without_anchor_has_none(self, repo: TaskRepository) -> None:
+        task_id = await repo.create(
+            name="no-anchor",
+            prompt="prompt",
+            interval_seconds=3600,
+            channel_id=1,
+        )
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["anchor_hour"] is None
+        assert task["anchor_minute"] is None
+
+    async def test_create_with_anchor_sets_next_run_to_anchor_time(
+        self, repo: TaskRepository
+    ) -> None:
+        """When anchor is set and run_immediately=False, next_run_at should be
+        the next occurrence of anchor time."""
+        from datetime import datetime
+
+        task_id = await repo.create(
+            name="anchor-schedule",
+            prompt="prompt",
+            interval_seconds=86400,
+            channel_id=1,
+            anchor_hour=18,
+            anchor_minute=0,
+            run_immediately=False,
+        )
+        task = await repo.get(task_id)
+        assert task is not None
+        next_dt = datetime.fromtimestamp(task["next_run_at"])
+        assert next_dt.hour == 18
+        assert next_dt.minute == 0
+
     async def test_duplicate_name_raises(self, repo: TaskRepository) -> None:
         import aiosqlite
 
@@ -136,6 +184,45 @@ class TestTaskRepoUpdateNextRun:
         assert task["next_run_at"] >= before + 3600 - 1  # allow 1s skew
         assert task["last_run_at"] is not None
 
+    async def test_update_next_run_with_anchor_snaps_to_wall_clock(
+        self, repo: TaskRepository
+    ) -> None:
+        """When anchor_hour/anchor_minute are set, next_run_at should snap to
+        the next occurrence of that wall-clock time instead of now + interval."""
+        task_id = await repo.create(
+            name="anchored",
+            prompt="p",
+            interval_seconds=86400,  # daily
+            channel_id=1,
+            anchor_hour=18,
+            anchor_minute=0,
+        )
+        await repo.update_next_run(task_id, interval_seconds=86400)
+        task = await repo.get(task_id)
+        assert task is not None
+
+        from datetime import datetime
+
+        next_dt = datetime.fromtimestamp(task["next_run_at"])
+        assert next_dt.hour == 18
+        assert next_dt.minute == 0
+        assert next_dt.second == 0
+        # Must be in the future
+        assert task["next_run_at"] > time.time()
+
+    async def test_update_next_run_without_anchor_uses_relative(self, repo: TaskRepository) -> None:
+        """Without anchor, update_next_run still uses now + interval (backward compat)."""
+        before = time.time()
+        task_id = await repo.create(
+            name="no-anchor", prompt="p", interval_seconds=600, channel_id=1
+        )
+        await repo.update_next_run(task_id, interval_seconds=600)
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["next_run_at"] >= before + 600 - 1
+        assert task["anchor_hour"] is None
+        assert task["anchor_minute"] is None
+
 
 class TestTaskRepoDelete:
     async def test_delete_existing(self, repo: TaskRepository) -> None:
@@ -187,6 +274,34 @@ class TestTaskRepoUpdate:
         task = await repo.get(task_id)
         assert task is not None
         assert task["interval_seconds"] == 7200
+
+    async def test_update_anchor_time(self, repo: TaskRepository) -> None:
+        task_id = await repo.create(
+            name="u-anchor", prompt="p", interval_seconds=86400, channel_id=1
+        )
+        result = await repo.update(task_id, anchor_hour=9, anchor_minute=30)
+        assert result is True
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["anchor_hour"] == 9
+        assert task["anchor_minute"] == 30
+
+    async def test_update_clear_anchor(self, repo: TaskRepository) -> None:
+        task_id = await repo.create(
+            name="u-clear",
+            prompt="p",
+            interval_seconds=86400,
+            channel_id=1,
+            anchor_hour=18,
+            anchor_minute=0,
+        )
+        # Clear anchor by setting to -1 (sentinel for None)
+        result = await repo.update(task_id, anchor_hour=-1)
+        assert result is True
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["anchor_hour"] is None
+        assert task["anchor_minute"] is None
 
     async def test_update_nonexistent_returns_false(self, repo: TaskRepository) -> None:
         result = await repo.update(99999, prompt="x")

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "2.0.15"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- Add `anchor_hour`/`anchor_minute` columns to `scheduled_tasks` (nullable, backward compatible)
- When anchor is set, `update_next_run()` snaps to the next wall-clock occurrence instead of `now + interval`
- Prevents cumulative time drift (reported: 11 hours over 12 days in #320)
- API: `anchor_time: "HH:MM"` in `POST /api/tasks` and `PATCH /api/tasks/{id}`
- API: `next_run_at` override in `PATCH /api/tasks/{id}` for manual schedule resets

## How it works
```python
# Without anchor (existing behavior, backward compatible):
next_run_at = now + interval_seconds  # drifts over time

# With anchor (new):
next_run_at = next_occurrence(18:00)  # always snaps to wall-clock
```

## Test plan
- [x] 7 new tests in `test_task_repo.py`
- [x] All 78 existing related tests pass
- [x] ruff check + ruff format clean
- [x] pyright clean

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)