### PR TITLE
feat: add /resume command

### DIFF
--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -59,6 +59,7 @@ _HELP_CATEGORY: dict[str, str | None] = {
     "context": "📌 Session",
     "usage": "📌 Session",
     "sessions": "📌 Session",
+    "resume": "📌 Session",
     "resume-info": "📌 Session",
     "sync-sessions": "📌 Session",
     "sync-settings": "📌 Session",

--- a/claude_discord/cogs/session_manage.py
+++ b/claude_discord/cogs/session_manage.py
@@ -20,7 +20,7 @@ from discord.ext import commands
 from ..database.repository import SessionRepository, UsageStatsRepository
 from ..database.settings_repo import SettingsRepository
 from ..discord_ui.embeds import COLOR_ERROR, COLOR_INFO, COLOR_SUCCESS, COLOR_TOOL
-from ..discord_ui.views import ToolSelectView
+from ..discord_ui.views import ResumeSelectView, ToolSelectView
 from ..worktree import WorktreeManager
 from .session_sync import sync_cli_sessions
 
@@ -414,6 +414,27 @@ class SessionManageCog(commands.Cog):
             embed.set_footer(text="Setting updated! New syncs will use this style.")
 
         await interaction.response.send_message(embed=embed)
+
+    @app_commands.command(
+        name="resume",
+        description="Resume a previous session in a new thread",
+    )
+    async def resume_session(self, interaction: discord.Interaction) -> None:
+        """Show a select menu of recent sessions to resume."""
+        records = await self.repo.list_all(limit=25)
+        if not records:
+            await interaction.response.send_message(
+                "No sessions found. Start a conversation first!",
+                ephemeral=True,
+            )
+            return
+
+        view = ResumeSelectView(records=records, bot=self.bot)
+        await interaction.response.send_message(
+            "\U0001f504 **Resume** — select a session to continue:",
+            view=view,
+            ephemeral=True,
+        )
 
     @app_commands.command(
         name="resume-info",

--- a/claude_discord/discord_ui/views.py
+++ b/claude_discord/discord_ui/views.py
@@ -14,6 +14,7 @@ from ..claude.runner import ClaudeRunner
 from .embeds import COLOR_SUCCESS, stopped_embed, tool_result_embed, tool_result_preview_embed
 
 if TYPE_CHECKING:
+    from ..database.repository import SessionRecord
     from ..database.settings_repo import SettingsRepository
 
 logger = logging.getLogger(__name__)
@@ -268,6 +269,109 @@ class RewindSelectView(discord.ui.View):
 
     async def _on_cancel(self, interaction: discord.Interaction) -> None:
         await interaction.response.edit_message(content="Rewind cancelled.", view=None)
+        self.stop()
+
+    async def on_timeout(self) -> None:
+        """No-op: the message remains but the view becomes inactive."""
+
+
+_ORIGIN_ICON = {
+    "discord": "\U0001f4ac",  # 💬
+    "cli": "\U0001f5a5\ufe0f",  # 🖥️
+}
+
+
+class ResumeSelectView(discord.ui.View):
+    """Select menu for choosing a session to resume in a new thread.
+
+    Shows a list of recent sessions with their summary and origin.
+    When the user picks one, a new thread is created and the selected
+    session is resumed via ``--resume``.
+    """
+
+    def __init__(
+        self,
+        records: list[SessionRecord],
+        bot: Any,
+    ) -> None:
+        super().__init__(timeout=60)
+        self._records = records
+        self._bot = bot
+
+        options = [
+            discord.SelectOption(
+                label=self._build_label(record),
+                value=str(i),
+                description=self._build_description(record),
+            )
+            for i, record in enumerate(records[:25])
+        ]
+
+        select = discord.ui.Select(
+            placeholder="Select a session to resume...",
+            options=options,
+        )
+        select.callback = self._on_select
+        self.add_item(select)
+
+    @staticmethod
+    def _build_label(record: SessionRecord) -> str:
+        icon = _ORIGIN_ICON.get(record.origin, "")
+        summary = record.summary or "(no summary)"
+        prefix = f"{icon} " if icon else ""
+        return f"{prefix}{summary}"[:100]
+
+    @staticmethod
+    def _build_description(record: SessionRecord) -> str | None:
+        parts: list[str] = []
+        if record.working_dir:
+            dir_short = record.working_dir.rsplit("/", 1)[-1]
+            parts.append(dir_short)
+        parts.append(record.last_used_at[:16])
+        desc = " | ".join(parts)
+        return desc[:100] if desc else None
+
+    async def _on_select(self, interaction: discord.Interaction) -> None:
+        data = cast(dict[str, Any], interaction.data)
+        idx = int(data["values"][0])
+        record = self._records[idx]
+
+        chat_cog = self._bot.get_cog("ClaudeChatCog")
+        if chat_cog is None:
+            await interaction.response.edit_message(
+                content="\u274c ClaudeChatCog is not loaded — cannot resume.",
+                view=None,
+            )
+            self.stop()
+            return
+
+        channel = self._bot.get_channel(self._bot.channel_id)
+        if not isinstance(channel, discord.TextChannel):
+            await interaction.response.edit_message(
+                content="\u274c Channel not found — cannot create thread.",
+                view=None,
+            )
+            self.stop()
+            return
+
+        await interaction.response.edit_message(
+            content=f"\U0001f504 Resuming session: _{record.summary or record.session_id[:8]}_...",
+            view=None,
+        )
+
+        thread_name = f"\u25b6 {record.summary or 'Resumed session'}"[:100]
+        await chat_cog.spawn_session(
+            channel=channel,
+            prompt="Resuming previous session. Continue from where we left off.",
+            thread_name=thread_name,
+            session_id=record.session_id,
+        )
+
+        with contextlib.suppress(discord.HTTPException):
+            await interaction.followup.send(
+                "\u2705 Resumed in a new thread!",
+                ephemeral=True,
+            )
         self.stop()
 
     async def on_timeout(self) -> None:

--- a/tests/test_resume_command.py
+++ b/tests/test_resume_command.py
@@ -1,0 +1,164 @@
+"""Tests for /resume command and ResumeSelectView."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+
+from claude_discord.database.repository import SessionRecord
+
+
+def _make_record(
+    thread_id: int = 100,
+    session_id: str = "abc-123",
+    origin: str = "discord",
+    summary: str | None = "Fix login bug",
+    working_dir: str | None = "/home/user/project",
+    model: str | None = "sonnet",
+) -> SessionRecord:
+    return SessionRecord(
+        thread_id=thread_id,
+        session_id=session_id,
+        working_dir=working_dir,
+        model=model,
+        origin=origin,
+        summary=summary,
+        created_at="2026-02-19 10:00:00",
+        last_used_at="2026-02-19 11:00:00",
+    )
+
+
+def _make_interaction(*, in_thread: bool = False) -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    if in_thread:
+        interaction.channel = MagicMock(spec=discord.Thread)
+    else:
+        interaction.channel = MagicMock(spec=discord.TextChannel)
+        interaction.channel.id = 999
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _make_cog():
+    from claude_discord.cogs.session_manage import SessionManageCog
+
+    bot = MagicMock()
+    bot.channel_id = 999
+    bot.get_channel = MagicMock(return_value=MagicMock(spec=discord.TextChannel))
+    bot.get_cog = MagicMock(return_value=None)
+    repo = MagicMock()
+    repo.get = AsyncMock(return_value=None)
+    repo.list_all = AsyncMock(return_value=[])
+    repo.get_by_session_id = AsyncMock(return_value=None)
+    return SessionManageCog(bot=bot, repo=repo)
+
+
+class TestResumeCommand:
+    """Tests for /resume slash command."""
+
+    async def test_no_sessions_sends_ephemeral(self):
+        """When no sessions exist, /resume shows an ephemeral message."""
+        cog = _make_cog()
+        cog.repo.list_all = AsyncMock(return_value=[])
+        interaction = _make_interaction()
+        await cog.resume_session.callback(cog, interaction)
+        call_args = interaction.response.send_message.call_args
+        assert call_args.kwargs.get("ephemeral") is True
+
+    async def test_shows_select_menu_with_sessions(self):
+        """When sessions exist, /resume shows a select menu."""
+        cog = _make_cog()
+        records = [
+            _make_record(thread_id=100, session_id="aaa-111", summary="First task"),
+            _make_record(thread_id=101, session_id="bbb-222", summary="Second task"),
+        ]
+        cog.repo.list_all = AsyncMock(return_value=records)
+        interaction = _make_interaction()
+        await cog.resume_session.callback(cog, interaction)
+        call_args = interaction.response.send_message.call_args
+        # Should have a view attached
+        assert call_args.kwargs.get("view") is not None
+
+    async def test_sessions_limited_to_25(self):
+        """Select menu options are capped at 25 (Discord limit)."""
+        cog = _make_cog()
+        records = [
+            _make_record(thread_id=i, session_id=f"sess-{i:03d}", summary=f"Task {i}")
+            for i in range(30)
+        ]
+        cog.repo.list_all = AsyncMock(return_value=records)
+        interaction = _make_interaction()
+        await cog.resume_session.callback(cog, interaction)
+        call_args = interaction.response.send_message.call_args
+        view = call_args.kwargs.get("view")
+        assert view is not None
+        # Find the select menu in the view's children
+        selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+        assert len(selects) == 1
+        assert len(selects[0].options) <= 25
+
+
+class TestResumeSelectView:
+    """Tests for ResumeSelectView."""
+
+    async def test_creates_options_from_records(self):
+        from claude_discord.discord_ui.views import ResumeSelectView
+
+        records = [
+            _make_record(session_id="aaa-111", summary="First task"),
+            _make_record(session_id="bbb-222", summary="Second task", working_dir="/tmp"),
+        ]
+        view = ResumeSelectView(
+            records=records,
+            bot=MagicMock(),
+        )
+        selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+        assert len(selects) == 1
+        assert len(selects[0].options) == 2
+
+    async def test_option_labels_contain_summary(self):
+        from claude_discord.discord_ui.views import ResumeSelectView
+
+        records = [
+            _make_record(session_id="aaa-111", summary="My cool task"),
+        ]
+        view = ResumeSelectView(records=records, bot=MagicMock())
+        selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+        assert "My cool task" in selects[0].options[0].label
+
+    async def test_option_value_is_index(self):
+        from claude_discord.discord_ui.views import ResumeSelectView
+
+        records = [
+            _make_record(session_id="aaa-111", summary="First"),
+            _make_record(session_id="bbb-222", summary="Second"),
+        ]
+        view = ResumeSelectView(records=records, bot=MagicMock())
+        selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+        assert selects[0].options[0].value == "0"
+        assert selects[0].options[1].value == "1"
+
+    async def test_no_summary_shows_fallback(self):
+        from claude_discord.discord_ui.views import ResumeSelectView
+
+        records = [
+            _make_record(session_id="aaa-111", summary=None),
+        ]
+        view = ResumeSelectView(records=records, bot=MagicMock())
+        selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+        assert selects[0].options[0].label != ""
+
+    async def test_description_contains_working_dir(self):
+        from claude_discord.discord_ui.views import ResumeSelectView
+
+        records = [
+            _make_record(session_id="aaa-111", summary="Task", working_dir="/home/user/myproject"),
+        ]
+        view = ResumeSelectView(records=records, bot=MagicMock())
+        selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+        assert "myproject" in (selects[0].options[0].description or "")


### PR DESCRIPTION
## Summary
- `/resume` コマンドを追加。Discord上でセッション一覧を表示し、選択したセッションを新スレッドで再開できる
- Claude Code CLIの `/resume` と同じ体験をDiscordで実現
- `ResumeSelectView` (Select Menu) → セッション選択 → `spawn_session` で新スレッド作成＆resume

## Changes
- `claude_discord/discord_ui/views.py`: `ResumeSelectView` 追加
- `claude_discord/cogs/session_manage.py`: `/resume` スラッシュコマンド追加
- `claude_discord/cogs/claude_chat.py`: `_HELP_CATEGORY` にエントリ追加
- `tests/test_resume_command.py`: コマンド・Viewのテスト8件

## Test plan
- [x] `/resume` でセッションがない場合、ephemeralメッセージを表示
- [x] `/resume` でセッションがある場合、Select Menuを表示
- [x] Select Menuのオプションが25件以下に制限される
- [x] オプションのラベルにサマリーが含まれる
- [x] サマリーなしの場合フォールバックテキストを表示
- [x] descriptionにworking dirを表示
- [x] `test_help_sync` が通る（_HELP_CATEGORY同期）
- [ ] Discord上で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)