### PR TITLE
feat: always use stdin=PIPE for permission_request support

### DIFF
--- a/claude_discord/claude/runner.py
+++ b/claude_discord/claude/runner.py
@@ -31,12 +31,6 @@ logger = logging.getLogger(__name__)
 # Sentinel to distinguish "not provided" from None (which means "no tool restrictions").
 _UNSET = object()
 
-# Prompts larger than this (in bytes) are sent via stdin (stream-json) instead
-# of as a positional CLI argument, to avoid hitting the OS ARG_MAX limit
-# (typically 2MB on Linux).  128KB leaves ample headroom for other arguments
-# and environment variables that also count toward the limit.
-_STDIN_PROMPT_THRESHOLD = 128 * 1024
-
 
 def _resolve_windows_cmd(cmd_path: Path) -> list[str] | None:
     """Resolve a Windows npm .cmd/.bat wrapper to ``[node, cli_js]``.
@@ -141,15 +135,10 @@ class ClaudeRunner:
             "Starting Claude CLI: %s (cwd=%s, pid will follow)", " ".join(args[:6]) + " ...", cwd
         )
 
-        # We need stdin=PIPE when the initial user message is sent via
-        # stream-json input: either because images are attached, or because
-        # the prompt is too large for a CLI argument (ARG_MAX / E2BIG).
-        #
-        # For small text-only sessions we keep stdin=DEVNULL: Claude CLI
-        # blocks on startup when stdin is an open pipe in default text-input
-        # mode, and we have no data to send.
-        use_stdin = self.images or len(prompt.encode()) > _STDIN_PROMPT_THRESHOLD
-        stdin_mode = asyncio.subprocess.PIPE if use_stdin else asyncio.subprocess.DEVNULL
+        # Always use stdin=PIPE with --input-format stream-json so we can:
+        #  1. Send the initial user message (text + optional images) via stdin
+        #  2. Respond to permission_request / elicitation / plan_approval events
+        stdin_mode = asyncio.subprocess.PIPE
 
         self._process = await asyncio.create_subprocess_exec(
             *args,
@@ -163,9 +152,9 @@ class ClaudeRunner:
 
         logger.info("Claude CLI started: pid=%s", self._process.pid)
 
-        # For stream-json input sessions, send the initial user message (including
-        # base64 image data or large text) to stdin now that the process is up.
-        if use_stdin and self._process.stdin is not None:
+        # Send the initial user message (text + optional base64 images) via stdin.
+        # stdin is always PIPE now (stream-json input mode).
+        if self._process.stdin is not None:
             await self._send_stream_json_message(prompt)
 
         try:
@@ -382,19 +371,10 @@ class ClaudeRunner:
         if self.append_system_prompt:
             args.extend(["--append-system-prompt", self.append_system_prompt])
 
-        if self.images or len(prompt.encode()) > _STDIN_PROMPT_THRESHOLD:
-            # Images are passed via stdin as base64 content blocks in the
-            # stream-json input protocol.  Large text prompts (>128KB) are
-            # also sent via stdin to avoid the OS ARG_MAX / E2BIG limit.
-            # The --input-format flag tells the CLI to read the user message
-            # from stdin instead of the positional argument, so we do NOT
-            # append "-- <prompt>" in this branch.
-            args.extend(["--input-format", "stream-json"])
-        else:
-            # Use -- to separate flags from positional args (prevents prompt
-            # content starting with - from being interpreted as a flag)
-            args.append("--")
-            args.append(prompt)
+        # Always use stream-json input so stdin stays open for:
+        #  - sending the user prompt (with optional base64 images)
+        #  - responding to permission_request / elicitation / plan_approval
+        args.extend(["--input-format", "stream-json"])
 
         # On Windows, .cmd/.bat wrappers cannot be executed directly by
         # create_subprocess_exec.  Resolve to the underlying Node script.

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -27,9 +27,10 @@ class TestBuildArgs:
         assert "stream-json" in args
         assert "--model" in args
         assert "sonnet" in args
-        # prompt should be after -- separator
-        assert args[-1] == "hello"
-        assert args[-2] == "--"
+        # Prompt is sent via stdin (stream-json input), NOT as a CLI argument
+        assert "--input-format" in args
+        assert "hello" not in args
+        assert "--" not in args
 
     def test_session_id_valid_uuid(self) -> None:
         sid = "241e0726-bbc3-40e7-9db0-086823acde26"
@@ -45,11 +46,11 @@ class TestBuildArgs:
         with pytest.raises(ValueError, match="Invalid session_id"):
             self.runner._build_args("hello", session_id="abc def")
 
-    def test_prompt_after_double_dash(self) -> None:
-        """Prompt starting with -- should not be interpreted as a flag."""
+    def test_prompt_not_in_args(self) -> None:
+        """Prompt is always sent via stdin, never as a CLI argument (prevents flag injection)."""
         args = self.runner._build_args("--help", session_id=None)
-        idx = args.index("--")
-        assert args[idx + 1] == "--help"
+        assert "--help" not in args  # dangerous prompt not in args
+        assert "--" not in args  # no -- separator needed
 
     def test_allowed_tools(self) -> None:
         runner = ClaudeRunner(allowed_tools=["Bash", "Read"])
@@ -113,13 +114,12 @@ class TestBuildArgs:
         idx = args.index("--append-system-prompt")
         assert args[idx + 1] == "You are in a concurrent env."
 
-    def test_append_system_prompt_before_double_dash(self) -> None:
-        """--append-system-prompt must appear before the -- separator."""
-        runner = ClaudeRunner(append_system_prompt="ctx")
+    def test_always_uses_stream_json_input(self) -> None:
+        """All sessions use stream-json input for permission responses."""
+        runner = ClaudeRunner()
         args = runner._build_args("hello", session_id=None)
-        sp_idx = args.index("--append-system-prompt")
-        dd_idx = args.index("--")
-        assert sp_idx < dd_idx
+        idx = args.index("--input-format")
+        assert args[idx + 1] == "stream-json"
 
     def test_no_append_system_prompt_by_default(self) -> None:
         runner = ClaudeRunner()
@@ -533,18 +533,20 @@ class TestImageStreamJson:
         assert "--" not in args
         assert "look at this" not in args
 
-    def test_no_stream_json_input_format_without_images(self) -> None:
-        """Without images, --input-format stream-json is NOT added."""
+    def test_stream_json_input_always_present(self) -> None:
+        """--input-format stream-json is always added (needed for permission responses)."""
         runner = ClaudeRunner()
         args = runner._build_args("hello", session_id=None)
-        assert "--input-format" not in args
+        assert "--input-format" in args
+        idx = args.index("--input-format")
+        assert args[idx + 1] == "stream-json"
 
-    def test_prompt_in_cli_args_without_images(self) -> None:
-        """Without images, prompt is still passed as a CLI arg (existing behaviour)."""
+    def test_prompt_never_in_cli_args(self) -> None:
+        """Prompt is always sent via stdin, not as a CLI argument."""
         runner = ClaudeRunner()
         args = runner._build_args("hello", session_id=None)
-        assert args[-1] == "hello"
-        assert args[-2] == "--"
+        assert "hello" not in args
+        assert "--" not in args
 
     @pytest.mark.asyncio
     async def test_send_stream_json_message_base64_format(self) -> None:
@@ -666,11 +668,21 @@ class TestImageStreamJson:
         assert image_blocks[0]["source"]["media_type"] == "image/png"
 
     @pytest.mark.asyncio
-    async def test_run_uses_devnull_stdin_without_images(self) -> None:
-        """run() uses stdin=DEVNULL for text-only sessions (no hang risk)."""
+    async def test_run_uses_pipe_stdin_for_text_only(self) -> None:
+        """run() uses stdin=PIPE even for text-only sessions (needed for permission responses)."""
         import asyncio as _asyncio
+        import json
 
         runner = ClaudeRunner()
+
+        written: list[bytes] = []
+
+        def capture_write(data: bytes) -> None:
+            written.append(data)
+
+        mock_stdin = MagicMock()
+        mock_stdin.write = capture_write
+        mock_stdin.drain = AsyncMock()
 
         mock_process = AsyncMock()
         mock_process.pid = 42
@@ -679,7 +691,7 @@ class TestImageStreamJson:
         mock_process.stdout.readline = AsyncMock(return_value=b"")
         mock_process.stderr = AsyncMock()
         mock_process.stderr.read = AsyncMock(return_value=b"")
-        mock_process.stdin = None
+        mock_process.stdin = mock_stdin
         mock_process.wait = AsyncMock(return_value=0)
 
         with (
@@ -692,7 +704,14 @@ class TestImageStreamJson:
             _ = [event async for event in runner.run("hello")]
 
         call_kwargs = mock_exec.call_args[1]
-        assert call_kwargs["stdin"] == _asyncio.subprocess.DEVNULL
+        assert call_kwargs["stdin"] == _asyncio.subprocess.PIPE
+
+        # Prompt sent as stream-json message via stdin
+        assert len(written) == 1
+        payload = json.loads(written[0].decode())
+        assert payload["type"] == "user"
+        text_blocks = [c for c in payload["message"]["content"] if c.get("type") == "text"]
+        assert any("hello" in b["text"] for b in text_blocks)
 
     @pytest.mark.asyncio
     async def test_multiple_images_all_sent(self) -> None:
@@ -754,13 +773,13 @@ class TestLargePromptStdin:
         assert "--" not in args
         assert large_prompt not in args
 
-    def test_small_prompt_still_uses_cli_args(self) -> None:
-        """Small prompts continue to use the traditional -- <prompt> approach."""
+    def test_small_prompt_also_uses_stream_json(self) -> None:
+        """Small prompts also use stream-json (all prompts go via stdin now)."""
         runner = ClaudeRunner()
         args = runner._build_args("hello", session_id=None)
-        assert "--input-format" not in args
-        assert args[-1] == "hello"
-        assert args[-2] == "--"
+        assert "--input-format" in args
+        assert "hello" not in args
+        assert "--" not in args
 
     @pytest.mark.asyncio
     async def test_run_uses_pipe_stdin_for_large_prompt(self) -> None:
@@ -813,11 +832,21 @@ class TestLargePromptStdin:
         assert text_blocks[0]["text"] == large_prompt
 
     @pytest.mark.asyncio
-    async def test_run_still_uses_devnull_for_small_prompt(self) -> None:
-        """run() uses stdin=DEVNULL for small text-only prompts (no regression)."""
+    async def test_run_uses_pipe_stdin_for_small_prompt(self) -> None:
+        """run() uses stdin=PIPE even for small prompts (permission responses need it)."""
         import asyncio as _asyncio
+        import json
 
         runner = ClaudeRunner()
+
+        written: list[bytes] = []
+
+        def capture_write(data: bytes) -> None:
+            written.append(data)
+
+        mock_stdin = MagicMock()
+        mock_stdin.write = capture_write
+        mock_stdin.drain = AsyncMock()
 
         mock_process = AsyncMock()
         mock_process.pid = 42
@@ -826,7 +855,7 @@ class TestLargePromptStdin:
         mock_process.stdout.readline = AsyncMock(return_value=b"")
         mock_process.stderr = AsyncMock()
         mock_process.stderr.read = AsyncMock(return_value=b"")
-        mock_process.stdin = None
+        mock_process.stdin = mock_stdin
         mock_process.wait = AsyncMock(return_value=0)
 
         with (
@@ -839,7 +868,12 @@ class TestLargePromptStdin:
             _ = [event async for event in runner.run("hello")]
 
         call_kwargs = mock_exec.call_args[1]
-        assert call_kwargs["stdin"] == _asyncio.subprocess.DEVNULL
+        assert call_kwargs["stdin"] == _asyncio.subprocess.PIPE
+
+        # Prompt sent via stdin
+        assert len(written) == 1
+        payload = json.loads(written[0].decode())
+        assert payload["type"] == "user"
 
 
 class TestResolveWindowsCmd:

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "2.1.16"
+version = "2.1.18"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Claude CLIプロセスを常に`stdin=PIPE` + `--input-format stream-json`で起動するように変更
- テキストのみのセッションでも`DEVNULL`ではなく`PIPE`を使用
- `_STDIN_PROMPT_THRESHOLD`定数を削除（全プロンプトがstdin経由になるため不要）

## Motivation

Claude CLI v2.1.81の`-p`モードでは`permission_request`イベントが発行されないバグがある（upstream: #37935, #36139, #35601）。将来CLIが修正されたときに即座にccdbのPermissionView（Allow/Denyボタン）が動くよう、stdinを常にオープンにしておく。

## Changes

### `claude_discord/claude/runner.py`
- `stdin`を常に`asyncio.subprocess.PIPE`に設定（条件分岐を削除）
- `--input-format stream-json`を常に付与（画像有無・プロンプトサイズに関係なく）
- `_STDIN_PROMPT_THRESHOLD`定数を削除

### `tests/test_runner.py`
- 7テストを更新: 全セッションでstdin=PIPE + stream-jsonを使用することを検証
- テスト名をリネームして新しい動作を正確に反映

## Related Issues

- #345 (permission_request events not emitted in `-p` mode)
- Upstream: anthropics/claude-code#37935, #36139, #35601

## Test Plan

- [x] 全73テストパス
- [x] dev-onモードでEbiBotが正常にメッセージ送受信できることを確認（このPR自体がstdin=PIPEで動作するセッションから作成）

🤖 Generated with [Claude Code](https://claude.com/claude-code)