### PR TITLE
feat: scheduled follow-up — post to existing threads + one-shot tasks

### DIFF
--- a/claude_discord/cogs/scheduler.py
+++ b/claude_discord/cogs/scheduler.py
@@ -97,31 +97,50 @@ class SchedulerCog(commands.Cog):
         await self.bot.wait_until_ready()
 
     async def _run_task(self, task: dict) -> None:
-        """Execute a single scheduled task in a Discord thread."""
+        """Execute a single scheduled task in a Discord thread.
+
+        When ``thread_id`` is set, posts into that existing thread (follow-up
+        mode) and optionally resumes the previous session.  Otherwise, creates
+        a new thread in the parent channel (original behavior).
+
+        When ``one_shot`` is True, the task is disabled after execution.
+        """
         task_id: int = task["id"]
         self._running.add(task_id)
         try:
-            channel = self.bot.get_channel(task["channel_id"])
-            if channel is None:
-                logger.warning(
-                    "SchedulerCog: channel %d not found for task %d (%s)",
-                    task["channel_id"],
-                    task_id,
-                    task["name"],
-                )
-                return
-            if not isinstance(channel, discord.TextChannel):
-                logger.warning("SchedulerCog: channel %d is not a TextChannel", task["channel_id"])
-                return
+            thread_id = task.get("thread_id")
+            session_id: str | None = None
 
-            # Post a starter message first so the thread appears in the channel
-            # timeline and shows up in the left sidebar under the parent channel.
-            # channel.create_thread() without a message only appears in the
-            # Threads panel (🧵), not in the channel list.
-            starter = await channel.send(f"🔄 **[Scheduled]** `{task['name']}`")
-            thread = await starter.create_thread(
-                name=f"[Scheduled] {task['name']}",
-            )
+            if thread_id:
+                # Follow-up mode: post into an existing thread
+                thread = self.bot.get_channel(thread_id)
+                if thread is None or not isinstance(thread, discord.Thread):
+                    logger.warning(
+                        "SchedulerCog: thread %d not found for task %d (%s) — falling back",
+                        thread_id,
+                        task_id,
+                        task["name"],
+                    )
+                    thread = await self._create_new_thread(task)
+                    if thread is None:
+                        return
+                else:
+                    await thread.send(f"🔄 **[Follow-up]** `{task['name']}`")
+                    # Try to resume the previous session in this thread
+                    if self.session_repo is not None:
+                        record = await self.session_repo.get(thread_id)
+                        if record is not None:
+                            session_id = record.session_id
+                            logger.info(
+                                "SchedulerCog: resuming session %s in thread %d",
+                                session_id,
+                                thread_id,
+                            )
+            else:
+                # Original behavior: create a new thread
+                thread = await self._create_new_thread(task)
+                if thread is None:
+                    return
 
             cloned = self.runner.clone()
             if task.get("working_dir"):
@@ -134,12 +153,35 @@ class SchedulerCog(commands.Cog):
                     runner=cloned,
                     repo=self.session_repo,
                     prompt=task["prompt"],
-                    session_id=None,
+                    session_id=session_id,
                     registry=registry,
                 )
             )
+
+            # One-shot tasks auto-disable after execution
+            if task.get("one_shot"):
+                await self.repo.set_enabled(task_id, enabled=False)
+                logger.info("SchedulerCog: one-shot task %d (%s) disabled", task_id, task["name"])
 
         except Exception:
             logger.exception("SchedulerCog: task %d (%s) failed", task_id, task["name"])
         finally:
             self._running.discard(task_id)
+
+    async def _create_new_thread(self, task: dict) -> discord.Thread | None:
+        """Create a new thread in the parent channel for a scheduled task."""
+        channel = self.bot.get_channel(task["channel_id"])
+        if channel is None:
+            logger.warning(
+                "SchedulerCog: channel %d not found for task %d (%s)",
+                task["channel_id"],
+                task["id"],
+                task["name"],
+            )
+            return None
+        if not isinstance(channel, discord.TextChannel):
+            logger.warning("SchedulerCog: channel %d is not a TextChannel", task["channel_id"])
+            return None
+
+        starter = await channel.send(f"🔄 **[Scheduled]** `{task['name']}`")
+        return await starter.create_thread(name=f"[Scheduled] {task['name']}")

--- a/claude_discord/database/task_repo.py
+++ b/claude_discord/database/task_repo.py
@@ -38,6 +38,12 @@ ALTER TABLE scheduled_tasks ADD COLUMN anchor_hour INTEGER;
 ALTER TABLE scheduled_tasks ADD COLUMN anchor_minute INTEGER DEFAULT 0;
 """
 
+# Migration: add follow-up columns (thread_id for existing thread, one_shot for auto-disable)
+_MIGRATION_FOLLOWUP = """
+ALTER TABLE scheduled_tasks ADD COLUMN thread_id INTEGER;
+ALTER TABLE scheduled_tasks ADD COLUMN one_shot INTEGER DEFAULT 0;
+"""
+
 
 class TaskRepository:
     """Async CRUD for scheduled_tasks table."""
@@ -58,6 +64,12 @@ class TaskRepository:
                     if stmt:
                         await db.execute(stmt)
                 logger.info("Migrated scheduled_tasks: added anchor_hour, anchor_minute")
+            if "thread_id" not in columns:
+                for stmt in _MIGRATION_FOLLOWUP.strip().split(";"):
+                    stmt = stmt.strip()
+                    if stmt:
+                        await db.execute(stmt)
+                logger.info("Migrated scheduled_tasks: added thread_id, one_shot")
             await db.commit()
         logger.info("Task DB initialized at %s", self.db_path)
 
@@ -101,6 +113,7 @@ class TaskRepository:
             return None
         d = dict(row)
         d["enabled"] = bool(d["enabled"])
+        d["one_shot"] = bool(d.get("one_shot", 0))
         return d
 
     async def get_all(self) -> list[dict]:
@@ -113,6 +126,7 @@ class TaskRepository:
         for row in rows:
             d = dict(row)
             d["enabled"] = bool(d["enabled"])
+            d["one_shot"] = bool(d.get("one_shot", 0))
             result.append(d)
         return result
 
@@ -132,6 +146,7 @@ class TaskRepository:
         for row in rows:
             d = dict(row)
             d["enabled"] = bool(d["enabled"])
+            d["one_shot"] = bool(d.get("one_shot", 0))
             result.append(d)
         return result
 
@@ -150,6 +165,8 @@ class TaskRepository:
         run_immediately: bool = True,
         anchor_hour: int | None = None,
         anchor_minute: int | None = None,
+        thread_id: int | None = None,
+        one_shot: bool = False,
     ) -> int:
         """Create a new scheduled task. Returns the created ID.
 
@@ -162,6 +179,10 @@ class TaskRepository:
             anchor_minute: Optional wall-clock minute (0-59) to snap to.
                 When anchor_hour is set, next_run_at is calculated as the
                 next future occurrence of that time, preventing drift.
+            thread_id: Optional Discord thread ID to post into. When set,
+                the scheduler posts to this existing thread instead of
+                creating a new one (follow-up mode).
+            one_shot: If True, the task auto-disables after a single execution.
         """
         now = time.time()
         if anchor_hour is not None and not run_immediately:
@@ -174,8 +195,9 @@ class TaskRepository:
             cursor = await db.execute(
                 """INSERT INTO scheduled_tasks
                    (name, prompt, interval_seconds, channel_id, working_dir,
-                    enabled, next_run_at, created_at, anchor_hour, anchor_minute)
-                   VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?)""",
+                    enabled, next_run_at, created_at, anchor_hour, anchor_minute,
+                    thread_id, one_shot)
+                   VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?)""",
                 (
                     name,
                     prompt,
@@ -186,6 +208,8 @@ class TaskRepository:
                     now,
                     anchor_hour,
                     anchor_minute,
+                    thread_id,
+                    1 if one_shot else 0,
                 ),
             )
             await db.commit()
@@ -251,10 +275,12 @@ class TaskRepository:
         working_dir: str | None = None,
         anchor_hour: int | None = None,
         anchor_minute: int | None = None,
+        thread_id: int | None = None,
     ) -> bool:
         """Partially update a task. Returns True if updated.
 
         Set ``anchor_hour=-1`` to clear the anchor (reset to relative mode).
+        Set ``thread_id=-1`` to clear the thread (reset to new-thread mode).
         """
         fields: list[str] = []
         values: list[object] = []
@@ -279,6 +305,13 @@ class TaskRepository:
                 values.append(anchor_hour)
                 fields.append("anchor_minute = ?")
                 values.append(anchor_minute if anchor_minute is not None else 0)
+        if thread_id is not None:
+            if thread_id < 0:
+                fields.append("thread_id = ?")
+                values.append(None)
+            else:
+                fields.append("thread_id = ?")
+                values.append(thread_id)
         if not fields:
             return False
         values.append(task_id)

--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -314,6 +314,11 @@ class ApiServer:
             anchor_time: (optional) Wall-clock time ``"HH:MM"`` to snap to,
                 preventing time drift. When set, next_run_at is calculated as
                 the next future occurrence of that time.
+            thread_id: (optional) Discord thread ID for follow-up mode.
+                When set, the scheduler posts into this existing thread
+                instead of creating a new one.
+            one_shot: (optional, default false) If true, auto-disable after
+                a single execution.
         """
         if err := self._require_task_repo():
             return err
@@ -331,6 +336,15 @@ class ApiServer:
         except ValueError as exc:
             return web.json_response({"error": str(exc)}, status=400)
 
+        # Parse optional follow-up parameters
+        raw_thread_id = data.get("thread_id")
+        thread_id: int | None = None
+        if raw_thread_id is not None:
+            with contextlib.suppress(ValueError, TypeError):
+                thread_id = int(raw_thread_id)
+
+        one_shot = bool(data.get("one_shot", False))
+
         try:
             task_id = await self.task_repo.create(  # type: ignore[union-attr]
                 name=str(data["name"]),
@@ -341,6 +355,8 @@ class ApiServer:
                 run_immediately=bool(data.get("run_immediately", True)),
                 anchor_hour=anchor_hour,
                 anchor_minute=anchor_minute,
+                thread_id=thread_id,
+                one_shot=one_shot,
             )
         except Exception as exc:
             # Most likely a UNIQUE constraint violation on name

--- a/tests/test_api_tasks.py
+++ b/tests/test_api_tasks.py
@@ -201,3 +201,87 @@ class TestTasksPatch:
     async def test_patch_nonexistent_returns_404(self, client: TestClient) -> None:
         resp = await client.patch("/api/tasks/99999", json={"enabled": False})
         assert resp.status == 404
+
+
+class TestTasksFollowUp:
+    """Tests for thread_id and one_shot parameters in /api/tasks."""
+
+    async def test_create_task_with_thread_id(self, client: TestClient) -> None:
+        resp = await client.post(
+            "/api/tasks",
+            json={
+                "name": "followup-task",
+                "prompt": "Check pipeline results",
+                "interval_seconds": 86400,
+                "channel_id": 12345,
+                "thread_id": 1234567890,
+            },
+        )
+        assert resp.status == 201
+
+    async def test_create_task_with_one_shot(self, client: TestClient) -> None:
+        resp = await client.post(
+            "/api/tasks",
+            json={
+                "name": "one-shot-task",
+                "prompt": "Check once",
+                "interval_seconds": 86400,
+                "channel_id": 12345,
+                "one_shot": True,
+            },
+        )
+        assert resp.status == 201
+
+    async def test_created_task_has_thread_id(
+        self, client: TestClient, task_repo: TaskRepository
+    ) -> None:
+        resp = await client.post(
+            "/api/tasks",
+            json={
+                "name": "with-thread",
+                "prompt": "p",
+                "interval_seconds": 86400,
+                "channel_id": 1,
+                "thread_id": 9999,
+            },
+        )
+        task_id = (await resp.json())["id"]
+        task = await task_repo.get(task_id)
+        assert task is not None
+        assert task["thread_id"] == 9999
+
+    async def test_created_task_has_one_shot(
+        self, client: TestClient, task_repo: TaskRepository
+    ) -> None:
+        resp = await client.post(
+            "/api/tasks",
+            json={
+                "name": "with-oneshot",
+                "prompt": "p",
+                "interval_seconds": 86400,
+                "channel_id": 1,
+                "one_shot": True,
+            },
+        )
+        task_id = (await resp.json())["id"]
+        task = await task_repo.get(task_id)
+        assert task is not None
+        assert task["one_shot"] is True
+
+    async def test_list_shows_thread_id_and_one_shot(self, client: TestClient) -> None:
+        await client.post(
+            "/api/tasks",
+            json={
+                "name": "full-followup",
+                "prompt": "p",
+                "interval_seconds": 86400,
+                "channel_id": 1,
+                "thread_id": 7777,
+                "one_shot": True,
+            },
+        )
+        resp = await client.get("/api/tasks")
+        data = await resp.json()
+        task = data["tasks"][0]
+        assert task["thread_id"] == 7777
+        assert task["one_shot"] is True

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -227,3 +227,161 @@ class TestSchedulerCogMasterLoop:
         ) as mock_run:
             await cog._master_loop()
         mock_run.assert_not_called()
+
+
+class TestSchedulerCogFollowUp:
+    """Tests for follow-up in existing threads (thread_id) and one-shot tasks."""
+
+    async def test_run_task_with_thread_id_posts_to_existing_thread(
+        self, repo: TaskRepository
+    ) -> None:
+        """When thread_id is set, _run_task should fetch the existing thread
+        and post there instead of creating a new one."""
+        import discord
+
+        task_id = await repo.create(
+            name="followup",
+            prompt="Check pipeline",
+            interval_seconds=86400,
+            channel_id=99,
+            thread_id=555555,
+        )
+        task = await repo.get(task_id)
+
+        mock_thread = AsyncMock(spec=discord.Thread)
+        mock_thread.send = AsyncMock()
+
+        bot = _make_bot()
+        bot.get_channel = MagicMock(
+            side_effect=lambda cid: {
+                99: MagicMock(spec=discord.TextChannel),
+                555555: mock_thread,
+            }.get(cid)
+        )
+
+        cog = SchedulerCog(bot, _make_runner(), repo=repo)
+
+        with patch(
+            "claude_discord.cogs.scheduler.run_claude_with_config", new_callable=AsyncMock
+        ) as mock_run:
+            await cog._run_task(task)
+
+        # Should use the existing thread, not create a new one
+        mock_run.assert_called_once()
+        run_config = mock_run.call_args[0][0]
+        assert run_config.thread is mock_thread
+
+        # Should have sent a starter message in the thread
+        mock_thread.send.assert_called_once()
+
+    async def test_one_shot_task_disabled_after_run(self, repo: TaskRepository) -> None:
+        """Tasks with one_shot=True should be disabled after execution."""
+        import discord
+
+        task_id = await repo.create(
+            name="one-time",
+            prompt="Check once",
+            interval_seconds=86400,
+            channel_id=99,
+            one_shot=True,
+        )
+        task = await repo.get(task_id)
+
+        mock_thread = AsyncMock(spec=discord.Thread)
+        mock_starter = AsyncMock()
+        mock_starter.create_thread = AsyncMock(return_value=mock_thread)
+        mock_channel = AsyncMock(spec=discord.TextChannel)
+        mock_channel.send = AsyncMock(return_value=mock_starter)
+
+        bot = _make_bot()
+        bot.get_channel = MagicMock(return_value=mock_channel)
+
+        cog = SchedulerCog(bot, _make_runner(), repo=repo)
+
+        with patch("claude_discord.cogs.scheduler.run_claude_with_config", new_callable=AsyncMock):
+            await cog._run_task(task)
+
+        # Task should be disabled after execution
+        updated = await repo.get(task_id)
+        assert updated is not None
+        assert updated["enabled"] is False
+
+    async def test_recurring_task_not_disabled_after_run(self, repo: TaskRepository) -> None:
+        """Regular tasks (one_shot=False) should remain enabled after execution."""
+        import discord
+
+        task_id = await repo.create(
+            name="recurring",
+            prompt="Regular check",
+            interval_seconds=3600,
+            channel_id=99,
+        )
+        task = await repo.get(task_id)
+
+        mock_thread = AsyncMock(spec=discord.Thread)
+        mock_starter = AsyncMock()
+        mock_starter.create_thread = AsyncMock(return_value=mock_thread)
+        mock_channel = AsyncMock(spec=discord.TextChannel)
+        mock_channel.send = AsyncMock(return_value=mock_starter)
+
+        bot = _make_bot()
+        bot.get_channel = MagicMock(return_value=mock_channel)
+
+        cog = SchedulerCog(bot, _make_runner(), repo=repo)
+
+        with patch("claude_discord.cogs.scheduler.run_claude_with_config", new_callable=AsyncMock):
+            await cog._run_task(task)
+
+        updated = await repo.get(task_id)
+        assert updated is not None
+        assert updated["enabled"] is True
+
+    async def test_followup_with_thread_id_resumes_session(self, repo: TaskRepository) -> None:
+        """When thread_id is set and session_repo has a record, session_id should be passed."""
+        # Set up session DB with an existing session for thread 555555
+        import tempfile
+
+        import discord
+
+        from claude_discord.database.models import init_db
+        from claude_discord.database.repository import SessionRepository
+
+        fd, session_db_path = tempfile.mkstemp(suffix=".db")
+        import os
+
+        os.close(fd)
+        await init_db(session_db_path)
+        session_repo = SessionRepository(session_db_path)
+        await session_repo.save(555555, "existing-session-id-abc", "/home/ebi")
+
+        task_id = await repo.create(
+            name="resume-followup",
+            prompt="Continue analysis",
+            interval_seconds=86400,
+            channel_id=99,
+            thread_id=555555,
+        )
+        task = await repo.get(task_id)
+
+        mock_thread = AsyncMock(spec=discord.Thread)
+        mock_thread.send = AsyncMock()
+
+        bot = _make_bot()
+        bot.get_channel = MagicMock(
+            side_effect=lambda cid: {
+                99: MagicMock(spec=discord.TextChannel),
+                555555: mock_thread,
+            }.get(cid)
+        )
+
+        cog = SchedulerCog(bot, _make_runner(), repo=repo, session_repo=session_repo)
+
+        with patch(
+            "claude_discord.cogs.scheduler.run_claude_with_config", new_callable=AsyncMock
+        ) as mock_run:
+            await cog._run_task(task)
+
+        run_config = mock_run.call_args[0][0]
+        assert run_config.session_id == "existing-session-id-abc"
+
+        os.unlink(session_db_path)

--- a/tests/test_task_repo.py
+++ b/tests/test_task_repo.py
@@ -306,3 +306,65 @@ class TestTaskRepoUpdate:
     async def test_update_nonexistent_returns_false(self, repo: TaskRepository) -> None:
         result = await repo.update(99999, prompt="x")
         assert result is False
+
+
+class TestTaskRepoThreadId:
+    """Tests for thread_id column — follow-up in existing threads."""
+
+    async def test_create_without_thread_id_defaults_to_none(self, repo: TaskRepository) -> None:
+        task_id = await repo.create(name="no-thread", prompt="p", interval_seconds=60, channel_id=1)
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["thread_id"] is None
+
+    async def test_create_with_thread_id(self, repo: TaskRepository) -> None:
+        task_id = await repo.create(
+            name="follow-up",
+            prompt="Check results",
+            interval_seconds=86400,
+            channel_id=1,
+            thread_id=1234567890,
+        )
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["thread_id"] == 1234567890
+
+    async def test_update_thread_id(self, repo: TaskRepository) -> None:
+        task_id = await repo.create(name="t", prompt="p", interval_seconds=60, channel_id=1)
+        result = await repo.update(task_id, thread_id=9876543210)
+        assert result is True
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["thread_id"] == 9876543210
+
+    async def test_clear_thread_id(self, repo: TaskRepository) -> None:
+        task_id = await repo.create(
+            name="t", prompt="p", interval_seconds=60, channel_id=1, thread_id=111
+        )
+        result = await repo.update(task_id, thread_id=-1)
+        assert result is True
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["thread_id"] is None
+
+
+class TestTaskRepoOneShot:
+    """Tests for one_shot column — auto-disable after execution."""
+
+    async def test_create_without_one_shot_defaults_to_false(self, repo: TaskRepository) -> None:
+        task_id = await repo.create(name="recurring", prompt="p", interval_seconds=60, channel_id=1)
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["one_shot"] is False
+
+    async def test_create_with_one_shot(self, repo: TaskRepository) -> None:
+        task_id = await repo.create(
+            name="once",
+            prompt="Check once",
+            interval_seconds=86400,
+            channel_id=1,
+            one_shot=True,
+        )
+        task = await repo.get(task_id)
+        assert task is not None
+        assert task["one_shot"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "2.1.18"
+version = "2.1.21"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- **thread_id**: タスクに既存スレッドIDを指定可能。指定された場合、新スレッド作成ではなく既存スレッドに投稿してセッション再開
- **one_shot**: 1回実行後に自動で`enabled=false`になるフラグ。「X月X日にこのスレッドで続きを」のようなフォローアップ用途
- REST API (`/api/tasks`) でも `thread_id` / `one_shot` パラメータを受け付け

## Changes
- `task_repo.py`: DBマイグレーション追加（thread_id, one_shot カラム）、CRUD対応
- `scheduler.py`: `_run_task()` に thread_id 分岐追加、`_create_new_thread()` ヘルパー抽出、one_shot 自動無効化
- `api_server.py`: create_task に thread_id / one_shot パラメータ追加
- テスト: 11テスト追加（task_repo: 6, scheduler: 4, api: 5） → 全64テスト PASS

## Test plan
- [x] `uv run pytest tests/ -x -q` — 64 passed
- [x] ruff lint PASS
- [ ] dev-on で実際のフォローアップタスク登録・実行を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)