### PR TITLE
feat: support auto permission mode as alternative to yolo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,13 @@ DISCORD_CHANNEL_ID=your-channel-id-here
 # Claude Code CLI Configuration
 CLAUDE_COMMAND=claude
 CLAUDE_MODEL=sonnet
-CLAUDE_PERMISSION_MODE=acceptEdits
+
+# Permission mode: "auto" (recommended), "plan", "acceptEdits", "bypassPermissions", "default"
+#   auto — AI classifies each tool call as safe/unsafe; best balance of safety and usability
+#   acceptEdits — Edit/Write auto-approved, Bash rejected
+#   Set CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true for legacy "yolo" mode (all tools, no checks)
+#   Note: yolo flag is ignored when permission mode is "auto" or "plan"
+CLAUDE_PERMISSION_MODE=auto
 CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=false
 CLAUDE_WORKING_DIR=
 

--- a/README.md
+++ b/README.md
@@ -536,9 +536,15 @@ Claude Code CLI runs in **`-p` (non-interactive) mode** when used through ccdb. 
 | `default` | ❌ **All tools rejected** — unusable | Do not use |
 | `acceptEdits` | ⚠️ Edit/Write auto-approved, Bash rejected (Claude falls back to Write for file ops) | Minimum viable option |
 | `bypassPermissions` | ✅ All tools approved | Works, but prefer the flag below |
-| **`CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`** | ✅ **All tools approved** | **Recommended** — ccdb already restricts access via `allowed_user_ids` |
+| **`auto`** | ✅ **AI-classified safety** — safe operations auto-approved, dangerous operations blocked | **Recommended** — best balance of safety and usability |
+| `plan` | ✅ AI-classified (read-only bias) — similar to auto but more conservative | For read-heavy workflows |
+| **`CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`** | ✅ **All tools approved, no safety checks** | Legacy "yolo" mode — use when auto mode is too restrictive |
 
-**Our recommendation:** Set `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`. Since ccdb controls who can interact with Claude via `allowed_user_ids`, the CLI-level permission checks add friction without meaningful security benefit. The "dangerously" in the name reflects the CLI's general-purpose warning; in the ccdb context where access is already gated, it's the practical choice.
+**Our recommendation:** Set `CLAUDE_PERMISSION_MODE=auto`. Auto mode uses an AI classifier to automatically approve safe operations (file edits, local testing, git push to working branch) while blocking dangerous ones (force push, production deploys, credential leakage). This gives Claude full autonomy for normal development work without the "anything goes" risk of yolo mode.
+
+**Fallback to yolo mode:** If auto mode blocks operations you need, set `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true` instead. Since ccdb controls who can interact with Claude via `allowed_user_ids`, the CLI-level permission checks add friction without meaningful security benefit. The "dangerously" in the name reflects the CLI's general-purpose warning; in the ccdb context where access is already gated, it's a practical choice.
+
+> **Note:** When `CLAUDE_PERMISSION_MODE` is set to `auto` or `plan`, `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` is automatically ignored — these modes have their own safety classifiers that would be overridden by the yolo flag.
 
 **For fine-grained control**, use `CLAUDE_ALLOWED_TOOLS` to allow specific tools without fully bypassing permissions:
 

--- a/claude_discord/claude/runner.py
+++ b/claude_discord/claude/runner.py
@@ -354,7 +354,12 @@ class ClaudeRunner:
         if self.include_partial_messages:
             args.append("--include-partial-messages")
 
-        if self.dangerously_skip_permissions:
+        # auto/plan modes have their own safety classifiers — adding
+        # --dangerously-skip-permissions would override them silently.
+        if self.dangerously_skip_permissions and self.permission_mode not in (
+            "auto",
+            "plan",
+        ):
             args.append("--dangerously-skip-permissions")
 
         if self.allowed_tools:

--- a/claude_discord/cogs/webhook_trigger.py
+++ b/claude_discord/cogs/webhook_trigger.py
@@ -47,6 +47,7 @@ class WebhookTrigger:
     timeout: int = 300
     allowed_tools: list[str] | None = None
     dangerously_skip_permissions: bool = True
+    permission_mode: str | None = None
 
 
 class WebhookTriggerCog(commands.Cog):
@@ -141,6 +142,8 @@ class WebhookTriggerCog(commands.Cog):
 
         runner = self.runner.clone()
         runner.dangerously_skip_permissions = trigger.dangerously_skip_permissions
+        if trigger.permission_mode is not None:
+            runner.permission_mode = trigger.permission_mode
         runner.timeout_seconds = trigger.timeout
         if trigger.working_dir:
             runner.working_dir = trigger.working_dir

--- a/examples/ebibot/.env.example
+++ b/examples/ebibot/.env.example
@@ -6,7 +6,10 @@ DISCORD_OWNER_ID=YOUR_USER_ID
 # Claude Code
 CLAUDE_COMMAND=claude
 CLAUDE_MODEL=sonnet
-CLAUDE_PERMISSION_MODE=acceptEdits
+# Permission mode: "auto" (recommended), "plan", "acceptEdits", "bypassPermissions", "default"
+# "auto" uses AI safety classifier — safe ops approved, dangerous ops blocked
+# For legacy "yolo" mode, use CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true instead
+CLAUDE_PERMISSION_MODE=auto
 CLAUDE_WORKING_DIR=/home/you
 MAX_CONCURRENT_SESSIONS=3
 SESSION_TIMEOUT_SECONDS=300

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -67,6 +67,34 @@ class TestBuildArgs:
         args = runner._build_args("hello", session_id=None)
         assert "--dangerously-skip-permissions" not in args
 
+    def test_auto_mode_suppresses_dangerously_skip(self) -> None:
+        """When permission_mode='auto', --dangerously-skip-permissions is NOT added."""
+        runner = ClaudeRunner(permission_mode="auto", dangerously_skip_permissions=True)
+        args = runner._build_args("hello", session_id=None)
+        assert "--dangerously-skip-permissions" not in args
+        idx = args.index("--permission-mode")
+        assert args[idx + 1] == "auto"
+
+    def test_auto_mode_without_yolo(self) -> None:
+        """auto mode works without dangerously_skip_permissions flag."""
+        runner = ClaudeRunner(permission_mode="auto")
+        args = runner._build_args("hello", session_id=None)
+        assert "--dangerously-skip-permissions" not in args
+        idx = args.index("--permission-mode")
+        assert args[idx + 1] == "auto"
+
+    def test_plan_mode_suppresses_dangerously_skip(self) -> None:
+        """When permission_mode='plan', --dangerously-skip-permissions is NOT added."""
+        runner = ClaudeRunner(permission_mode="plan", dangerously_skip_permissions=True)
+        args = runner._build_args("hello", session_id=None)
+        assert "--dangerously-skip-permissions" not in args
+
+    def test_yolo_still_works_with_other_modes(self) -> None:
+        """dangerously_skip_permissions works with non-auto/plan modes."""
+        runner = ClaudeRunner(permission_mode="acceptEdits", dangerously_skip_permissions=True)
+        args = runner._build_args("hello", session_id=None)
+        assert "--dangerously-skip-permissions" in args
+
     def test_include_partial_messages_default(self) -> None:
         runner = ClaudeRunner()
         args = runner._build_args("hello", session_id=None)

--- a/tests/test_webhook_trigger.py
+++ b/tests/test_webhook_trigger.py
@@ -351,6 +351,11 @@ class TestWebhookTriggerDataclass:
         assert trigger.timeout == 300
         assert trigger.allowed_tools is None
         assert trigger.dangerously_skip_permissions is True
+        assert trigger.permission_mode is None
+
+    def test_permission_mode_override(self) -> None:
+        trigger = WebhookTrigger(prompt="test", permission_mode="auto")
+        assert trigger.permission_mode == "auto"
 
     def test_frozen(self) -> None:
         trigger = WebhookTrigger(prompt="test")

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "2.1.15"
+version = "2.1.16"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- Add support for Claude Code's new `--permission-mode auto` which uses an AI safety classifier to auto-approve safe operations and block dangerous ones
- When `permission_mode` is `auto` or `plan`, `--dangerously-skip-permissions` is automatically suppressed (mutually exclusive)
- WebhookTrigger gains optional `permission_mode` override field
- README and .env.example updated with auto mode as the new recommended default

## Details

Claude Code CLI v2.1+ introduces `--permission-mode auto` as a middle ground between `acceptEdits` (too restrictive for `-p` mode) and `--dangerously-skip-permissions` (no safety checks at all). Auto mode:

- **Allows**: file edits, local testing, git push to working branch, reading credentials from config
- **Blocks**: force push, production deploys, credential leakage, data exfiltration, self-modification

This is a better fit for ccdb than yolo mode since ccdb already gates access via `allowed_user_ids`.

## Test plan
- [x] 5 new test cases for auto/plan mode suppression of yolo flag
- [x] WebhookTrigger permission_mode field tested
- [x] Existing tests still pass (103 total)
- [x] ruff check + format clean
- [ ] Deploy with `CLAUDE_PERMISSION_MODE=auto` and verify normal operations work

🤖 Generated with [Claude Code](https://claude.com/claude-code)