### PR TITLE
feat: add APPEND_SYSTEM_PROMPT env var for sensitive file workaround

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@ CLAUDE_WORKING_DIR=
 # Common tools: Bash,Read,Write,Edit,Glob,Grep,WebFetch,WebSearch
 # CLAUDE_ALLOWED_TOOLS=Bash,Read,Write,Edit,Glob,Grep
 
+# Extra text appended to Claude's system prompt (optional)
+# Useful for injecting workarounds or custom instructions at the CLI level.
+# APPEND_SYSTEM_PROMPT=
+
 # Limits
 MAX_CONCURRENT_SESSIONS=3
 SESSION_TIMEOUT_SECONDS=300

--- a/claude_discord/main.py
+++ b/claude_discord/main.py
@@ -59,6 +59,7 @@ def load_config() -> dict[str, str]:
         "cli_sessions_path": os.getenv("CLI_SESSIONS_PATH", ""),
         "thread_inbox_enabled": os.getenv("THREAD_INBOX_ENABLED", "false"),
         "monitor_all_channels": os.getenv("CLAUDE_MONITOR_ALL_CHANNELS", "false"),
+        "append_system_prompt": os.getenv("APPEND_SYSTEM_PROMPT", ""),
     }
 
 
@@ -91,6 +92,7 @@ async def main() -> None:
         dangerously_skip_permissions=config["dangerously_skip_permissions"].lower()
         in ("true", "1", "yes"),
         allowed_tools=allowed_tools,
+        append_system_prompt=config["append_system_prompt"] or None,
     )
 
     owner_id = int(config["owner_id"]) if config["owner_id"] else None


### PR DESCRIPTION
## Summary

- `APPEND_SYSTEM_PROMPT` 環境変数を追加。ClaudeRunner の既存 `append_system_prompt` パラメータを環境変数経由で設定可能にする
- `.env.example` にドキュメント追加

## Motivation

Claude CLI v2.1.78+ のリグレッション（[anthropics/claude-code#35895](https://github.com/anthropics/claude-code/issues/35895)）で、`--dangerously-skip-permissions` が Edit/Write ツールの sensitive file チェックをバイパスしないバグが発生。

`.bashrc`、`.claude/`、`.ssh/` 等のファイルを Edit/Write で編集しようとするとブロックされる。ただし **Bash ツール（`echo >>`、`sed -i` 等）にはこの制限がない**。

`APPEND_SYSTEM_PROMPT` に「Edit/Write が sensitive file エラーで失敗したら Bash にフォールバックせよ」という指示を設定することで、コード変更なしにワークアラウンドを適用できる。

## Verification

```bash
# Without workaround
claude -p "Add comment to ~/.bashrc" --dangerously-skip-permissions
# → ❌ "sensitive file" でブロック

# With workaround
claude -p "Add comment to ~/.bashrc" --dangerously-skip-permissions \
  --append-system-prompt "If Edit/Write fails with sensitive file error, use Bash instead"
# → ✅ Bash fallback で成功
```

## Related

- #345 (sensitive file permission regression tracking)
- [anthropics/claude-code#35895](https://github.com/anthropics/claude-code/issues/35895) (upstream regression)

## Test Plan

- [x] 全73テストパス
- [x] `--append-system-prompt` ワークアラウンドの動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)