### PR TITLE
fix: send large prompts via stdin to avoid ARG_MAX errors

### DIFF
--- a/claude_discord/claude/runner.py
+++ b/claude_discord/claude/runner.py
@@ -31,6 +31,12 @@ logger = logging.getLogger(__name__)
 # Sentinel to distinguish "not provided" from None (which means "no tool restrictions").
 _UNSET = object()
 
+# Prompts larger than this (in bytes) are sent via stdin (stream-json) instead
+# of as a positional CLI argument, to avoid hitting the OS ARG_MAX limit
+# (typically 2MB on Linux).  128KB leaves ample headroom for other arguments
+# and environment variables that also count toward the limit.
+_STDIN_PROMPT_THRESHOLD = 128 * 1024
+
 
 def _resolve_windows_cmd(cmd_path: Path) -> list[str] | None:
     """Resolve a Windows npm .cmd/.bat wrapper to ``[node, cli_js]``.
@@ -135,14 +141,15 @@ class ClaudeRunner:
             "Starting Claude CLI: %s (cwd=%s, pid will follow)", " ".join(args[:6]) + " ...", cwd
         )
 
-        # When image attachments are present we use --input-format stream-json and
-        # write the user message (with base64 image data) to stdin immediately
-        # after process start.  This requires stdin=PIPE.
+        # We need stdin=PIPE when the initial user message is sent via
+        # stream-json input: either because images are attached, or because
+        # the prompt is too large for a CLI argument (ARG_MAX / E2BIG).
         #
-        # For text-only sessions we keep stdin=DEVNULL: Claude CLI blocks on startup
-        # when stdin is an open pipe in default text-input mode, and we have no data
-        # to send.
-        stdin_mode = asyncio.subprocess.PIPE if self.images else asyncio.subprocess.DEVNULL
+        # For small text-only sessions we keep stdin=DEVNULL: Claude CLI
+        # blocks on startup when stdin is an open pipe in default text-input
+        # mode, and we have no data to send.
+        use_stdin = self.images or len(prompt.encode()) > _STDIN_PROMPT_THRESHOLD
+        stdin_mode = asyncio.subprocess.PIPE if use_stdin else asyncio.subprocess.DEVNULL
 
         self._process = await asyncio.create_subprocess_exec(
             *args,
@@ -157,8 +164,8 @@ class ClaudeRunner:
         logger.info("Claude CLI started: pid=%s", self._process.pid)
 
         # For stream-json input sessions, send the initial user message (including
-        # base64 image data) to stdin now that the process is up.
-        if self.images and self._process.stdin is not None:
+        # base64 image data or large text) to stdin now that the process is up.
+        if use_stdin and self._process.stdin is not None:
             await self._send_stream_json_message(prompt)
 
         try:
@@ -370,11 +377,13 @@ class ClaudeRunner:
         if self.append_system_prompt:
             args.extend(["--append-system-prompt", self.append_system_prompt])
 
-        if self.images:
+        if self.images or len(prompt.encode()) > _STDIN_PROMPT_THRESHOLD:
             # Images are passed via stdin as base64 content blocks in the
-            # stream-json input protocol.  The --input-format flag tells the
-            # CLI to read the user message from stdin instead of the positional
-            # argument, so we do NOT append "-- <prompt>" in this branch.
+            # stream-json input protocol.  Large text prompts (>128KB) are
+            # also sent via stdin to avoid the OS ARG_MAX / E2BIG limit.
+            # The --input-format flag tells the CLI to read the user message
+            # from stdin instead of the positional argument, so we do NOT
+            # append "-- <prompt>" in this branch.
             args.extend(["--input-format", "stream-json"])
         else:
             # Use -- to separate flags from positional args (prevents prompt

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -701,6 +701,119 @@ class TestImageStreamJson:
         assert image_blocks[1]["source"]["data"] == "anBn"
 
 
+class TestLargePromptStdin:
+    """Tests for large prompt stdin passthrough to avoid ARG_MAX / E2BIG errors.
+
+    When a text-only prompt exceeds the OS command-line argument size limit,
+    the runner must switch to --input-format stream-json and send the prompt
+    via stdin instead of as a positional CLI argument.
+    """
+
+    def test_large_prompt_uses_stream_json_in_args(self) -> None:
+        """_build_args() uses --input-format stream-json for large prompts."""
+        runner = ClaudeRunner()
+        large_prompt = "x" * 200_000  # 200KB — well above any reasonable ARG_MAX
+        args = runner._build_args(large_prompt, session_id=None)
+        assert "--input-format" in args
+        idx = args.index("--input-format")
+        assert args[idx + 1] == "stream-json"
+
+    def test_large_prompt_not_in_cli_args(self) -> None:
+        """Large prompt must NOT appear as a positional CLI argument."""
+        runner = ClaudeRunner()
+        large_prompt = "x" * 200_000
+        args = runner._build_args(large_prompt, session_id=None)
+        assert "--" not in args
+        assert large_prompt not in args
+
+    def test_small_prompt_still_uses_cli_args(self) -> None:
+        """Small prompts continue to use the traditional -- <prompt> approach."""
+        runner = ClaudeRunner()
+        args = runner._build_args("hello", session_id=None)
+        assert "--input-format" not in args
+        assert args[-1] == "hello"
+        assert args[-2] == "--"
+
+    @pytest.mark.asyncio
+    async def test_run_uses_pipe_stdin_for_large_prompt(self) -> None:
+        """run() uses stdin=PIPE and sends the prompt via stdin for large prompts."""
+        import asyncio as _asyncio
+        import json
+
+        runner = ClaudeRunner()
+        large_prompt = "x" * 200_000
+
+        written: list[bytes] = []
+
+        def capture_write(data: bytes) -> None:
+            written.append(data)
+
+        mock_stdin = MagicMock()
+        mock_stdin.write = capture_write
+        mock_stdin.drain = AsyncMock()
+
+        mock_process = AsyncMock()
+        mock_process.pid = 42
+        mock_process.returncode = None
+        mock_process.stdout = AsyncMock()
+        mock_process.stdout.readline = AsyncMock(return_value=b"")
+        mock_process.stderr = AsyncMock()
+        mock_process.stderr.read = AsyncMock(return_value=b"")
+        mock_process.stdin = mock_stdin
+        mock_process.wait = AsyncMock(return_value=0)
+
+        with (
+            patch(
+                "asyncio.create_subprocess_exec",
+                return_value=mock_process,
+            ) as mock_exec,
+            patch.object(runner, "_cleanup", new_callable=AsyncMock),
+        ):
+            _ = [event async for event in runner.run(large_prompt)]
+
+        # Must use stdin=PIPE
+        call_kwargs = mock_exec.call_args[1]
+        assert call_kwargs["stdin"] == _asyncio.subprocess.PIPE
+
+        # Must have sent the prompt via stdin as stream-json
+        assert len(written) == 1
+        payload = json.loads(written[0].decode())
+        assert payload["type"] == "user"
+        content = payload["message"]["content"]
+        text_blocks = [c for c in content if c.get("type") == "text"]
+        assert len(text_blocks) == 1
+        assert text_blocks[0]["text"] == large_prompt
+
+    @pytest.mark.asyncio
+    async def test_run_still_uses_devnull_for_small_prompt(self) -> None:
+        """run() uses stdin=DEVNULL for small text-only prompts (no regression)."""
+        import asyncio as _asyncio
+
+        runner = ClaudeRunner()
+
+        mock_process = AsyncMock()
+        mock_process.pid = 42
+        mock_process.returncode = None
+        mock_process.stdout = AsyncMock()
+        mock_process.stdout.readline = AsyncMock(return_value=b"")
+        mock_process.stderr = AsyncMock()
+        mock_process.stderr.read = AsyncMock(return_value=b"")
+        mock_process.stdin = None
+        mock_process.wait = AsyncMock(return_value=0)
+
+        with (
+            patch(
+                "asyncio.create_subprocess_exec",
+                return_value=mock_process,
+            ) as mock_exec,
+            patch.object(runner, "_cleanup", new_callable=AsyncMock),
+        ):
+            _ = [event async for event in runner.run("hello")]
+
+        call_kwargs = mock_exec.call_args[1]
+        assert call_kwargs["stdin"] == _asyncio.subprocess.DEVNULL
+
+
 class TestResolveWindowsCmd:
     """Tests for _resolve_windows_cmd helper.
 

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "2.1.15"
+version = "2.1.16"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- When a text-only prompt exceeds 128KB, it is now sent via `--input-format stream-json` + stdin instead of as a CLI positional argument
- This prevents `OSError: [Errno 7] Argument list too long` when users paste large JSON files in Discord
- Reuses the existing `_send_stream_json_message()` method (previously only used for image attachments)

## Changes
- `runner.py`: Added `_STDIN_PROMPT_THRESHOLD` (128KB) constant and updated `_build_args()` / `run()` to use stdin for large prompts
- `tests/test_runner.py`: Added 5 new tests (`TestLargePromptStdin`) covering args, stdin mode, and regression for small prompts

## Test plan
- [x] Unit tests: 147/147 passed, lint clean
- [x] Live test: 278KB JSON file (MVP Privacy Data export) successfully processed via Discord

🤖 Generated with [Claude Code](https://claude.com/claude-code)