### PR TITLE
fix: checkout uv.lock before git pull in pre-start.sh

### DIFF
--- a/scripts/pre-start.sh
+++ b/scripts/pre-start.sh
@@ -44,6 +44,8 @@ LOCAL_CHANGES=$(git status --porcelain 2>/dev/null | grep -v '^ M uv.lock$' | gr
 if [ "$CURRENT_BRANCH" != "main" ] || [ -n "$LOCAL_CHANGES" ]; then
     echo "[pre-start] Local dev mode (branch: $CURRENT_BRANCH) — skipping git pull" >&2
 else
+    # Discard uv.lock changes before pull — uv sync regenerates it afterwards.
+    git checkout -- uv.lock 2>/dev/null || true
     echo "[pre-start] Pulling latest code..." >&2
     set +e
     git pull --ff-only origin main 2>&1


### PR DESCRIPTION
## Summary
- `uv sync` regenerates `uv.lock` on every run, leaving it as an unstaged change
- The `LOCAL_CHANGES` filter correctly excluded `uv.lock` from the "should we pull?" decision
- But `git pull` itself still failed because git saw the dirty `uv.lock` (especially with `pull.rebase=true` in global gitconfig)
- Fix: explicitly `git checkout -- uv.lock` before attempting the pull

## Test plan
- [ ] Restart bot with modified `uv.lock` in working tree
- [ ] Verify `pre-start.sh` successfully pulls latest code instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)