### PR TITLE
fix: support PNG image attachments via base64 encoding

### DIFF
--- a/claude_discord/claude/runner.py
+++ b/claude_discord/claude/runner.py
@@ -21,7 +21,10 @@ from collections.abc import AsyncGenerator
 from pathlib import Path
 
 from .parser import parse_line
-from .types import MessageType, StreamEvent
+from .types import ImageData, MessageType, StreamEvent
+
+# Re-export for backward compatibility
+__all__ = ["ClaudeRunner", "ImageData"]
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +91,7 @@ class ClaudeRunner:
         api_secret: str | None = None,
         thread_id: int | None = None,
         append_system_prompt: str | None = None,
-        image_urls: list[str] | None = None,
+        images: list[ImageData] | None = None,
         fork_session: bool = False,
     ) -> None:
         self.command = command
@@ -103,7 +106,7 @@ class ClaudeRunner:
         self.api_secret = api_secret
         self.thread_id = thread_id
         self.append_system_prompt = append_system_prompt
-        self.image_urls = image_urls
+        self.images = images
         self.fork_session = fork_session
         self._process: asyncio.subprocess.Process | None = None
 
@@ -133,13 +136,13 @@ class ClaudeRunner:
         )
 
         # When image attachments are present we use --input-format stream-json and
-        # write the user message (with image URLs) to stdin immediately after
-        # process start.  This requires stdin=PIPE.
+        # write the user message (with base64 image data) to stdin immediately
+        # after process start.  This requires stdin=PIPE.
         #
         # For text-only sessions we keep stdin=DEVNULL: Claude CLI blocks on startup
         # when stdin is an open pipe in default text-input mode, and we have no data
         # to send.
-        stdin_mode = asyncio.subprocess.PIPE if self.image_urls else asyncio.subprocess.DEVNULL
+        stdin_mode = asyncio.subprocess.PIPE if self.images else asyncio.subprocess.DEVNULL
 
         self._process = await asyncio.create_subprocess_exec(
             *args,
@@ -154,8 +157,8 @@ class ClaudeRunner:
         logger.info("Claude CLI started: pid=%s", self._process.pid)
 
         # For stream-json input sessions, send the initial user message (including
-        # image URLs) to stdin now that the process is up.
-        if self.image_urls and self._process.stdin is not None:
+        # base64 image data) to stdin now that the process is up.
+        if self.images and self._process.stdin is not None:
             await self._send_stream_json_message(prompt)
 
         try:
@@ -223,7 +226,7 @@ class ClaudeRunner:
                 if append_system_prompt is not None
                 else self.append_system_prompt
             ),
-            # image_urls are NOT inherited — they are per-invocation.
+            # images are NOT inherited — they are per-invocation.
             # The caller (run_claude_with_config) passes them via RunConfig.
             # fork_session is NOT inherited — it's a per-invocation flag.
             fork_session=fork_session,
@@ -257,14 +260,13 @@ class ClaudeRunner:
     async def _send_stream_json_message(self, prompt: str) -> None:
         """Write the initial user message to stdin in stream-json format.
 
-        Called immediately after process start when ``image_urls`` is set.
-        Builds a user message with URL-type image content blocks followed
+        Called immediately after process start when ``images`` is set.
+        Builds a user message with base64-type image content blocks followed
         by the text prompt, then writes it as a single JSON line to stdin.
 
-        Claude Code CLI silently drops base64 image blocks in stream-json input
-        mode (confirmed with CLI 2.1.59).  Using ``{"type": "url"}`` image
-        sources is the only format that reaches the Anthropic API through the
-        CLI's stream-json input pipeline.
+        Images are pre-downloaded and base64-encoded by the caller (prompt_builder)
+        to avoid issues where the CLI's internal URL-fetch rejects certain formats
+        (e.g. PNG).
 
         The CLI reads this message and begins processing; stdin is left open so
         that ``inject_tool_result`` can send subsequent responses if needed.
@@ -272,17 +274,18 @@ class ClaudeRunner:
         assert self._process is not None and self._process.stdin is not None
 
         content: list[dict] = []
-        for url in self.image_urls or []:
+        for img in self.images or []:
             content.append(
                 {
                     "type": "image",
                     "source": {
-                        "type": "url",
-                        "url": url,
+                        "type": "base64",
+                        "media_type": img.media_type,
+                        "data": img.data,
                     },
                 }
             )
-            logger.debug("Added image URL for stream-json input: %.80s", url)
+            logger.debug("Added base64 image (%s, %d chars)", img.media_type, len(img.data))
 
         # Only add the text block if the prompt is non-empty.
         # An empty text block causes a 400 error from the Anthropic API when
@@ -364,8 +367,8 @@ class ClaudeRunner:
         if self.append_system_prompt:
             args.extend(["--append-system-prompt", self.append_system_prompt])
 
-        if self.image_urls:
-            # Images are passed via stdin as URL content blocks in the
+        if self.images:
+            # Images are passed via stdin as base64 content blocks in the
             # stream-json input protocol.  The --input-format flag tells the
             # CLI to read the user message from stdin instead of the positional
             # argument, so we do NOT append "-- <prompt>" in this branch.

--- a/claude_discord/claude/types.py
+++ b/claude_discord/claude/types.py
@@ -11,6 +11,18 @@ if TYPE_CHECKING:
     import discord
 
 
+@dataclass(frozen=True)
+class ImageData:
+    """Base64-encoded image data with its media type.
+
+    Used to pass downloaded Discord image attachments to the Claude Code CLI
+    via stream-json base64 image blocks.
+    """
+
+    data: str  # base64-encoded string (no data: URI prefix)
+    media_type: str  # e.g. "image/jpeg", "image/png"
+
+
 class MessageType(Enum):
     """Top-level message types in stream-json output."""
 

--- a/claude_discord/cogs/_run_helper.py
+++ b/claude_discord/cogs/_run_helper.py
@@ -182,9 +182,9 @@ async def run_claude_with_config(config: RunConfig) -> str | None:
         if system_context
         else config.runner
     )
-    # Inject per-invocation image URLs (not inherited by runner.clone()).
-    if config.image_urls:
-        runner.image_urls = config.image_urls
+    # Inject per-invocation images (not inherited by runner.clone()).
+    if config.images:
+        runner.images = config.images
 
     # Keep stop_view in sync with the runner that will own the live subprocess.
     # When system_context is present a fresh clone is created above, making the

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -21,6 +21,7 @@ from discord.ext import commands
 
 from ..claude.rewind import find_session_jsonl, parse_user_turns
 from ..claude.runner import ClaudeRunner
+from ..claude.types import ImageData
 from ..concurrency import SessionRegistry
 from ..database.ask_repo import PendingAskRepository
 from ..database.lounge_repo import LoungeRepository
@@ -425,7 +426,7 @@ class ClaudeChatCog(commands.Cog):
 
     async def _handle_new_conversation(self, message: discord.Message) -> None:
         """Start a Claude Code session, creating a thread unless inline-reply mode is active."""
-        prompt, image_urls = await self._build_prompt_and_images(message)
+        prompt, images = await self._build_prompt_and_images(message)
         chat_only = message.channel.id in self._chat_only_channel_ids
         if (
             isinstance(message.channel, discord.TextChannel)
@@ -437,7 +438,7 @@ class ClaudeChatCog(commands.Cog):
                 message.channel,
                 prompt,
                 session_id=None,
-                image_urls=image_urls,
+                images=images,
                 chat_only=chat_only,
             )
         else:
@@ -450,7 +451,7 @@ class ClaudeChatCog(commands.Cog):
                 thread,
                 prompt,
                 session_id=None,
-                image_urls=image_urls,
+                images=images,
                 chat_only=chat_only,
             )
 
@@ -661,10 +662,10 @@ class ClaudeChatCog(commands.Cog):
 
         record = await self.repo.get(thread.id)
         session_id = record.session_id if record else None
-        prompt, image_urls = await self._build_prompt_and_images(message)
+        prompt, images = await self._build_prompt_and_images(message)
 
         # Nothing to send — ignore silently (e.g. unsupported attachment only).
-        if not prompt and not image_urls:
+        if not prompt and not images:
             return
 
         # User replied — remove this thread from the inbox immediately so the
@@ -700,12 +701,14 @@ class ClaudeChatCog(commands.Cog):
             thread,
             prompt,
             session_id=session_id,
-            image_urls=image_urls,
+            images=images,
             working_dir_override=record.working_dir if record else None,
             chat_only=chat_only,
         )
 
-    async def _build_prompt_and_images(self, message: discord.Message) -> tuple[str, list[str]]:
+    async def _build_prompt_and_images(
+        self, message: discord.Message
+    ) -> tuple[str, list[ImageData]]:
         """Delegate to the standalone prompt_builder module."""
         return await build_prompt_and_images(message)
 
@@ -715,7 +718,7 @@ class ClaudeChatCog(commands.Cog):
         thread: discord.Thread | discord.TextChannel,
         prompt: str,
         session_id: str | None,
-        image_urls: list[str] | None = None,
+        images: list[ImageData] | None = None,
         fork: bool = False,
         working_dir_override: str | None = None,
         chat_only: bool = False,
@@ -796,7 +799,7 @@ class ClaudeChatCog(commands.Cog):
                         lounge_repo=self._lounge_repo,
                         stop_view=stop_view,
                         worktree_manager=getattr(self.bot, "worktree_manager", None),
-                        image_urls=image_urls,
+                        images=images,
                         attach_on_request=wants_file_attachment(prompt),
                         inbox_repo=getattr(self.bot, "inbox_repo", None),
                         inbox_dashboard=dashboard,

--- a/claude_discord/cogs/prompt_builder.py
+++ b/claude_discord/cogs/prompt_builder.py
@@ -1,4 +1,4 @@
-"""Build a prompt string and collect image URLs from a Discord message.
+"""Build a prompt string and collect image data from a Discord message.
 
 Extracted from ClaudeChatCog to keep the Cog thin.  This module is a
 pure function layer — it only depends on ``discord.Message`` and has no
@@ -7,10 +7,13 @@ Cog or Bot state.
 
 from __future__ import annotations
 
+import base64
 import logging
 import os.path
 
 import discord
+
+from ..claude.types import ImageData
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +87,34 @@ MAX_TOTAL_BYTES = 500_000  # 500 KB across all text attachments
 MAX_ATTACHMENTS = 5
 MAX_IMAGES = 4  # Claude supports up to 4 images per prompt
 
+# Media types accepted by the Anthropic API for base64 image blocks.
+_SUPPORTED_MEDIA_TYPES: frozenset[str] = frozenset(
+    {"image/jpeg", "image/png", "image/gif", "image/webp"}
+)
+
+# Extension → media type mapping for fallback detection.
+_EXT_TO_MEDIA_TYPE: dict[str, str] = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".bmp": "image/jpeg",  # BMP will be treated as JPEG after download
+    ".svg": "image/png",  # SVG not supported by API
+}
+
+
+def _detect_media_type(content_type: str, filename: str) -> str:
+    """Determine the media type from content_type header or filename extension."""
+    # Try content_type first (e.g. "image/png; charset=utf-8" → "image/png")
+    if content_type:
+        mt = content_type.split(";")[0].strip().lower()
+        if mt in _SUPPORTED_MEDIA_TYPES:
+            return mt
+    # Fallback to extension
+    ext = os.path.splitext(filename.lower())[1]
+    return _EXT_TO_MEDIA_TYPE.get(ext, "image/jpeg")
+
 
 # Keywords that indicate the user wants a file sent/attached.
 _SEND_FILE_KEYWORDS = (
@@ -112,22 +143,26 @@ def wants_file_attachment(prompt: str) -> bool:
     return any(kw in lower for kw in _SEND_FILE_KEYWORDS)
 
 
-async def build_prompt_and_images(message: discord.Message) -> tuple[str, list[str]]:
-    """Build the prompt string and collect image attachment URLs.
+async def build_prompt_and_images(
+    message: discord.Message,
+) -> tuple[str, list[ImageData]]:
+    """Build the prompt string and collect image attachments as base64 data.
 
     Text attachments (text/*, application/json, application/xml) are appended
-    inline to the prompt.  Image attachments (image/*) are collected as HTTPS
-    URLs (Discord CDN) and returned for stream-json input to Claude Code CLI.
+    inline to the prompt.  Image attachments (image/*) are downloaded from the
+    Discord CDN and returned as base64-encoded ``ImageData`` objects for
+    stream-json input to Claude Code CLI.
 
-    Claude Code CLI silently drops base64 image blocks in stream-json mode.
-    Passing Discord CDN URLs directly as ``{"type": "url"}`` image sources is
-    the only format the CLI forwards to the Anthropic API.
+    Images are downloaded and base64-encoded on the ccdb side rather than
+    passing Discord CDN URLs directly.  This avoids issues where the CLI's
+    internal URL-fetch-to-base64 conversion rejects certain image formats
+    (e.g. PNG — see GitHub issue for details).
 
     Both binary-file types that exceed size limits and unsupported types are
     silently skipped — never raise an error to the user.
 
     Returns:
-        (prompt_text, image_urls) — HTTPS URLs for stream-json url-type blocks.
+        (prompt_text, images) — base64-encoded image data for stream-json blocks.
     """
     prompt = message.content or ""
     if not message.attachments:
@@ -135,7 +170,7 @@ async def build_prompt_and_images(message: discord.Message) -> tuple[str, list[s
 
     total_bytes = 0
     sections: list[str] = []
-    image_urls: list[str] = []
+    images: list[ImageData] = []
 
     for attachment in message.attachments[:MAX_ATTACHMENTS]:
         content_type = attachment.content_type or ""
@@ -145,13 +180,13 @@ async def build_prompt_and_images(message: discord.Message) -> tuple[str, list[s
         if not content_type:
             ext = os.path.splitext(attachment.filename.lower())[1]
             if ext in _IMAGE_EXTENSIONS:
-                content_type = "image/png"  # triggers CDN URL path below
+                content_type = "image/png"  # triggers image download path below
             elif ext in _TEXT_EXTENSIONS:
                 content_type = "text/plain"
 
-        # ---- Image attachments → collect CDN URL for stream-json input ----
+        # ---- Image attachments → download and base64-encode ----
         if content_type.startswith(IMAGE_MIME_PREFIXES):
-            if len(image_urls) >= MAX_IMAGES:
+            if len(images) >= MAX_IMAGES:
                 logger.debug("Skipping image %s: max images reached", attachment.filename)
                 continue
             if attachment.size > MAX_IMAGE_BYTES:
@@ -161,8 +196,19 @@ async def build_prompt_and_images(message: discord.Message) -> tuple[str, list[s
                     attachment.size,
                 )
                 continue
-            image_urls.append(attachment.url)
-            logger.debug("Collected image URL for %s: %.80s", attachment.filename, attachment.url)
+            try:
+                raw = await attachment.read()
+                media_type = _detect_media_type(content_type, attachment.filename)
+                encoded = base64.standard_b64encode(raw).decode("ascii")
+                images.append(ImageData(data=encoded, media_type=media_type))
+                logger.debug(
+                    "Downloaded and encoded image %s (%d bytes, %s)",
+                    attachment.filename,
+                    len(raw),
+                    media_type,
+                )
+            except Exception:
+                logger.debug("Failed to download image %s", attachment.filename, exc_info=True)
             continue
 
         # ---- Text attachments → inline in prompt ----
@@ -198,4 +244,4 @@ async def build_prompt_and_images(message: discord.Message) -> tuple[str, list[s
             logger.debug("Failed to read attachment %s", attachment.filename, exc_info=True)
             continue
 
-    return prompt + "".join(sections), image_urls
+    return prompt + "".join(sections), images

--- a/claude_discord/cogs/run_config.py
+++ b/claude_discord/cogs/run_config.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 import discord
 
 from ..claude.runner import ClaudeRunner
+from ..claude.types import ImageData
 from ..concurrency import SessionRegistry
 from ..database.ask_repo import PendingAskRepository
 from ..database.lounge_repo import LoungeRepository
@@ -65,9 +66,8 @@ class RunConfig:
     lounge_repo: LoungeRepository | None = None
     stop_view: StopView | None = None
     worktree_manager: WorktreeManager | None = None
-    # HTTPS URLs of image attachments to pass as stream-json url-type image blocks.
-    # Claude Code CLI silently drops base64 image blocks; URL type is required.
-    image_urls: list[str] | None = None
+    # Base64-encoded image data for stream-json base64-type image blocks.
+    images: list[ImageData] | None = None
     # When True, inject a system-prompt instruction telling Claude to write
     # requested file paths to .ccdb-attachments so the bot can send them.
     attach_on_request: bool = False
@@ -89,7 +89,7 @@ class RunConfig:
     # Prevent accidental field mutation — RunConfig is a value object.
     # Use dataclasses.replace() to create modified copies.
     def __post_init__(self) -> None:
-        if not self.prompt and not self.image_urls:
+        if not self.prompt and not self.images:
             raise ValueError("RunConfig.prompt must not be empty")
 
     def with_prompt(self, prompt: str) -> RunConfig:

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -784,15 +784,15 @@ class TestImageOnlyMessage:
 
     @pytest.mark.asyncio
     async def test_build_prompt_and_images_returns_empty_prompt(self) -> None:
-        """Image-only message should return empty prompt + image URL list."""
+        """Image-only message should return empty prompt + ImageData list."""
         cog = _make_cog()
         msg = self._make_image_message()
 
-        prompt, image_urls = await cog._build_prompt_and_images(msg)
+        prompt, images = await cog._build_prompt_and_images(msg)
 
         assert prompt == ""
-        assert len(image_urls) == 1
-        assert "photo.png" in image_urls[0]
+        assert len(images) == 1
+        assert images[0].media_type == "image/png"
 
     @pytest.mark.asyncio
     async def test_handle_thread_reply_does_not_crash(self) -> None:
@@ -805,11 +805,10 @@ class TestImageOnlyMessage:
         await cog._handle_thread_reply(msg)
 
         cog._run_claude.assert_called_once()
-        # Verify image_urls were passed through
+        # Verify images were passed through
         call_kwargs = cog._run_claude.call_args
-        assert call_kwargs.kwargs.get("image_urls") == [
-            "https://cdn.discordapp.com/attachments/111/222/photo.png"
-        ]
+        images = call_kwargs.kwargs.get("images")
+        assert images is not None and len(images) == 1
 
     @pytest.mark.asyncio
     async def test_handle_thread_reply_skips_empty_message(self) -> None:

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 from unittest.mock import AsyncMock, MagicMock
 
 import discord
@@ -60,23 +61,57 @@ class TestBuildPromptAndImages:
         assert "file content here" in prompt
 
     @pytest.mark.asyncio
-    async def test_image_attachment_returns_cdn_url(self) -> None:
-        """Images are returned as Discord CDN URLs, NOT downloaded to tempfiles."""
-        cdn_url = "https://cdn.discordapp.com/attachments/111/222/image.png"
+    async def test_image_attachment_returns_base64_data(self) -> None:
+        """Images are downloaded and returned as base64-encoded ImageData."""
+        image_bytes = b"\x89PNG\r\n\x1a\nfake-png-data"
         att = _make_attachment(
             filename="image.png",
             content_type="image/png",
-            size=100,
-            url=cdn_url,
+            size=len(image_bytes),
+            content=image_bytes,
         )
         msg = _make_message(content="see image", attachments=[att])
 
-        prompt, image_urls = await build_prompt_and_images(msg)
+        prompt, images = await build_prompt_and_images(msg)
 
         assert prompt == "see image"
-        assert len(image_urls) == 1
-        assert image_urls[0] == cdn_url
-        att.read.assert_not_called()
+        assert len(images) == 1
+        assert images[0].media_type == "image/png"
+        assert images[0].data == base64.standard_b64encode(image_bytes).decode("ascii")
+        att.read.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_jpeg_image_media_type(self) -> None:
+        """JPEG images get the correct media_type."""
+        jpeg_bytes = b"\xff\xd8\xff\xe0fake-jpeg"
+        att = _make_attachment(
+            filename="photo.jpg",
+            content_type="image/jpeg",
+            size=len(jpeg_bytes),
+            content=jpeg_bytes,
+        )
+        msg = _make_message(content="", attachments=[att])
+
+        _, images = await build_prompt_and_images(msg)
+
+        assert len(images) == 1
+        assert images[0].media_type == "image/jpeg"
+
+    @pytest.mark.asyncio
+    async def test_webp_image_media_type(self) -> None:
+        """WebP images get the correct media_type."""
+        att = _make_attachment(
+            filename="pic.webp",
+            content_type="image/webp",
+            size=100,
+            content=b"webp-data",
+        )
+        msg = _make_message(content="", attachments=[att])
+
+        _, images = await build_prompt_and_images(msg)
+
+        assert len(images) == 1
+        assert images[0].media_type == "image/webp"
 
     @pytest.mark.asyncio
     async def test_binary_non_image_skipped(self) -> None:
@@ -190,6 +225,22 @@ class TestBuildPromptAndImages:
         assert "b.md" in prompt
         assert "beta" in prompt
 
+    @pytest.mark.asyncio
+    async def test_image_download_failure_skipped(self) -> None:
+        """If image download fails, it's silently skipped."""
+        att = _make_attachment(
+            filename="broken.png",
+            content_type="image/png",
+            size=100,
+        )
+        att.read = AsyncMock(side_effect=Exception("download failed"))
+        msg = _make_message(content="see this", attachments=[att])
+
+        prompt, images = await build_prompt_and_images(msg)
+
+        assert prompt == "see this"
+        assert images == []
+
 
 class TestNoContentType:
     """content_type が None のとき（Discord のロングテキスト自動変換等）の動作。"""
@@ -206,11 +257,11 @@ class TestNoContentType:
         att.content_type = None  # content_type を明示的に None に
         msg = _make_message(content="", attachments=[att])
 
-        prompt, image_urls = await build_prompt_and_images(msg)
+        prompt, images = await build_prompt_and_images(msg)
 
         assert "message.txt" in prompt
         assert "long message" in prompt
-        assert image_urls == []
+        assert images == []
 
     @pytest.mark.asyncio
     async def test_no_content_type_py_extension_treated_as_text(self) -> None:
@@ -239,27 +290,28 @@ class TestNoContentType:
         att.content_type = None
         msg = _make_message(content="what is this", attachments=[att])
 
-        prompt, image_urls = await build_prompt_and_images(msg)
+        prompt, images = await build_prompt_and_images(msg)
 
         assert "data.bin" not in prompt
-        assert image_urls == []
+        assert images == []
 
     @pytest.mark.asyncio
-    async def test_no_content_type_png_extension_not_sent_as_image(self) -> None:
-        """content_type なし＋.png 拡張子でも、CDN URL が image_urls に入るべき。"""
+    async def test_no_content_type_png_extension_downloaded_as_image(self) -> None:
+        """content_type なし＋.png 拡張子 → ダウンロードして base64 ImageData に。"""
+        image_bytes = b"\x89PNGfakedata"
         att = _make_attachment(
             filename="screenshot.png",
             content_type=None,
-            url="https://cdn.discordapp.com/attachments/1/2/screenshot.png",
-            content=b"",
+            content=image_bytes,
         )
         att.content_type = None
         msg = _make_message(content="see this", attachments=[att])
 
-        _, image_urls = await build_prompt_and_images(msg)
+        _, images = await build_prompt_and_images(msg)
 
-        assert len(image_urls) == 1
-        assert "screenshot.png" in image_urls[0]
+        assert len(images) == 1
+        assert images[0].media_type == "image/png"
+        assert images[0].data == base64.standard_b64encode(image_bytes).decode("ascii")
 
 
 class TestLargeTextAttachment:

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from claude_discord.claude.types import ImageData
 from claude_discord.cogs.run_config import RunConfig
 
 
@@ -20,6 +21,9 @@ def _make_config(**overrides):
     return RunConfig(**defaults)
 
 
+_SAMPLE_IMAGE = ImageData(data="aGVsbG8=", media_type="image/png")
+
+
 class TestRunConfigValidation:
     """Test RunConfig.__post_init__ validation."""
 
@@ -29,10 +33,10 @@ class TestRunConfigValidation:
             _make_config(prompt="")
 
     def test_empty_prompt_with_images_allowed(self):
-        """Empty prompt with image_urls should be accepted."""
-        config = _make_config(prompt="", image_urls=["https://cdn.example.com/img.png"])
+        """Empty prompt with images should be accepted."""
+        config = _make_config(prompt="", images=[_SAMPLE_IMAGE])
         assert config.prompt == ""
-        assert config.image_urls == ["https://cdn.example.com/img.png"]
+        assert config.images == [_SAMPLE_IMAGE]
 
     def test_nonempty_prompt_no_images_allowed(self):
         """Normal text prompt should work as before."""
@@ -41,17 +45,17 @@ class TestRunConfigValidation:
 
     def test_nonempty_prompt_with_images_allowed(self):
         """Text prompt with images should work."""
-        config = _make_config(prompt="describe this", image_urls=["https://example.com/a.png"])
+        config = _make_config(prompt="describe this", images=[_SAMPLE_IMAGE])
         assert config.prompt == "describe this"
 
     def test_empty_prompt_empty_images_raises(self):
         """Empty prompt with empty image list should raise ValueError."""
         with pytest.raises(ValueError, match="must not be empty"):
-            _make_config(prompt="", image_urls=[])
+            _make_config(prompt="", images=[])
 
     def test_with_prompt_preserves_images(self):
-        """with_prompt should carry over image_urls."""
-        original = _make_config(prompt="old", image_urls=["https://example.com/img.png"])
+        """with_prompt should carry over images."""
+        original = _make_config(prompt="old", images=[_SAMPLE_IMAGE])
         updated = original.with_prompt("new prompt")
         assert updated.prompt == "new prompt"
-        assert updated.image_urls == ["https://example.com/img.png"]
+        assert updated.images == [_SAMPLE_IMAGE]

--- a/tests/test_run_helper.py
+++ b/tests/test_run_helper.py
@@ -10,6 +10,7 @@ import discord
 import pytest
 
 from claude_discord.claude.types import (
+    ImageData,
     MessageType,
     StreamEvent,
     ToolCategory,
@@ -1113,8 +1114,10 @@ class TestImageOnlyRunConfig:
     """Regression tests: image-only messages (empty prompt) through run_claude_with_config.
 
     The bug: RunConfig.__post_init__ rejected empty prompts unconditionally,
-    but image-only Discord messages produce prompt="" with valid image_urls.
+    but image-only Discord messages produce prompt="" with valid images.
     """
+
+    _SAMPLE_IMAGE = ImageData(data="aGVsbG8=", media_type="image/png")
 
     @pytest.fixture
     def thread(self) -> MagicMock:
@@ -1146,39 +1149,39 @@ class TestImageOnlyRunConfig:
 
     @pytest.mark.asyncio
     async def test_empty_prompt_with_images_completes(self, thread: MagicMock) -> None:
-        """run_claude_with_config with prompt='' and image_urls must complete without error."""
+        """run_claude_with_config with prompt='' and images must complete without error."""
         runner = MagicMock()
         runner.working_dir = None
-        runner.image_urls = None
+        runner.images = None
         runner.run = self._make_async_gen(self._simple_events())
 
         config = RunConfig(
             thread=thread,
             runner=runner,
             prompt="",
-            image_urls=["https://cdn.discordapp.com/attachments/111/222/photo.png"],
+            images=[self._SAMPLE_IMAGE],
         )
 
         session_id = await run_claude_with_config(config)
         assert session_id == "sess-img"
 
     @pytest.mark.asyncio
-    async def test_image_urls_injected_into_runner(self, thread: MagicMock) -> None:
-        """Image URLs from config must be set on the runner before run() is called."""
+    async def test_images_injected_into_runner(self, thread: MagicMock) -> None:
+        """Images from config must be set on the runner before run() is called."""
         runner = MagicMock()
         runner.working_dir = None
-        runner.image_urls = None
+        runner.images = None
         runner.run = self._make_async_gen(self._simple_events())
 
         config = RunConfig(
             thread=thread,
             runner=runner,
             prompt="",
-            image_urls=["https://example.com/img.png"],
+            images=[self._SAMPLE_IMAGE],
         )
 
         await run_claude_with_config(config)
-        assert runner.image_urls == ["https://example.com/img.png"]
+        assert runner.images == [self._SAMPLE_IMAGE]
 
 
 class TestCompactRerun:
@@ -1210,7 +1213,7 @@ class TestCompactRerun:
         """After compact_boundary, run_claude_with_config must call runner.run() a second time."""
         runner = MagicMock()
         runner.working_dir = None
-        runner.image_urls = None
+        runner.images = None
         runner.interrupt = AsyncMock()
 
         compact_events = [
@@ -1251,7 +1254,7 @@ class TestCompactRerun:
         """The rerun invokes runner.clone() with an append_system_prompt guardrail."""
         runner = MagicMock()
         runner.working_dir = None
-        runner.image_urls = None
+        runner.images = None
         runner.interrupt = AsyncMock()
 
         compact_events = [
@@ -1281,7 +1284,7 @@ class TestCompactRerun:
         # Clone returns a runner that delivers rerun_events.
         cloned_runner = MagicMock()
         cloned_runner.working_dir = None
-        cloned_runner.image_urls = None
+        cloned_runner.images = None
         cloned_runner.interrupt = AsyncMock()
         cloned_runner.run = mock_run  # same mock; call_count distinguishes runs
 
@@ -1304,7 +1307,7 @@ class TestCompactRerun:
         """When compact fires during a post_compact_rerun, do NOT interrupt again (no loop)."""
         runner = MagicMock()
         runner.working_dir = None
-        runner.image_urls = None
+        runner.images = None
         runner.interrupt = AsyncMock()
 
         events = [
@@ -1340,13 +1343,13 @@ class TestCompactRerun:
         """
         original_runner = MagicMock()
         original_runner.working_dir = None
-        original_runner.image_urls = None
+        original_runner.images = None
         original_runner.interrupt = AsyncMock()
         original_runner.model = "test-model"
 
         cloned_runner = MagicMock()
         cloned_runner.working_dir = None
-        cloned_runner.image_urls = None
+        cloned_runner.images = None
         cloned_runner.interrupt = AsyncMock()
         cloned_runner.model = "test-model"
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from claude_discord.claude.runner import ClaudeRunner, _resolve_windows_cmd
+from claude_discord.claude.types import ImageData
 
 
 class TestBuildArgs:
@@ -467,47 +468,36 @@ class TestSignalKillSuppression:
 class TestImageStreamJson:
     """Tests for --input-format stream-json image attachment support.
 
-    Regression tests for the bug where --image flags were added to the CLI
-    args even though the flag does not exist in claude CLI.  Images must be
-    passed via --input-format stream-json / stdin instead.
-
-    Images are passed as HTTPS URL content blocks (``{"type": "url", "url": ...}``),
-    not base64.  Claude Code CLI silently drops base64 image blocks in stream-json
-    input mode (confirmed with CLI 2.1.59); URL type is the only format that
-    reaches the Anthropic API through the CLI's stream-json input pipeline.
-
-    See: https://github.com/ebibibi/claude-code-discord-bridge/issues/177
+    Images are downloaded by prompt_builder, base64-encoded, and passed as
+    ``ImageData`` objects.  The runner sends them as base64-type content blocks
+    via stream-json stdin.
     """
+
+    _SAMPLE_IMG = ImageData(data="aGVsbG8=", media_type="image/png")
 
     def test_no_image_flag_in_args(self) -> None:
         """_build_args() must NOT produce --image flags (flag does not exist)."""
-        runner = ClaudeRunner(image_urls=["https://cdn.discordapp.com/photo.png"])
+        runner = ClaudeRunner(images=[self._SAMPLE_IMG])
         args = runner._build_args("look at this", session_id=None)
         assert "--image" not in args
 
     def test_stream_json_input_format_added_for_images(self) -> None:
-        """_build_args() adds --input-format stream-json when image_urls is set."""
-        runner = ClaudeRunner(image_urls=["https://cdn.discordapp.com/photo.png"])
+        """_build_args() adds --input-format stream-json when images is set."""
+        runner = ClaudeRunner(images=[self._SAMPLE_IMG])
         args = runner._build_args("look at this", session_id=None)
         assert "--input-format" in args
         idx = args.index("--input-format")
         assert args[idx + 1] == "stream-json"
 
     def test_prompt_not_in_cli_args_when_images_present(self) -> None:
-        """Prompt must NOT appear as a CLI arg when using stream-json input.
-
-        In stream-json mode the prompt is part of the JSON sent to stdin.
-        Passing it as a CLI arg as well would cause a duplicate-input error.
-        """
-        runner = ClaudeRunner(image_urls=["https://cdn.discordapp.com/photo.png"])
+        """Prompt must NOT appear as a CLI arg when using stream-json input."""
+        runner = ClaudeRunner(images=[self._SAMPLE_IMG])
         args = runner._build_args("look at this", session_id=None)
-        # Double-dash separator must not be present
         assert "--" not in args
-        # Prompt must not appear as a positional arg
         assert "look at this" not in args
 
     def test_no_stream_json_input_format_without_images(self) -> None:
-        """Without image_urls, --input-format stream-json is NOT added."""
+        """Without images, --input-format stream-json is NOT added."""
         runner = ClaudeRunner()
         args = runner._build_args("hello", session_id=None)
         assert "--input-format" not in args
@@ -519,20 +509,13 @@ class TestImageStreamJson:
         assert args[-1] == "hello"
         assert args[-2] == "--"
 
-    # ── tests ─────────────────────────────────────────────────────────────────
-
     @pytest.mark.asyncio
-    async def test_send_stream_json_message_url_format(self) -> None:
-        """Images are sent as url-type blocks, NOT base64.
-
-        Claude Code CLI silently drops base64 image blocks in stream-json input
-        mode.  URL-type image blocks are the only format that reaches the
-        Anthropic API through the CLI's stream-json pipeline.
-        """
+    async def test_send_stream_json_message_base64_format(self) -> None:
+        """Images are sent as base64-type blocks with media_type."""
         import json
 
-        image_url = "https://cdn.discordapp.com/attachments/123/456/photo.png"
-        runner = ClaudeRunner(image_urls=[image_url])
+        img = ImageData(data="aW1hZ2VkYXRh", media_type="image/png")
+        runner = ClaudeRunner(images=[img])
 
         written: list[bytes] = []
 
@@ -549,18 +532,17 @@ class TestImageStreamJson:
 
         await runner._send_stream_json_message("describe this image")
 
-        assert len(written) == 1, "stdin.write should be called exactly once"
+        assert len(written) == 1
         payload = json.loads(written[0].decode())
 
         content = payload["message"]["content"]
-        assert len(content) == 2, "should have one image block + one text block"
+        assert len(content) == 2
 
         img_block = content[0]
         assert img_block["type"] == "image"
-        assert img_block["source"]["type"] == "url", (
-            "image source must be 'url' type — base64 is silently dropped by Claude Code CLI"
-        )
-        assert img_block["source"]["url"] == image_url
+        assert img_block["source"]["type"] == "base64"
+        assert img_block["source"]["media_type"] == "image/png"
+        assert img_block["source"]["data"] == "aW1hZ2VkYXRh"
 
         text_block = content[1]
         assert text_block["type"] == "text"
@@ -568,16 +550,11 @@ class TestImageStreamJson:
 
     @pytest.mark.asyncio
     async def test_send_stream_json_message_empty_prompt_omits_text_block(self) -> None:
-        """Empty prompt must NOT add a text block.
-
-        The Anthropic API rejects empty text blocks when cache_control is set:
-        "cache_control cannot be set for empty text blocks"
-        This happens when the user sends just an image with no text in Discord.
-        """
+        """Empty prompt must NOT add a text block."""
         import json
 
-        image_url = "https://cdn.discordapp.com/attachments/123/456/photo.png"
-        runner = ClaudeRunner(image_urls=[image_url])
+        img = ImageData(data="aW1hZ2VkYXRh", media_type="image/jpeg")
+        runner = ClaudeRunner(images=[img])
 
         written: list[bytes] = []
 
@@ -598,17 +575,17 @@ class TestImageStreamJson:
         payload = json.loads(written[0].decode())
         content = payload["message"]["content"]
 
-        assert len(content) == 1, "empty prompt: only the image block, no text block"
+        assert len(content) == 1
         assert content[0]["type"] == "image"
 
     @pytest.mark.asyncio
-    async def test_run_uses_pipe_stdin_and_sends_image_url_via_stdin(self) -> None:
-        """run() uses stdin=PIPE and the JSON written to stdin contains the image URL."""
+    async def test_run_uses_pipe_stdin_and_sends_base64_image(self) -> None:
+        """run() uses stdin=PIPE and sends base64 image data via stdin."""
         import asyncio as _asyncio
         import json
 
-        image_url = "https://cdn.discordapp.com/attachments/123/456/photo.png"
-        runner = ClaudeRunner(image_urls=[image_url])
+        img = ImageData(data="aW1hZ2VkYXRh", media_type="image/png")
+        runner = ClaudeRunner(images=[img])
 
         written: list[bytes] = []
 
@@ -638,30 +615,18 @@ class TestImageStreamJson:
         ):
             _ = [event async for event in runner.run("what do you see?")]
 
-        # 1. subprocess must have been started with stdin=PIPE
         call_kwargs = mock_exec.call_args[1]
-        assert call_kwargs["stdin"] == _asyncio.subprocess.PIPE, (
-            "stdin must be PIPE when images are present, not DEVNULL"
-        )
+        assert call_kwargs["stdin"] == _asyncio.subprocess.PIPE
 
-        # 2. stdin.write must have been called — image data was actually sent
-        assert len(written) == 1, "stdin.write should be called once with the user message"
+        assert len(written) == 1
 
         payload = json.loads(written[0].decode())
         content = payload["message"]["content"]
 
-        # 3. image block must be present and use url type
         image_blocks = [c for c in content if c.get("type") == "image"]
-        assert len(image_blocks) == 1, "exactly one image block expected"
-        assert image_blocks[0]["source"]["type"] == "url", (
-            "image source must be 'url' type — base64 is silently dropped by Claude Code CLI"
-        )
-        assert image_blocks[0]["source"]["url"] == image_url
-
-        # 4. text prompt must also be present
-        text_blocks = [c for c in content if c.get("type") == "text"]
-        assert len(text_blocks) == 1
-        assert text_blocks[0]["text"] == "what do you see?"
+        assert len(image_blocks) == 1
+        assert image_blocks[0]["source"]["type"] == "base64"
+        assert image_blocks[0]["source"]["media_type"] == "image/png"
 
     @pytest.mark.asyncio
     async def test_run_uses_devnull_stdin_without_images(self) -> None:
@@ -677,7 +642,7 @@ class TestImageStreamJson:
         mock_process.stdout.readline = AsyncMock(return_value=b"")
         mock_process.stderr = AsyncMock()
         mock_process.stderr.read = AsyncMock(return_value=b"")
-        mock_process.stdin = None  # DEVNULL → no stdin attribute
+        mock_process.stdin = None
         mock_process.wait = AsyncMock(return_value=0)
 
         with (
@@ -690,20 +655,18 @@ class TestImageStreamJson:
             _ = [event async for event in runner.run("hello")]
 
         call_kwargs = mock_exec.call_args[1]
-        assert call_kwargs["stdin"] == _asyncio.subprocess.DEVNULL, (
-            "text-only sessions must use DEVNULL to avoid stdin-hang"
-        )
+        assert call_kwargs["stdin"] == _asyncio.subprocess.DEVNULL
 
     @pytest.mark.asyncio
-    async def test_multiple_image_urls_all_sent(self) -> None:
-        """Multiple image URLs are all included as separate url-type image blocks."""
+    async def test_multiple_images_all_sent(self) -> None:
+        """Multiple images are all included as separate base64-type image blocks."""
         import json
 
-        urls = [
-            "https://cdn.discordapp.com/attachments/1/2/a.png",
-            "https://cdn.discordapp.com/attachments/1/2/b.jpg",
+        imgs = [
+            ImageData(data="aW1n", media_type="image/png"),
+            ImageData(data="anBn", media_type="image/jpeg"),
         ]
-        runner = ClaudeRunner(image_urls=urls)
+        runner = ClaudeRunner(images=imgs)
 
         written: list[bytes] = []
 
@@ -724,9 +687,9 @@ class TestImageStreamJson:
         content = payload["message"]["content"]
 
         image_blocks = [c for c in content if c.get("type") == "image"]
-        assert len(image_blocks) == 2, "both image URLs must appear as image blocks"
-        sent_urls = [b["source"]["url"] for b in image_blocks]
-        assert sent_urls == urls
+        assert len(image_blocks) == 2
+        assert image_blocks[0]["source"]["data"] == "aW1n"
+        assert image_blocks[1]["source"]["data"] == "anBn"
 
 
 class TestResolveWindowsCmd:

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "2.0.15"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- Discord CDN URLを直接渡す方式から、ccdb側で画像をダウンロードしてbase64エンコードして送信する方式に変更
- Claude Code CLIの内部URL-to-base64変換がPNG形式を拒否する問題を解決
- `ImageData` dataclassを `types.py` に追加し、画像パイプライン全体をリファクタリング

## 変更内容
- `types.py`: `ImageData(data, media_type)` frozen dataclass追加
- `prompt_builder.py`: 画像をDiscord CDNからダウンロード → base64エンコード → `ImageData`で返却
- `runner.py`: stream-jsonでURL blockの代わりにbase64 blockを送信
- `run_config.py`: `image_urls: list[str]` → `images: list[ImageData]`
- `claude_chat.py`, `_run_helper.py`: 上記に合わせてリネーム

## 原因
```
API Error: 400 {"type":"error","error":{"type":"invalid_request_error",
"message":"messages.11.content.16.image.source.base64.data: Image format image/png not supported"}}
```
CLIがURL画像を内部でfetch→base64変換する際にPNGが拒否されていた。ccdb側でbase64変換を行うことで回避。

## Test plan
- [x] `test_prompt_builder.py` — 画像ダウンロード・base64エンコード・media_type検出
- [x] `test_runner.py` — base64画像ブロックのstream-json送信
- [x] `test_run_config.py` — ImageData対応のバリデーション
- [x] `test_claude_chat.py` — E2E画像パイプライン
- [x] `test_run_helper.py::TestImageOnlyRunConfig` — 画像のみメッセージ
- [x] ruff lint/format pass
- [ ] dev-on で実際にPNG画像をDiscordで送って動作確認