### PR TITLE
feat: save prompt as session summary for /resume display

### DIFF
--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -247,7 +247,16 @@ class EventProcessor:
 
         self._state.session_id = event.session_id
         if self._config.repo:
-            await self._config.repo.save(self._config.thread.id, self._state.session_id)
+            # For new sessions, save the prompt as the summary so /resume can display it.
+            # For resumed sessions (config.session_id is set), pass no summary to keep
+            # the existing one via COALESCE in the SQL query.
+            if self._config.session_id:
+                await self._config.repo.save(self._config.thread.id, self._state.session_id)
+            else:
+                summary = self._config.prompt[:100] if self._config.prompt else None
+                await self._config.repo.save(
+                    self._config.thread.id, self._state.session_id, summary=summary
+                )
 
         # Guard: post session_start_embed only once (Claude can emit multiple SYSTEM events).
         # Skip in chat_only mode — no session start embed.

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -100,7 +100,10 @@ class TestOnSystem:
         assert p.session_id == "sess-abc"
 
     @pytest.mark.asyncio
-    async def test_saves_to_repo(self, thread: MagicMock, runner: MagicMock) -> None:
+    async def test_saves_to_repo_with_summary_for_new_session(
+        self, thread: MagicMock, runner: MagicMock
+    ) -> None:
+        """New sessions save the prompt as summary."""
         repo = MagicMock()
         repo.save = AsyncMock()
         config = _make_config(thread, runner, repo=repo)
@@ -108,7 +111,36 @@ class TestOnSystem:
 
         await p.process(StreamEvent(message_type=MessageType.SYSTEM, session_id="s1"))
 
-        repo.save.assert_called_once_with(thread.id, "s1")
+        repo.save.assert_called_once_with(thread.id, "s1", summary="test prompt")
+
+    @pytest.mark.asyncio
+    async def test_saves_to_repo_without_summary_for_resumed_session(
+        self, thread: MagicMock, runner: MagicMock
+    ) -> None:
+        """Resumed sessions do not overwrite the existing summary."""
+        repo = MagicMock()
+        repo.save = AsyncMock()
+        config = _make_config(thread, runner, repo=repo, session_id="existing-sess")
+        p = EventProcessor(config)
+
+        await p.process(StreamEvent(message_type=MessageType.SYSTEM, session_id="existing-sess"))
+
+        repo.save.assert_called_once_with(thread.id, "existing-sess")
+
+    @pytest.mark.asyncio
+    async def test_summary_truncated_to_100_chars(
+        self, thread: MagicMock, runner: MagicMock
+    ) -> None:
+        """Summary is truncated to 100 characters."""
+        repo = MagicMock()
+        repo.save = AsyncMock()
+        long_prompt = "x" * 200
+        config = RunConfig(thread=thread, runner=runner, prompt=long_prompt, repo=repo)
+        p = EventProcessor(config)
+
+        await p.process(StreamEvent(message_type=MessageType.SYSTEM, session_id="s1"))
+
+        repo.save.assert_called_once_with(thread.id, "s1", summary="x" * 100)
 
     @pytest.mark.asyncio
     async def test_sends_start_embed_for_new_session(

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "2.1.6"
+version = "2.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -253,6 +253,9 @@ dependencies = [
 [package.optional-dependencies]
 api = [
     { name = "aiohttp" },
+]
+images = [
+    { name = "pillow" },
 ]
 
 [package.dev-dependencies]
@@ -271,9 +274,10 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'api'", specifier = ">=3.9" },
     { name = "aiosqlite", specifier = ">=0.20,<1.0" },
     { name = "discord-py", specifier = ">=2.4,<3.0" },
+    { name = "pillow", marker = "extra == 'images'", specifier = ">=10.0" },
     { name = "python-dotenv", specifier = ">=1.0,<2.0" },
 ]
-provides-extras = ["api"]
+provides-extras = ["api", "images"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- New sessions save the first prompt (truncated to 100 chars) as the `summary` field in the sessions DB
- `/resume` now shows meaningful descriptions instead of "(no summary)" for every entry
- Resumed sessions pass no summary to preserve the existing one via `COALESCE` in SQL
- Existing sessions without summaries will remain "(no summary)" until they start a new thread

## Test plan
- [x] 3 new unit tests (new session saves summary, resumed session preserves, truncation to 100 chars)
- [x] All 68 event_processor tests pass
- [x] Lint and format clean
- [ ] Discord: `/resume` shows first message for new sessions created after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)