### PR TITLE
[docs-sync] Add APPEND_SYSTEM_PROMPT to configuration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ In chat-only mode, permission requests and `AskUserQuestion` prompts are **alway
 | `CLI_SESSIONS_PATH` | Path to `~/.claude/projects` for CLI session discovery (enables `/sync-sessions`) | (optional) |
 | `CUSTOM_COGS_DIR` | Directory containing custom Cog files to load at startup (see [Custom Cogs](#custom-cogs-extend-without-forking)) | (optional) |
 | `CLAUDE_ALLOWED_TOOLS` | Comma-separated list of allowed tools for Claude CLI | (optional) |
+| `APPEND_SYSTEM_PROMPT` | Extra text appended to Claude's system prompt via `--append-system-prompt` — useful for injecting workarounds or CLI-level instructions without modifying `CLAUDE.md` | (optional) |
 | `CLAUDE_CHANNEL_IDS` | Additional channel IDs (comma-separated) for multi-channel setup | (optional) |
 | `THREAD_INBOX_ENABLED` | Enable the persistent thread inbox (classifies sessions as `waiting`/`done`/`ambiguous` via `claude -p`; shown in thread dashboard) | `false` |
 | `THREAD_AUTO_RENAME` | Auto-rename new thread titles using Claude AI — generates a short, descriptive title from the first user message via a background `claude -p` call (never delays session start) | `false` |

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -537,6 +537,7 @@ CHAT_ONLY_CHANNEL_IDS=444,555
 | `CLI_SESSIONS_PATH` | CLI セッション検出用のパス（`~/.claude/projects`）。`/sync-sessions` の有効化に必要 | （オプション） |
 | `CUSTOM_COGS_DIR` | 起動時に読み込むカスタム Cog ファイルを含むディレクトリ（[カスタム Cog](#カスタム-cogフォーク不要で機能拡張) 参照） | （オプション） |
 | `CLAUDE_ALLOWED_TOOLS` | Claude CLI に許可するツールのカンマ区切りリスト | （オプション） |
+| `APPEND_SYSTEM_PROMPT` | `--append-system-prompt` 経由で Claude のシステムプロンプトに追記するテキスト — `CLAUDE.md` を変更せずに CLIレベルの指示や回避策を注入する際に便利 | （オプション） |
 | `CLAUDE_CHANNEL_IDS` | マルチチャンネル設定用の追加チャンネル ID（カンマ区切り） | （オプション） |
 | `THREAD_INBOX_ENABLED` | 永続スレッドインボックスを有効化（`claude -p` でセッションを `waiting`/`done`/`ambiguous` に分類し、スレッドダッシュボードに表示） | `false` |
 | `THREAD_AUTO_RENAME` | 新しいスレッドのタイトルを Claude AI で自動リネーム — 最初のユーザーメッセージをもとにバックグラウンドの `claude -p` 呼び出しで短く分かりやすいタイトルを生成（セッション開始を遅延させない） | `false` |


### PR DESCRIPTION
## Summary

- Add `APPEND_SYSTEM_PROMPT` environment variable to the configuration table in README.md and docs/ja/README.md
- This env var was implemented in d3a9da1 but the docs entry was accidentally reverted in 286647d

## Changes

| File | Change |
|------|--------|
| `README.md` | Added `APPEND_SYSTEM_PROMPT` row to configuration table |
| `docs/ja/README.md` | Added Japanese translation of the same row |

## Test plan

- [ ] Verify the configuration table in README.md contains `APPEND_SYSTEM_PROMPT`
- [ ] Verify the Japanese README contains the same entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
