### PR TITLE
fix: set msg.id in test to fix Windows CI (OSError)

### DIFF
--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -815,6 +815,7 @@ class TestImageOnlyMessage:
         thread.parent_id = 999
         thread.send = AsyncMock()
         msg = MagicMock(spec=discord.Message)
+        msg.id = thread_id  # must be an int so str(msg.id) is a valid path on Windows
         msg.channel = thread
         msg.content = ""  # No text — image only
         msg.author = MagicMock()

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "2.1.9"
+version = "2.1.13"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- Fix Windows CI test failures in `TestImageOnlyMessage` caused by MagicMock's string representation containing `<>` (forbidden Windows path characters)
- Set `msg.id = thread_id` in `_make_image_message()` so `str(message.id)` produces a valid integer path component

Closes #338

## Root Cause
`_build_prompt_and_images()` uses `str(message.id)` in a temp path:
```python
save_dir = os.path.join(tempfile.gettempdir(), "ccdb-uploads", str(message.id))
```
Without explicit `msg.id`, MagicMock returns `<MagicMock name='mock.id' ...>` → `<>` invalid on Windows.

## Test plan
- [x] `TestImageOnlyMessage` passes locally (3/3 tests)
- [ ] Windows CI should now pass (was failing on 3.10, 3.11, 3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)