### PR TITLE
[docs-sync] Update permission_request FAQ for stdin=PIPE (#346)

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ Common tool names: `Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`, `WebFetch`, 
 
 **Runtime changes via Discord:** Use `/tools-set` to change allowed tools at runtime without restarting the bot. The setting is persisted and takes effect for all new sessions immediately. Use `/tools-show` to see the current configuration, or `/tools-reset` to revert to the `.env` default.
 
-> **Why don't permission buttons appear in Discord?** The CLI's `-p` mode never emits `permission_request` events, so there's nothing for ccdb to display. The `AskUserQuestion` buttons you see (choice prompts from Claude) are a different mechanism that works correctly. See [#210](https://github.com/ebibibi/claude-code-discord-bridge/issues/210) for the full investigation.
+> **Permission buttons in Discord:** When `CLAUDE_PERMISSION_MODE=default`, Claude emits `permission_request` events and ccdb displays Allow/Deny buttons in the thread. stdin is always kept open (stream-json input mode) so the bot can send responses back to Claude. If you are using `auto` or `plan` mode, Claude handles permissions automatically without requiring user interaction.
 
 ---
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -576,7 +576,7 @@ CLAUDE_ALLOWED_TOOLS=Read,Glob,Grep
 
 **Discord からの実行時変更：** `/tools-set` を使用すると、Bot を再起動せずに実行時に許可ツールを変更できます。設定は永続化され、以降のすべての新規セッションに即座に反映されます。現在の設定を確認するには `/tools-show`、`.env` デフォルトに戻すには `/tools-reset` を使用してください。
 
-> **Discord にパーミッションボタンが表示されないのはなぜ？** CLI の `-p` モードは `permission_request` イベントを発行しないため、ccdb に表示するものがありません。表示される `AskUserQuestion` ボタン（Claude からの選択プロンプト）は別のメカニズムであり、正常に動作します。詳細な調査は [#210](https://github.com/ebibibi/claude-code-discord-bridge/issues/210) を参照してください。
+> **Discord のパーミッションボタン：** `CLAUDE_PERMISSION_MODE=default` の場合、Claude は `permission_request` イベントを発行し、ccdb はスレッドに許可／拒否ボタンを表示します。stdin は常時開放（stream-json 入力モード）されているため、Bot が Claude へ応答を返すことができます。`auto` または `plan` モードを使用している場合、Claude はユーザーの操作なしに自動でパーミッションを処理します。
 
 ---
 


### PR DESCRIPTION
## Summary

- Update outdated FAQ about permission_request events in English and Japanese README
- The previous note said "CLI's `-p` mode never emits `permission_request` events" — this was outdated; ccdb has handled these events via `event_processor.py` and `permission_view.py` for some time
- PR #346 (always use stdin=PIPE) ensures responses can always be sent back to Claude, making the feature fully functional
- Replace the old "Why don't permission buttons appear?" note with accurate description of current behavior

## Test plan

- [ ] Verify the updated FAQ text is accurate against current code behavior
- [ ] Confirm Japanese translation is natural and complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)
