### PR TITLE
[docs-sync] Add CCDB_CLI_ENV_FILE to all translated READMEs

### DIFF
--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -306,6 +306,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `CHAT_ONLY_CHANNEL_IDS` | IDs de canal separadas por coma donde solo se muestran las respuestas de texto de Claude (embeds de herramientas/thinking/Todo ocultos) | (opcional) |
 | `THREAD_INBOX_ENABLED` | Habilita la bandeja de entrada persistente de hilos (clasifica sesiones como `waiting`/`done`/`ambiguous` via `claude -p`; mostrado en el panel de hilos) | `false` |
 | `THREAD_AUTO_RENAME` | Renombra automáticamente los títulos de nuevos hilos con Claude AI — genera un título corto y descriptivo del primer mensaje del usuario mediante una llamada a `claude -p` en segundo plano (sin retrasar el inicio de la sesión) | `false` |
+| `CCDB_CLI_ENV_FILE` | Ruta a un archivo `KEY=VALUE` cuyas variables se fusionan en el entorno del subproceso CLI en cada invocación. Los cambios surten efecto inmediatamente sin reiniciar el bot. Útil para enrutamiento de API temporal (p.ej., cambio a Azure Foundry) | (opcional) |
 
 ### Modos de Permiso — Qué Funciona en el Modo `-p`
 

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -306,6 +306,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `CHAT_ONLY_CHANNEL_IDS` | IDs de canal séparés par des virgules où seules les réponses texte de Claude sont affichées (embeds d'outils/thinking/Todo masqués) | (optionnel) |
 | `THREAD_INBOX_ENABLED` | Active la boîte de réception persistante des fils (classe les sessions en `waiting`/`done`/`ambiguous` via `claude -p` ; affiché dans le tableau de bord des fils) | `false` |
 | `THREAD_AUTO_RENAME` | Renomme automatiquement les titres des nouveaux fils avec Claude AI — génère un titre court et descriptif du premier message utilisateur via un appel `claude -p` en arrière-plan (sans délai de démarrage de session) | `false` |
+| `CCDB_CLI_ENV_FILE` | Chemin vers un fichier `KEY=VALUE` dont les variables sont fusionnées dans l'environnement du sous-processus CLI à chaque invocation. Les modifications prennent effet immédiatement sans redémarrer le bot. Utile pour le routage d'API temporaire (ex. : basculement vers Azure Foundry) | (optionnel) |
 
 ### Modes d'autorisation — Ce qui fonctionne en mode `-p`
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -540,6 +540,7 @@ CHAT_ONLY_CHANNEL_IDS=444,555
 | `CLAUDE_CHANNEL_IDS` | マルチチャンネル設定用の追加チャンネル ID（カンマ区切り） | （オプション） |
 | `THREAD_INBOX_ENABLED` | 永続スレッドインボックスを有効化（`claude -p` でセッションを `waiting`/`done`/`ambiguous` に分類し、スレッドダッシュボードに表示） | `false` |
 | `THREAD_AUTO_RENAME` | 新しいスレッドのタイトルを Claude AI で自動リネーム — 最初のユーザーメッセージをもとにバックグラウンドの `claude -p` 呼び出しで短く分かりやすいタイトルを生成（セッション開始を遅延させない） | `false` |
+| `CCDB_CLI_ENV_FILE` | CLI サブプロセス環境に毎回マージする `KEY=VALUE` ファイルのパス。変更はボットを再起動せずに即時反映される。一時的な API ルーティング（Azure Foundry への切り替えなど）に便利 | （オプション） |
 | `API_HOST` | REST API バインドアドレス | `127.0.0.1` |
 | `API_PORT` | REST API ポート（設定すると REST API が有効になる） | （オプション） |
 

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -306,6 +306,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `CHAT_ONLY_CHANNEL_IDS` | Claude의 텍스트 응답만 표시하는 채널 ID (쉼표로 구분, 도구 임베드/thinking/Todo 숨김) | (선택) |
 | `THREAD_INBOX_ENABLED` | 지속적인 스레드 수신함 활성화 (`claude -p`로 세션을 `waiting`/`done`/`ambiguous`로 분류; 스레드 대시보드에 표시) | `false` |
 | `THREAD_AUTO_RENAME` | Claude AI를 사용하여 새 스레드 제목 자동 이름 변경 — 백그라운드 `claude -p` 호출로 첫 번째 사용자 메시지에서 짧고 설명적인 제목 생성 (세션 시작 지연 없음) | `false` |
+| `CCDB_CLI_ENV_FILE` | 매 호출 시 CLI 서브프로세스 환경에 병합할 `KEY=VALUE` 파일 경로. 변경 사항은 봇을 재시작하지 않고 즉시 적용됨. 임시 API 라우팅(예: Azure Foundry 전환)에 유용 | (선택) |
 
 ### 권한 모드 — `-p` 모드에서 작동하는 기능
 

--- a/docs/pt-BR/README.md
+++ b/docs/pt-BR/README.md
@@ -306,6 +306,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `CHAT_ONLY_CHANNEL_IDS` | IDs de canal separados por vírgula onde apenas as respostas de texto do Claude são exibidas (embeds de ferramentas/thinking/Todo ocultos) | (opcional) |
 | `THREAD_INBOX_ENABLED` | Ativa a caixa de entrada persistente de threads (classifica sessões como `waiting`/`done`/`ambiguous` via `claude -p`; exibido no painel de threads) | `false` |
 | `THREAD_AUTO_RENAME` | Renomeia automaticamente títulos de novas threads com Claude AI — gera um título curto e descritivo da primeira mensagem do usuário via chamada `claude -p` em segundo plano (sem atrasar o início da sessão) | `false` |
+| `CCDB_CLI_ENV_FILE` | Caminho para um arquivo `KEY=VALUE` cujas variáveis são mescladas no ambiente do subprocesso CLI a cada invocação. Alterações têm efeito imediato sem reiniciar o bot. Útil para roteamento de API temporário (ex.: alternância para Azure Foundry) | (opcional) |
 
 ### Modos de Permissão — O Que Funciona no Modo `-p`
 

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -323,6 +323,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `CHAT_ONLY_CHANNEL_IDS` | 仅显示 Claude 文本回复的频道 ID（逗号分隔，工具嵌入/thinking/Todo 隐藏） | （可选） |
 | `THREAD_INBOX_ENABLED` | 启用持久线程收件箱（通过 `claude -p` 将会话分类为 `waiting`/`done`/`ambiguous`；显示在线程面板中） | `false` |
 | `THREAD_AUTO_RENAME` | 使用 Claude AI 自动重命名新线程标题 — 通过后台 `claude -p` 调用从首条用户消息生成简短描述性标题（不影响会话启动速度） | `false` |
+| `CCDB_CLI_ENV_FILE` | 每次调用时合并到 CLI 子进程环境的 `KEY=VALUE` 文件路径。更改无需重启机器人即可立即生效。适用于临时 API 路由（如切换到 Azure Foundry） | （可选） |
 
 ### 权限模式 — `-p` 模式下的功能说明
 


### PR DESCRIPTION
## Summary

- Add `CCDB_CLI_ENV_FILE` environment variable entry to all translated README files (ja, zh-CN, ko, es, pt-BR, fr)
- This env var was added to the English README in feat: add CLI env overlay support (CCDB_CLI_ENV_FILE) (#359) but translations were not updated

## Changes

| Language | File |
|----------|------|
| Japanese | docs/ja/README.md |
| Chinese Simplified | docs/zh-CN/README.md |
| Korean | docs/ko/README.md |
| Spanish | docs/es/README.md |
| Portuguese (Brazil) | docs/pt-BR/README.md |
| French | docs/fr/README.md |

## Test plan

- [ ] Verify `CCDB_CLI_ENV_FILE` row appears in the environment variables table in each translated file
- [ ] Confirm code snippets, variable names, and URLs are unchanged
- [ ] Check that surrounding rows are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)