### PR TITLE
[docs-sync] Document auto_start=false for /api/spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,21 @@ curl -X POST "$CCDB_API_URL/api/spawn" \
 # Returns immediately with the thread ID; Claude runs in the background
 ```
 
+**Deferred start (`auto_start=false`)** — Create a thread and post a seed message without starting Claude immediately. Claude starts only when a user replies, and receives the seed message as context automatically.
+
+```bash
+# Post a notification; Claude starts when the user replies
+curl -X POST "$CCDB_API_URL/api/spawn" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Good morning! Here is your daily summary: ...",
+    "thread_name": "Morning Briefing",
+    "auto_start": false
+  }'
+```
+
+This is useful for notification-style workflows (e.g. daily briefings, CI alerts) where you want to display information upfront and let the user decide whether to engage Claude.
+
 Claude subprocesses receive `DISCORD_THREAD_ID` as an environment variable, so a running session can spawn child sessions to parallelize work.
 
 ### Startup Resume
@@ -746,7 +761,7 @@ uv add "claude-code-discord-bridge[api]"
 | GET | `/api/tasks` | List registered tasks |
 | DELETE | `/api/tasks/{id}` | Remove a task |
 | PATCH | `/api/tasks/{id}` | Update a task (enable/disable, change schedule) |
-| POST | `/api/spawn` | Create a new Discord thread and start a Claude Code session (non-blocking) |
+| POST | `/api/spawn` | Create a new Discord thread and start a Claude Code session (non-blocking); pass `auto_start: false` to defer Claude until the first user reply |
 | POST | `/api/mark-resume` | Mark a thread for automatic resume on next bot startup |
 | GET | `/api/lounge` | Read recent AI Lounge messages |
 | POST | `/api/lounge` | Post a message to the AI Lounge (with optional `label`) |

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -112,6 +112,21 @@ curl -X POST "$CCDB_API_URL/api/spawn" \
 # スレッド作成後すぐに返答し、Claude はバックグラウンドで実行
 ```
 
+**遅延起動 (`auto_start=false`)** — スレッドを作成してシードメッセージを投稿するが、Claude をすぐには起動しない。ユーザーが返信したときに初めて Claude が起動し、シードメッセージのコンテキストを自動的に受け取ります。
+
+```bash
+# 通知を投稿し、ユーザーが返信したときに Claude を起動
+curl -X POST "$CCDB_API_URL/api/spawn" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "おはようございます！本日のサマリーです: ...",
+    "thread_name": "モーニングブリーフィング",
+    "auto_start": false
+  }'
+```
+
+デイリーブリーフィングや CI アラートなど、情報を先に表示してユーザーが Claude に問いかけるかどうかを判断するワークフローに便利です。
+
 Claude のサブプロセスには `DISCORD_THREAD_ID` 環境変数が渡されるため、実行中のセッションから子セッションを起動して作業を並列化できます。
 
 ### スタートアップリジューム
@@ -747,7 +762,7 @@ uv add "claude-code-discord-bridge[api]"
 | GET | `/api/tasks` | 登録済みタスクの一覧 |
 | DELETE | `/api/tasks/{id}` | タスクの削除 |
 | PATCH | `/api/tasks/{id}` | タスクの更新（有効/無効、スケジュール変更） |
-| POST | `/api/spawn` | 新しい Discord スレッドを作成し Claude Code セッションを起動（非ブロッキング） |
+| POST | `/api/spawn` | 新しい Discord スレッドを作成し Claude Code セッションを起動（非ブロッキング）。`auto_start: false` を指定するとユーザーの最初の返信まで Claude の起動を延期できる |
 | POST | `/api/mark-resume` | 次回 Bot 起動時のスレッド自動リジュームを登録 |
 | GET | `/api/lounge` | AI Lounge の最近のメッセージを取得 |
 | POST | `/api/lounge` | AI Lounge にメッセージを投稿（`label` オプション） |


### PR DESCRIPTION
## Summary

- Document `auto_start=false` parameter for `POST /api/spawn` in README.md (English)
- Add usage example showing deferred-start workflow (notification → user replies → Claude starts)
- Update REST API table entry with `auto_start` description
- Apply same changes to `docs/ja/README.md` (Japanese translation)

## Changes

Added in both `README.md` and `docs/ja/README.md`:
- Explanation of `auto_start=false` behavior: thread + seed message created, Claude deferred until first user reply
- `curl` example for notification-style workflows (e.g. goodmorning briefings)
- Updated `/api/spawn` table entry to mention `auto_start: false` option

## Test plan

- [ ] Verify rendered markdown looks correct on GitHub
- [ ] Confirm code block formatting is intact
- [ ] Check links are not broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)
