### PR TITLE
[docs-sync] Document CLAUDE_COMMAND version pinning and yolo-mode auto-approve (#352)

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ In chat-only mode, permission requests and `AskUserQuestion` prompts are **alway
 |----------|-------------|---------|
 | `DISCORD_BOT_TOKEN` | Your Discord bot token | (required) |
 | `DISCORD_CHANNEL_ID` | Channel ID for Claude chat | (required) |
-| `CLAUDE_COMMAND` | Path to Claude Code CLI | `claude` |
+| `CLAUDE_COMMAND` | Path or name of the Claude CLI binary. Use to pin a specific version (e.g. `CLAUDE_COMMAND=/usr/local/lib/node_modules/@anthropic-ai/claude-code@2.1.77/cli.js`) — useful to avoid regressions in newer CLI releases. | `claude` |
 | `CLAUDE_MODEL` | Model to use | `sonnet` |
 | `CLAUDE_PERMISSION_MODE` | Permission mode for CLI | `acceptEdits` |
 | `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | Skip all permission checks (use with caution) | `false` |
@@ -575,7 +575,7 @@ Common tool names: `Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`, `WebFetch`, 
 
 **Runtime changes via Discord:** Use `/tools-set` to change allowed tools at runtime without restarting the bot. The setting is persisted and takes effect for all new sessions immediately. Use `/tools-show` to see the current configuration, or `/tools-reset` to revert to the `.env` default.
 
-> **Permission buttons in Discord:** When `CLAUDE_PERMISSION_MODE=default`, Claude emits `permission_request` events and ccdb displays Allow/Deny buttons in the thread. stdin is always kept open (stream-json input mode) so the bot can send responses back to Claude. If you are using `auto` or `plan` mode, Claude handles permissions automatically without requiring user interaction.
+> **Permission buttons in Discord:** When `CLAUDE_PERMISSION_MODE=default`, Claude emits `permission_request` events and ccdb displays Allow/Deny buttons in the thread. stdin is always kept open (stream-json input mode) so the bot can send responses back to Claude. If you are using `auto` or `plan` mode, Claude handles permissions automatically without requiring user interaction. When `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true` (yolo mode), ccdb **auto-approves** any `permission_request` events immediately — no Allow/Deny buttons are shown. This is a workaround for a CLI regression (v2.1.78+, upstream [#35895](https://github.com/anthropics/claude-code/issues/35895)) where `--dangerously-skip-permissions` fails to bypass the file-level sensitive-path check.
 
 ---
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -521,7 +521,7 @@ CHAT_ONLY_CHANNEL_IDS=444,555
 |--------|------|-----------|
 | `DISCORD_BOT_TOKEN` | Discord Bot トークン | （必須） |
 | `DISCORD_CHANNEL_ID` | Claude チャット用チャンネル ID | （必須） |
-| `CLAUDE_COMMAND` | Claude Code CLI へのパス | `claude` |
+| `CLAUDE_COMMAND` | Claude CLI バイナリのパスまたは名前。特定バージョンを固定する場合に使用（例: `CLAUDE_COMMAND=/usr/local/lib/node_modules/@anthropic-ai/claude-code@2.1.77/cli.js`）— 新バージョンのリグレッション回避に便利。 | `claude` |
 | `CLAUDE_MODEL` | 使用するモデル | `sonnet` |
 | `CLAUDE_PERMISSION_MODE` | CLI のパーミッションモード | `auto` |
 | `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | 全パーミッションチェックをスキップ（注意して使用） | `false` |
@@ -576,7 +576,7 @@ CLAUDE_ALLOWED_TOOLS=Read,Glob,Grep
 
 **Discord からの実行時変更：** `/tools-set` を使用すると、Bot を再起動せずに実行時に許可ツールを変更できます。設定は永続化され、以降のすべての新規セッションに即座に反映されます。現在の設定を確認するには `/tools-show`、`.env` デフォルトに戻すには `/tools-reset` を使用してください。
 
-> **Discord のパーミッションボタン：** `CLAUDE_PERMISSION_MODE=default` の場合、Claude は `permission_request` イベントを発行し、ccdb はスレッドに許可／拒否ボタンを表示します。stdin は常時開放（stream-json 入力モード）されているため、Bot が Claude へ応答を返すことができます。`auto` または `plan` モードを使用している場合、Claude はユーザーの操作なしに自動でパーミッションを処理します。
+> **Discord のパーミッションボタン：** `CLAUDE_PERMISSION_MODE=default` の場合、Claude は `permission_request` イベントを発行し、ccdb はスレッドに許可／拒否ボタンを表示します。stdin は常時開放（stream-json 入力モード）されているため、Bot が Claude へ応答を返すことができます。`auto` または `plan` モードを使用している場合、Claude はユーザーの操作なしに自動でパーミッションを処理します。`CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`（yolo モード）の場合、ccdb は `permission_request` イベントを**即座に自動承認**します — 許可／拒否ボタンは表示されません。これは CLI のリグレッション（v2.1.78+、upstream [#35895](https://github.com/anthropics/claude-code/issues/35895)）の回避策で、`--dangerously-skip-permissions` がファイルレベルの機密パスチェックをバイパスできない問題に対処しています。
 
 ---
 


### PR DESCRIPTION
## Summary

- `README.md`: `CLAUDE_COMMAND` 環境変数の説明にバージョン固定の注記を追加
- `README.md`: `dangerously_skip_permissions=true`（yolo モード）時の `permission_request` 自動承認動作を文書化（CLI v2.1.78+ リグレッション #35895 のワークアラウンド）
- `docs/ja/README.md`: 上記変更の日本語翻訳

---

- `README.md`: Added version-pinning note to `CLAUDE_COMMAND` description
- `README.md`: Documented auto-approve behavior for `permission_request` events when yolo mode is active (workaround for CLI v2.1.78+ regression upstream #35895)
- `docs/ja/README.md`: Japanese translations of the above

## Test plan

- [ ] Verify `CLAUDE_COMMAND` table row accurately reflects the `.env.example` comment
- [ ] Verify permission buttons note is consistent with `event_processor.py` auto-approve logic
- [ ] Verify Japanese translation is accurate and natural

🤖 Generated with [Claude Code](https://claude.com/claude-code)
