### PR TITLE
feat: save all Discord attachments to disk with prominent header

### DIFF
--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import os
+import tempfile
 from typing import TYPE_CHECKING
 
 import discord
@@ -736,8 +738,17 @@ class ClaudeChatCog(commands.Cog):
     async def _build_prompt_and_images(
         self, message: discord.Message
     ) -> tuple[str, list[ImageData]]:
-        """Delegate to the standalone prompt_builder module."""
-        return await build_prompt_and_images(message)
+        """Delegate to the standalone prompt_builder module.
+
+        When the message has attachments, creates a temporary directory so all
+        files (including PDF, Excel, etc.) are saved to disk and their paths
+        are listed in a header prepended to the prompt.
+        """
+        save_dir: str | None = None
+        if message.attachments:
+            save_dir = os.path.join(tempfile.gettempdir(), "ccdb-uploads", str(message.id))
+            os.makedirs(save_dir, exist_ok=True)
+        return await build_prompt_and_images(message, save_dir=save_dir)
 
     async def _run_claude(
         self,

--- a/claude_discord/cogs/prompt_builder.py
+++ b/claude_discord/cogs/prompt_builder.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import base64
 import logging
+import os
 import os.path
 
 import discord
@@ -211,8 +212,70 @@ def wants_file_attachment(prompt: str) -> bool:
     return any(kw in lower for kw in _SEND_FILE_KEYWORDS)
 
 
+def _unique_path(directory: str, filename: str) -> str:
+    """Return a unique file path in *directory*, appending ``_N`` on collision."""
+    path = os.path.join(directory, filename)
+    if not os.path.exists(path):
+        return path
+    base, ext = os.path.splitext(filename)
+    counter = 1
+    while True:
+        candidate = os.path.join(directory, f"{base}_{counter}{ext}")
+        if not os.path.exists(candidate):
+            return candidate
+        counter += 1
+
+
+async def _save_attachment_to_disk(
+    attachment: discord.Attachment,
+    save_dir: str,
+    raw: bytes | None = None,
+) -> str | None:
+    """Download and save an attachment to *save_dir*.
+
+    If *raw* is already downloaded, reuse it.  Returns the absolute path on
+    success, None on failure.
+    """
+    try:
+        if raw is None:
+            raw = await attachment.read()
+        path = _unique_path(save_dir, attachment.filename)
+        with open(path, "wb") as f:
+            f.write(raw)
+        return path
+    except Exception:
+        logger.debug("Failed to save attachment %s to disk", attachment.filename, exc_info=True)
+        return None
+
+
+def _build_attachment_header(saved_files: list[tuple[str, str]]) -> str:
+    """Build a prominent header listing saved attachment paths.
+
+    Args:
+        saved_files: list of (filename, absolute_path) tuples.
+
+    Returns:
+        A formatted header string to prepend to the prompt.
+    """
+    if not saved_files:
+        return ""
+    lines = [f"[Attached files — {len(saved_files)} file(s)]"]
+    for filename, path in saved_files:
+        lines.append(f"  - {filename}: {path}")
+    lines.append(
+        "Use the Read tool to access these files. PDF/Excel/image files can all be read directly."
+    )
+    return "\n".join(lines)
+
+
+# Maximum size for attachments saved to disk (10 MB — generous for PDFs/Excel).
+MAX_SAVE_BYTES = 10_000_000
+
+
 async def build_prompt_and_images(
     message: discord.Message,
+    *,
+    save_dir: str | None = None,
 ) -> tuple[str, list[ImageData]]:
     """Build the prompt string and collect image attachments as base64 data.
 
@@ -220,6 +283,11 @@ async def build_prompt_and_images(
     inline to the prompt.  Image attachments (image/*) are downloaded from the
     Discord CDN and returned as base64-encoded ``ImageData`` objects for
     stream-json input to Claude Code CLI.
+
+    When *save_dir* is provided, **all** attachments (including PDF, Excel,
+    and other binary formats) are saved to that directory, and a prominent
+    header listing file paths is prepended to the prompt.  This lets Claude
+    access files via the Read tool that would otherwise be silently skipped.
 
     Images are downloaded and base64-encoded on the ccdb side rather than
     passing Discord CDN URLs directly.  This avoids issues where the CLI's
@@ -239,6 +307,8 @@ async def build_prompt_and_images(
     total_bytes = 0
     sections: list[str] = []
     images: list[ImageData] = []
+    # Track files saved to disk for the header.
+    saved_files: list[tuple[str, str]] = []
 
     for attachment in message.attachments[:MAX_ATTACHMENTS]:
         content_type = attachment.content_type or ""
@@ -276,41 +346,63 @@ async def build_prompt_and_images(
                     len(raw),
                     media_type,
                 )
+                # Also save to disk if save_dir is provided.
+                if save_dir is not None:
+                    saved = await _save_attachment_to_disk(attachment, save_dir, raw=raw)
+                    if saved:
+                        saved_files.append((attachment.filename, saved))
             except Exception:
                 logger.debug("Failed to download image %s", attachment.filename, exc_info=True)
             continue
 
         # ---- Text attachments → inline in prompt ----
-        if not content_type.startswith(ALLOWED_MIME_PREFIXES):
+        if content_type.startswith(ALLOWED_MIME_PREFIXES):
+            total_bytes += min(attachment.size, MAX_ATTACHMENT_BYTES)
+            if total_bytes > MAX_TOTAL_BYTES:
+                logger.debug("Stopping attachment processing: total size exceeded")
+                break
+            try:
+                data = await attachment.read()
+                text = data.decode("utf-8", errors="replace")
+                if len(text) > MAX_ATTACHMENT_BYTES:
+                    truncated_chars = MAX_ATTACHMENT_BYTES
+                    notice = (
+                        f"\n... [truncated: showing first {truncated_chars // 1000}KB"
+                        f" of {len(text) // 1000}KB]"
+                    )
+                    text = text[:truncated_chars] + notice
+                    logger.debug(
+                        "Truncated attachment %s from %d to %d chars",
+                        attachment.filename,
+                        len(data),
+                        truncated_chars,
+                    )
+                sections.append(f"\n\n--- Attached file: {attachment.filename} ---\n{text}")
+                # Also save to disk if save_dir is provided.
+                if save_dir is not None:
+                    saved = await _save_attachment_to_disk(attachment, save_dir, raw=data)
+                    if saved:
+                        saved_files.append((attachment.filename, saved))
+            except Exception:
+                logger.debug("Failed to read attachment %s", attachment.filename, exc_info=True)
+            continue
+
+        # ---- Other binary attachments (PDF, Excel, etc.) → save to disk only ----
+        if save_dir is not None and attachment.size <= MAX_SAVE_BYTES:
+            saved = await _save_attachment_to_disk(attachment, save_dir)
+            if saved:
+                saved_files.append((attachment.filename, saved))
+        else:
             logger.debug(
                 "Skipping attachment %s: unsupported type %s",
                 attachment.filename,
                 content_type,
             )
-            continue
-        total_bytes += min(attachment.size, MAX_ATTACHMENT_BYTES)
-        if total_bytes > MAX_TOTAL_BYTES:
-            logger.debug("Stopping attachment processing: total size exceeded")
-            break
-        try:
-            data = await attachment.read()
-            text = data.decode("utf-8", errors="replace")
-            if len(text) > MAX_ATTACHMENT_BYTES:
-                truncated_chars = MAX_ATTACHMENT_BYTES
-                notice = (
-                    f"\n... [truncated: showing first {truncated_chars // 1000}KB"
-                    f" of {len(text) // 1000}KB]"
-                )
-                text = text[:truncated_chars] + notice
-                logger.debug(
-                    "Truncated attachment %s from %d to %d chars",
-                    attachment.filename,
-                    len(data),
-                    truncated_chars,
-                )
-            sections.append(f"\n\n--- Attached file: {attachment.filename} ---\n{text}")
-        except Exception:
-            logger.debug("Failed to read attachment %s", attachment.filename, exc_info=True)
-            continue
 
-    return prompt + "".join(sections), images
+    # Build the final prompt.  When files are saved, prepend a header so
+    # Claude immediately sees what was attached and where to find them.
+    inline_prompt = prompt + "".join(sections)
+    if saved_files:
+        header = _build_attachment_header(saved_files)
+        return f"{header}\n\n{inline_prompt}", images
+    return inline_prompt, images

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -830,13 +830,14 @@ class TestImageOnlyMessage:
 
     @pytest.mark.asyncio
     async def test_build_prompt_and_images_returns_empty_prompt(self) -> None:
-        """Image-only message should return empty prompt + ImageData list."""
+        """Image-only message should return header + ImageData list."""
         cog = _make_cog()
         msg = self._make_image_message()
 
         prompt, images = await cog._build_prompt_and_images(msg)
 
-        assert prompt == ""
+        # With save_dir enabled, image-only messages get an attachment header.
+        assert "photo.png" in prompt
         assert len(images) == 1
         assert images[0].media_type == "image/png"
 

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import base64
 import io
+import os
+import tempfile
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
@@ -510,3 +512,179 @@ class TestLargeTextAttachment:
         assert "START" in prompt
         # 末尾の END は切り詰められて含まれない
         assert "END" not in prompt
+
+
+class TestSaveAttachmentsToDisk:
+    """save_dir が指定されたとき、全添付ファイルがディスクに保存される。"""
+
+    @pytest.mark.asyncio
+    async def test_text_attachment_saved_to_disk(self) -> None:
+        """テキスト添付はディスクに保存され、パスがプロンプトヘッダーに含まれる。"""
+        att = _make_attachment(filename="notes.txt", content=b"file content here")
+        msg = _make_message(content="check this", attachments=[att])
+
+        with tempfile.TemporaryDirectory() as save_dir:
+            prompt, _ = await build_prompt_and_images(msg, save_dir=save_dir)
+
+            # ファイルがディスクに保存されている
+            saved_path = os.path.join(save_dir, "notes.txt")
+            assert os.path.exists(saved_path)
+            with open(saved_path, "rb") as f:
+                assert f.read() == b"file content here"
+
+            # プロンプトにヘッダーが含まれる
+            assert "notes.txt" in prompt
+            assert saved_path in prompt
+
+    @pytest.mark.asyncio
+    async def test_image_saved_to_disk(self) -> None:
+        """画像添付もディスクに保存される。"""
+        image_bytes = b"\x89PNG\r\n\x1a\nfake-png-data"
+        att = _make_attachment(
+            filename="screenshot.png",
+            content_type="image/png",
+            size=len(image_bytes),
+            content=image_bytes,
+        )
+        msg = _make_message(content="see image", attachments=[att])
+
+        with tempfile.TemporaryDirectory() as save_dir:
+            prompt, images = await build_prompt_and_images(msg, save_dir=save_dir)
+
+            # ディスクに保存されている
+            saved_path = os.path.join(save_dir, "screenshot.png")
+            assert os.path.exists(saved_path)
+
+            # base64エンコードも返される（既存動作を維持）
+            assert len(images) == 1
+
+            # ヘッダーにパスが含まれる
+            assert saved_path in prompt
+
+    @pytest.mark.asyncio
+    async def test_pdf_saved_to_disk(self) -> None:
+        """PDFなど非テキスト・非画像ファイルもディスクに保存される。"""
+        pdf_content = b"%PDF-1.4 fake pdf content"
+        att = _make_attachment(
+            filename="report.pdf",
+            content_type="application/pdf",
+            size=len(pdf_content),
+            content=pdf_content,
+        )
+        msg = _make_message(content="see report", attachments=[att])
+
+        with tempfile.TemporaryDirectory() as save_dir:
+            prompt, _ = await build_prompt_and_images(msg, save_dir=save_dir)
+
+            # ディスクに保存されている
+            saved_path = os.path.join(save_dir, "report.pdf")
+            assert os.path.exists(saved_path)
+            with open(saved_path, "rb") as f:
+                assert f.read() == pdf_content
+
+            # ヘッダーにパスが含まれる
+            assert saved_path in prompt
+            assert "report.pdf" in prompt
+
+    @pytest.mark.asyncio
+    async def test_excel_saved_to_disk(self) -> None:
+        """Excelファイルもディスクに保存される。"""
+        xlsx_content = b"PK\x03\x04fake xlsx"
+        att = _make_attachment(
+            filename="data.xlsx",
+            content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            size=len(xlsx_content),
+            content=xlsx_content,
+        )
+        msg = _make_message(content="see data", attachments=[att])
+
+        with tempfile.TemporaryDirectory() as save_dir:
+            prompt, _ = await build_prompt_and_images(msg, save_dir=save_dir)
+
+            saved_path = os.path.join(save_dir, "data.xlsx")
+            assert os.path.exists(saved_path)
+            assert saved_path in prompt
+
+    @pytest.mark.asyncio
+    async def test_zip_saved_to_disk(self) -> None:
+        """ZIPファイルもディスクに保存される（以前はサイレントスキップだった）。"""
+        zip_content = b"PK\x03\x04fake zip"
+        att = _make_attachment(
+            filename="archive.zip",
+            content_type="application/zip",
+            size=len(zip_content),
+            content=zip_content,
+        )
+        msg = _make_message(content="see zip", attachments=[att])
+
+        with tempfile.TemporaryDirectory() as save_dir:
+            prompt, _ = await build_prompt_and_images(msg, save_dir=save_dir)
+
+            saved_path = os.path.join(save_dir, "archive.zip")
+            assert os.path.exists(saved_path)
+            assert saved_path in prompt
+
+    @pytest.mark.asyncio
+    async def test_header_lists_all_files(self) -> None:
+        """複数の添付ファイルのヘッダーがまとめて表示される。"""
+        attachments = [
+            _make_attachment(filename="a.txt", content=b"alpha"),
+            _make_attachment(
+                filename="b.pdf",
+                content_type="application/pdf",
+                content=b"%PDF",
+            ),
+        ]
+        msg = _make_message(content="two files", attachments=attachments)
+
+        with tempfile.TemporaryDirectory() as save_dir:
+            prompt, _ = await build_prompt_and_images(msg, save_dir=save_dir)
+
+            assert "a.txt" in prompt
+            assert "b.pdf" in prompt
+            # ヘッダーセクションが存在する
+            assert "Attached" in prompt or "添付" in prompt
+
+    @pytest.mark.asyncio
+    async def test_no_save_dir_keeps_old_behavior(self) -> None:
+        """save_dir=None（デフォルト）のとき、既存の動作が維持される。"""
+        att = _make_attachment(
+            filename="archive.zip",
+            content_type="application/zip",
+            content=b"PK...",
+        )
+        msg = _make_message(content="see zip", attachments=[att])
+
+        # save_dir なし → 従来通りzipはスキップ
+        prompt, _ = await build_prompt_and_images(msg)
+        assert prompt == "see zip"
+
+    @pytest.mark.asyncio
+    async def test_duplicate_filenames_handled(self) -> None:
+        """同名ファイルが複数あっても衝突しない。"""
+        attachments = [
+            _make_attachment(filename="file.txt", content=b"first"),
+            _make_attachment(filename="file.txt", content=b"second"),
+        ]
+        msg = _make_message(content="dupes", attachments=attachments)
+
+        with tempfile.TemporaryDirectory() as save_dir:
+            prompt, _ = await build_prompt_and_images(msg, save_dir=save_dir)
+
+            # 両方のファイルが存在する（リネームされている）
+            files = os.listdir(save_dir)
+            assert len(files) == 2
+
+    @pytest.mark.asyncio
+    async def test_header_appears_before_user_message(self) -> None:
+        """ヘッダーはユーザーメッセージの前に表示される。"""
+        att = _make_attachment(filename="data.csv", content=b"a,b,c")
+        msg = _make_message(content="analyze this", attachments=[att])
+
+        with tempfile.TemporaryDirectory() as save_dir:
+            prompt, _ = await build_prompt_and_images(msg, save_dir=save_dir)
+
+            header_pos = prompt.find("data.csv")
+            message_pos = prompt.find("analyze this")
+            # ヘッダーがユーザーメッセージより先に出現する
+            assert header_pos < message_pos


### PR DESCRIPTION
## Summary
- **All** Discord attachments (PDF, Excel, ZIP, etc.) are now saved to disk — previously silently dropped
- A clear `[Attached files]` header with absolute file paths is prepended to the prompt
- Claude can now use the Read tool to access any attached file type
- Backward compatible: existing inline text + base64 image behavior unchanged

## Problem
When users attached files to Discord messages:
1. Non-text/non-image files (PDF, Excel, ZIP) were **silently ignored** — Claude never knew they existed
2. Text files were appended at the end of the prompt with a subtle `--- Attached file ---` marker that was easy to miss

## Solution
- Added `save_dir` parameter to `build_prompt_and_images()` (keyword-only, defaults to `None` for backward compat)
- When `save_dir` is provided, all attachments are downloaded and saved to disk
- A prominent header is prepended to the prompt listing all files with their absolute paths
- `claude_chat.py` creates a temp dir at `/tmp/ccdb-uploads/{message_id}/` automatically

## Test plan
- [x] 9 new tests for disk save behavior (text, image, PDF, Excel, ZIP, duplicates, header ordering)
- [x] All 38 prompt_builder tests pass
- [x] All 100 prompt_builder + claude_chat tests pass
- [x] Backward compat: `save_dir=None` preserves exact old behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)