### PR TITLE
[docs-sync] Update docs for APPEND_SYSTEM_PROMPT and tools/ monorepo (#348, #349)

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ In chat-only mode, permission requests and `AskUserQuestion` prompts are **alway
 | `CUSTOM_COGS_DIR` | Directory containing custom Cog files to load at startup (see [Custom Cogs](#custom-cogs-extend-without-forking)) | (optional) |
 | `CLAUDE_ALLOWED_TOOLS` | Comma-separated list of allowed tools for Claude CLI | (optional) |
 | `CLAUDE_CHANNEL_IDS` | Additional channel IDs (comma-separated) for multi-channel setup | (optional) |
+| `APPEND_SYSTEM_PROMPT` | Extra text appended to Claude's system prompt — useful for injecting workarounds or custom CLI-level instructions without code changes | (optional) |
 | `THREAD_INBOX_ENABLED` | Enable the persistent thread inbox (classifies sessions as `waiting`/`done`/`ambiguous` via `claude -p`; shown in thread dashboard) | `false` |
 | `THREAD_AUTO_RENAME` | Auto-rename new thread titles using Claude AI — generates a short, descriptive title from the first user message via a background `claude -p` call (never delays session start) | `false` |
 | `API_HOST` | REST API bind address | `127.0.0.1` |
@@ -876,6 +877,10 @@ examples/
       watchdog.py          # Todoist overdue task monitor
       auto_upgrade.py      # Self-update via GitHub webhook
       docs_sync.py         # Auto-translate docs on push
+tools/                     # JBS AI Tools platform (monorepo companion)
+  api/                     # Azure Functions API — task-based file processing
+  web/                     # React + TypeScript + Vite frontend
+  infra/                   # Bicep infrastructure definitions
 ```
 
 ### Design Philosophy

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -538,6 +538,7 @@ CHAT_ONLY_CHANNEL_IDS=444,555
 | `CUSTOM_COGS_DIR` | 起動時に読み込むカスタム Cog ファイルを含むディレクトリ（[カスタム Cog](#カスタム-cogフォーク不要で機能拡張) 参照） | （オプション） |
 | `CLAUDE_ALLOWED_TOOLS` | Claude CLI に許可するツールのカンマ区切りリスト | （オプション） |
 | `CLAUDE_CHANNEL_IDS` | マルチチャンネル設定用の追加チャンネル ID（カンマ区切り） | （オプション） |
+| `APPEND_SYSTEM_PROMPT` | Claude のシステムプロンプトに追記するテキスト — コード変更なしに CLI レベルの回避策やカスタム指示を注入するのに便利 | （オプション） |
 | `THREAD_INBOX_ENABLED` | 永続スレッドインボックスを有効化（`claude -p` でセッションを `waiting`/`done`/`ambiguous` に分類し、スレッドダッシュボードに表示） | `false` |
 | `THREAD_AUTO_RENAME` | 新しいスレッドのタイトルを Claude AI で自動リネーム — 最初のユーザーメッセージをもとにバックグラウンドの `claude -p` 呼び出しで短く分かりやすいタイトルを生成（セッション開始を遅延させない） | `false` |
 | `API_HOST` | REST API バインドアドレス | `127.0.0.1` |
@@ -877,6 +878,10 @@ examples/
       watchdog.py          # Todoist 期限切れタスクモニター
       auto_upgrade.py      # GitHub webhook 経由の自己更新
       docs_sync.py         # push 時のドキュメント自動翻訳
+tools/                     # JBS AI Tools プラットフォーム（モノレポ同梱）
+  api/                     # Azure Functions API — タスク定義ベースのファイル処理
+  web/                     # React + TypeScript + Vite フロントエンド
+  infra/                   # Bicep インフラ定義
 ```
 
 ### 設計思想


### PR DESCRIPTION
## Summary

- Add `APPEND_SYSTEM_PROMPT` env var to the configuration table (English + Japanese)
- Add `tools/` monorepo directory to the project structure (English + Japanese)

These reflect two recent commits:
- `feat: add APPEND_SYSTEM_PROMPT env var for CLI-level instructions (#348)`
- `feat: add JBS AI Tools platform (tools/ monorepo) (#349)`

## Test plan
- [ ] Configuration table in README.md includes `APPEND_SYSTEM_PROMPT` row
- [ ] Project structure in README.md includes `tools/` directory
- [ ] Japanese README (docs/ja/README.md) mirrors both additions
