### PR TITLE
fix: Issue #345 自動修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,12 @@ DISCORD_BOT_TOKEN=your-bot-token-here
 DISCORD_CHANNEL_ID=your-channel-id-here
 
 # Claude Code CLI Configuration
+# Path or name of the Claude CLI binary. Override to pin a specific version.
+# Example: CLAUDE_COMMAND=/usr/local/lib/node_modules/@anthropic-ai/claude-code@2.1.77/cli.js
+# Note: CLI v2.1.78+ has a regression where --dangerously-skip-permissions does not
+# bypass sensitive file checks on Edit/Write tools (upstream #35895). ccdb auto-approves
+# these permission requests when yolo mode is enabled, but pinning v2.1.77 avoids the
+# issue entirely.
 CLAUDE_COMMAND=claude
 CLAUDE_MODEL=sonnet
 

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -548,8 +548,30 @@ class EventProcessor:
         logger.info("Plan approval prompt posted (session=%s)", request_id)
 
     async def _handle_permission_request(self, event: StreamEvent) -> None:
-        """Post permission embed with Allow/Deny buttons."""
+        """Post permission embed with Allow/Deny buttons.
+
+        When dangerously_skip_permissions is enabled on the runner, auto-approve
+        the request immediately instead of showing the UI.  This works around a
+        CLI regression (v2.1.78+, upstream #35895) where --dangerously-skip-permissions
+        fails to bypass the file-level sensitive-path check on Edit/Write tools,
+        causing permission_request events to be emitted even in yolo mode.
+        """
         assert event.permission_request is not None
+
+        # Workaround for CLI v2.1.78+ regression (#35895):
+        # Auto-approve when yolo mode is active — the user already opted into
+        # unrestricted execution by setting dangerously_skip_permissions=true.
+        if self._config.runner.dangerously_skip_permissions:
+            await self._config.runner.inject_tool_result(
+                event.permission_request.request_id, {"approved": True}
+            )
+            logger.info(
+                "Permission auto-approved (yolo mode): %s (request_id=%s)",
+                event.permission_request.tool_name,
+                event.permission_request.request_id,
+            )
+            return
+
         embed = permission_embed(event.permission_request)
         view = PermissionView(self._config.runner, event.permission_request)
         await self._config.thread.send(embed=embed, view=view)

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -1231,3 +1231,63 @@ class TestChatOnlyMode:
             c for c in thread.send.call_args_list if c.args and isinstance(c.args[0], str)
         ]
         assert not any("compact" in str(c).lower() for c in text_sends)
+
+
+class TestPermissionAutoApprove:
+    """Permission requests are auto-approved when dangerously_skip_permissions is True.
+
+    Workaround for CLI v2.1.78+ regression (upstream #35895) where
+    --dangerously-skip-permissions fails to bypass file-level sensitive-path
+    checks on Edit/Write tools.
+    """
+
+    @pytest.mark.asyncio
+    async def test_auto_approve_when_yolo_enabled(
+        self, thread: MagicMock, runner: MagicMock
+    ) -> None:
+        """permission_request is auto-approved without Discord UI when yolo mode is on."""
+        from claude_discord.claude.types import PermissionRequest
+
+        runner.dangerously_skip_permissions = True
+        runner.inject_tool_result = AsyncMock()
+        config = _make_config(thread, runner)
+        p = EventProcessor(config)
+
+        event = StreamEvent(
+            message_type=MessageType.SYSTEM,
+            permission_request=PermissionRequest(
+                request_id="req-yolo-1",
+                tool_name="Edit",
+                tool_input={"file_path": "/home/user/.bashrc"},
+            ),
+        )
+        await p.process(event)
+
+        runner.inject_tool_result.assert_called_once_with("req-yolo-1", {"approved": True})
+        # No embed/view posted to Discord
+        thread.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_shows_ui_when_yolo_disabled(self, thread: MagicMock, runner: MagicMock) -> None:
+        """permission_request shows Allow/Deny buttons when yolo mode is off."""
+        from claude_discord.claude.types import PermissionRequest
+
+        runner.dangerously_skip_permissions = False
+        runner.inject_tool_result = AsyncMock()
+        config = _make_config(thread, runner)
+        p = EventProcessor(config)
+
+        event = StreamEvent(
+            message_type=MessageType.SYSTEM,
+            permission_request=PermissionRequest(
+                request_id="req-normal-1",
+                tool_name="Edit",
+                tool_input={"file_path": "/home/user/.bashrc"},
+            ),
+        )
+        await p.process(event)
+
+        # inject_tool_result NOT called — user must click Allow/Deny
+        runner.inject_tool_result.assert_not_called()
+        # Discord embed + view posted
+        thread.send.assert_called_once()


### PR DESCRIPTION
Closes #345

Issue #345 を `claude -p` で自動解決しました。

### 変更内容

全70テスト合格 ✅

## 変更内容まとめ

**Issue**: CLI v2.1.78+ のリグレッションで `--dangerously-skip-permissions` が Edit/Write ツールの sensitive file チェック（`.bashrc`, `.claude/`, `.ssh/` 等）をバイパスしない

**修正箇所 (2ファイル + テスト1ファイル)**:

1. **`claude_discord/cogs/event_processor.py`** — `_handle_permission_request` メソッドに自動承認ロジックを追加。`runner.dangerously_skip_permissions` が `True` の場合、Discord に Allow/Deny ボタンを表示せず、即座に `inject_tool_result({"approved": True})` を送信する。yolo モードでない場合は従来通り UI を表示。

2. **`.env.example`** — `CLAUDE_COMMAND` の説明にリグレッション情報と v2.1.77 ピン固定のワークアラウンドを記載。

3. **`tests/test_event_processor.py`** — `TestPermissionAutoApprove` クラスを追加。yolo モード ON 時の自動承認と、OFF 時の UI 表示をそれぞれ検証。


---
*issue_resolver.py による自動修正*