### PR TITLE
feat: add CLI env overlay support (CCDB_CLI_ENV_FILE)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,12 @@ CLAUDE_WORKING_DIR=
 # Useful for injecting workarounds or custom instructions at the CLI level.
 # APPEND_SYSTEM_PROMPT=
 
+# CLI environment overlay file (optional)
+# Path to a KEY=VALUE file whose variables are merged into the CLI subprocess env.
+# The file is read on every CLI invocation, so changes take effect immediately
+# without restarting the bot. Useful for temporary API routing (e.g., Azure Foundry).
+# CCDB_CLI_ENV_FILE=/path/to/overlay.env
+
 # Limits
 MAX_CONCURRENT_SESSIONS=3
 SESSION_TIMEOUT_SECONDS=300

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ Discord frontend for Claude Code CLI. **This is a framework (OSS library), not a
 7. **REST API as the control plane**: Claude Code subprocesses communicate back to ccdb via REST API (`CCDB_API_URL` env var), not via stdout markers or special output formats. This makes the interface explicit, testable, and usable by external systems (GitHub Actions, etc.). See `ext/api_server.py`.
 8. **SQLite-backed dynamic scheduler**: Scheduled tasks are stored in `scheduled_tasks` DB table and executed by a single `discord.ext.tasks` master loop (every 30s). Tasks are registered at runtime via REST API — no code changes needed to add new tasks. `discord.ext.tasks` decorators are only used for the master loop, not per-task (they're static/compile-time constructs).
 9. **Claude handles "what", ccdb handles "when"**: For scheduled tasks, ccdb only manages the schedule. All domain logic (what to check, how to deduplicate, what to post) lives in the Claude prompt. No GitHub/AzureDevOps-specific code in ccdb itself.
+10. **CLI env overlay** (`CCDB_CLI_ENV_FILE`): Optional `KEY=VALUE` file read on every CLI spawn to inject env vars into the subprocess. Enables live configuration changes (e.g., switching to Azure Foundry) without restarting the bot. The file is read by `_build_env()` in `runner.py`.
 
 ### Why REST API over stdout markers for Claude→ccdb communication
 

--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ In chat-only mode, permission requests and `AskUserQuestion` prompts are **alway
 | `CLAUDE_CHANNEL_IDS` | Additional channel IDs (comma-separated) for multi-channel setup | (optional) |
 | `THREAD_INBOX_ENABLED` | Enable the persistent thread inbox (classifies sessions as `waiting`/`done`/`ambiguous` via `claude -p`; shown in thread dashboard) | `false` |
 | `THREAD_AUTO_RENAME` | Auto-rename new thread titles using Claude AI — generates a short, descriptive title from the first user message via a background `claude -p` call (never delays session start) | `false` |
+| `CCDB_CLI_ENV_FILE` | Path to a `KEY=VALUE` file whose variables are merged into the CLI subprocess environment on every invocation. Changes take effect immediately without restarting the bot. Useful for temporary API routing (e.g., Azure Foundry) | (optional) |
 | `API_HOST` | REST API bind address | `127.0.0.1` |
 | `API_PORT` | REST API port (enables REST API when set) | (optional) |
 

--- a/claude_discord/claude/runner.py
+++ b/claude_discord/claude/runner.py
@@ -403,8 +403,23 @@ class ClaudeRunner:
 
         Injects CCDB_API_URL (and optionally CCDB_API_SECRET) so Claude Code
         can register scheduled tasks via ``curl $CCDB_API_URL/api/tasks``.
+
+        If ``CCDB_CLI_ENV_FILE`` is set, reads KEY=VALUE pairs from that file
+        and merges them into the env (overriding process env). This allows
+        injecting env vars into the CLI subprocess without restarting ccdb
+        (e.g., temporary Azure Foundry configuration).
         """
         env = {k: v for k, v in os.environ.items() if k not in self._STRIPPED_ENV_KEYS}
+        overlay_path = os.environ.get("CCDB_CLI_ENV_FILE")
+        if overlay_path:
+            try:
+                for line in Path(overlay_path).read_text().splitlines():
+                    line = line.strip()
+                    if line and not line.startswith("#") and "=" in line:
+                        key, value = line.split("=", 1)
+                        env[key] = value
+            except OSError:
+                logger.debug("CLI env overlay file not found: %s", overlay_path)
         if self.api_port is not None:
             env["CCDB_API_URL"] = f"http://127.0.0.1:{self.api_port}"
         if self.api_secret is not None:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -258,6 +258,60 @@ class TestBuildEnv:
         env = runner._build_env()
         assert "CCDB_API_SECRET" not in env
 
+    def test_reads_cli_env_overlay_file(self, tmp_path: Path) -> None:
+        overlay = tmp_path / "overlay.env"
+        overlay.write_text("MY_CUSTOM_VAR=hello\nANOTHER_VAR=world\n")
+        os.environ["CCDB_CLI_ENV_FILE"] = str(overlay)
+        try:
+            runner = ClaudeRunner()
+            env = runner._build_env()
+            assert env["MY_CUSTOM_VAR"] == "hello"
+            assert env["ANOTHER_VAR"] == "world"
+        finally:
+            del os.environ["CCDB_CLI_ENV_FILE"]
+
+    def test_cli_env_overlay_skips_comments_and_blanks(self, tmp_path: Path) -> None:
+        overlay = tmp_path / "overlay.env"
+        overlay.write_text("# comment\n\nVALID_KEY=value\n")
+        os.environ["CCDB_CLI_ENV_FILE"] = str(overlay)
+        try:
+            runner = ClaudeRunner()
+            env = runner._build_env()
+            assert env["VALID_KEY"] == "value"
+            assert "#" not in {k[0] for k in env if k.startswith("#")}
+        finally:
+            del os.environ["CCDB_CLI_ENV_FILE"]
+
+    def test_cli_env_overlay_missing_file_is_ignored(self) -> None:
+        os.environ["CCDB_CLI_ENV_FILE"] = "/nonexistent/overlay.env"
+        try:
+            runner = ClaudeRunner()
+            env = runner._build_env()
+            assert "PATH" in env  # still works
+        finally:
+            del os.environ["CCDB_CLI_ENV_FILE"]
+
+    def test_cli_env_overlay_not_set_no_effect(self) -> None:
+        original = os.environ.pop("CCDB_CLI_ENV_FILE", None)
+        try:
+            runner = ClaudeRunner()
+            env = runner._build_env()
+            assert "PATH" in env
+        finally:
+            if original is not None:
+                os.environ["CCDB_CLI_ENV_FILE"] = original
+
+    def test_cli_env_overlay_overrides_process_env(self, tmp_path: Path) -> None:
+        overlay = tmp_path / "overlay.env"
+        overlay.write_text("PATH=/custom/path\n")
+        os.environ["CCDB_CLI_ENV_FILE"] = str(overlay)
+        try:
+            runner = ClaudeRunner()
+            env = runner._build_env()
+            assert env["PATH"] == "/custom/path"
+        finally:
+            del os.environ["CCDB_CLI_ENV_FILE"]
+
 
 class TestClone:
     """Tests for clone method."""

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "2.1.22"
+version = "2.1.23"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Add `CCDB_CLI_ENV_FILE` support to `_build_env()` in `runner.py`
- When set, reads a `KEY=VALUE` file and merges variables into the CLI subprocess environment
- File is read on every CLI invocation — changes take effect immediately without bot restart
- Useful for temporary API routing (e.g., switching to Azure Foundry)

## Changes

- `claude_discord/claude/runner.py` — overlay file reading in `_build_env()`
- `tests/test_runner.py` — 5 new tests for overlay feature
- `README.md` — added to Configuration table
- `CLAUDE.md` — added as Key Design Decision #10
- `.env.example` — added commented example

## Test plan

- [x] 5 unit tests (read, skip comments/blanks, missing file, not set, override)
- [x] Full test suite passes (78 tests)
- [x] ruff check + format clean
- [ ] Discord integration test via dev-on mode