### PR TITLE
fix: Issue #304 自動修正

### DIFF
--- a/claude_discord/concurrency.py
+++ b/claude_discord/concurrency.py
@@ -28,7 +28,11 @@ class ActiveSession:
 
 _BASE_CONCURRENCY_NOTICE = """\
 [CONCURRENCY NOTICE — MANDATORY] You are one of MULTIPLE Claude Code sessions \
-running simultaneously via Discord. Other sessions ARE active right now. \
+running simultaneously via Discord. Your thread ID is {thread_id}. \
+Messages marked [this thread] in the AI Lounge are YOUR earlier posts from \
+this same thread — not from other sessions. After context compaction you may \
+see your own lounge messages; do NOT treat them as another session's work. \
+Other sessions ARE active right now. \
 You MUST follow these rules to avoid destroying each other's work:
 
 1. **Git — USE A WORKTREE (REQUIRED)**: Run \

--- a/tests/test_session_registry.py
+++ b/tests/test_session_registry.py
@@ -134,3 +134,23 @@ class TestConcurrencyNotice:
         notice = registry.build_concurrency_notice(1001)
         # Should mention files, ports, or processes
         assert any(word in notice.lower() for word in ["file", "port", "process", "resource"])
+
+    def test_notice_includes_own_thread_id(self) -> None:
+        """The notice should identify the current session's thread ID.
+
+        After context compaction the AI loses awareness of its own identity.
+        The concurrency notice must explicitly state the thread ID so the AI
+        can distinguish its own earlier lounge posts from other sessions'.
+        """
+        registry = SessionRegistry()
+        registry.register(1001, "my task")
+        notice = registry.build_concurrency_notice(1001)
+        assert "1001" in notice
+        assert "thread" in notice.lower()
+
+    def test_notice_includes_this_thread_guidance(self) -> None:
+        """The notice should explain that [this thread] markers are self-posts."""
+        registry = SessionRegistry()
+        registry.register(1001, "my task")
+        notice = registry.build_concurrency_notice(1001)
+        assert "[this thread]" in notice


### PR DESCRIPTION
Closes #304

Issue #304 を `claude -p` で自動解決しました。

### 変更内容

## 修正内容

**問題:** コンテキスト圧縮後、AIが自分の過去のloungeメッセージを「別セッションの投稿」と誤認してしまう。

**根本原因:** concurrency noticeに「自分のthread ID」が明記されていなかったため、圧縮後にAIが自身のアイデンティティを失う。

**変更ファイル:**

1. **`claude_discord/concurrency.py`** — `_BASE_CONCURRENCY_NOTICE` に3つの情報を追加：
   - `Your thread ID is {thread_id}` — 自分のIDを明示
   - `[this thread]` マーカーの説明 — lounge内の自分の投稿を識別する方法
   - コンテキスト圧縮後の注意 — 自分の過去投稿を別セッンと勘違いしないよう警告

2. **`tests/test_session_registry.py`** — テスト2件追加：
   - `test_notice_includes_own_thread_id` — thread IDがnoticeに含まれることを検証
   - `test_notice_includes_this_thread_guidance` — `[this thread]` の説明が含まれることを検証

`★ Insight ─────────────────────────────────────`
- Issue #304 の Proposed Fix 3項目のうち、1と2（thread_idフィールド追加・`[this thread]`アノテーション）は既にコードに実装済みだった。未実装だったのは3番目の「concurrency notice内でのthread identity明示」のみ
- `--append-system-prompt` はセッション開始時に1回だけ注入されるため、コンテキスト圧縮で失われうる。だからこそnotice内に明示的なIDと「圧縮後の注意」を書くことが重要
`─────────────────────────────────────────────────`


---
*issue_resolver.py による自動修正*