### PR TITLE
fix: pass env overlay to thread title renamer

### DIFF
--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -488,7 +488,11 @@ class ClaudeChatCog(commands.Cog):
         Runs as a background asyncio task so it does not block the main session.
         Silently no-ops on any error so the thread name is never left in a bad state.
         """
-        title = await suggest_title(user_message, claude_command=self.runner.command)
+        title = await suggest_title(
+            user_message,
+            claude_command=self.runner.command,
+            env=self.runner._build_env(),
+        )
         if title:
             try:
                 await thread.edit(name=title)

--- a/claude_discord/discord_ui/thread_renamer.py
+++ b/claude_discord/discord_ui/thread_renamer.py
@@ -78,12 +78,19 @@ def _clean_title(raw: str) -> str:
 async def suggest_title(
     user_message: str,
     claude_command: str = "claude",
+    env: dict[str, str] | None = None,
 ) -> str | None:
     """Call `claude -p` and return a short thread title.
 
     Returns None on empty input, timeout, or any error, so the caller can
     keep the original thread name without any visible failure.
     Prompt is passed as a direct argument to the binary (no shell, no injection risk).
+
+    Args:
+        env: Optional environment dict for the subprocess. When provided
+             (e.g. from ``ClaudeRunner._build_env()``), ensures the CLI
+             picks up the same API keys and overlay config as main sessions.
+             When ``None``, the subprocess inherits the parent environment.
     """
     if not user_message.strip():
         return None
@@ -97,6 +104,7 @@ async def suggest_title(
             prompt,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env=env,
         )
         try:
             stdout, _stderr = await asyncio.wait_for(proc.communicate(), timeout=_TIMEOUT_SECONDS)
@@ -107,6 +115,10 @@ async def suggest_title(
             return None
 
         raw = stdout.decode(errors="replace")
+        stderr_text = _stderr.decode(errors="replace").strip()
+        if stderr_text:
+            logger.warning("thread title renamer stderr: %s", stderr_text[:500])
+
         title = _clean_title(raw)
 
         if not title:

--- a/tests/test_thread_renamer.py
+++ b/tests/test_thread_renamer.py
@@ -242,6 +242,25 @@ class TestSuggestTitleErrors:
         assert result is None
 
     @pytest.mark.asyncio
+    async def test_passes_env_to_subprocess(self):
+        """When env dict is provided, it is forwarded to create_subprocess_exec."""
+        proc = _make_proc(b"Title from custom env\n")
+        custom_env = {"CLAUDE_CODE_USE_FOUNDRY": "1", "PATH": "/usr/bin"}
+        with patch("asyncio.create_subprocess_exec", return_value=proc) as mock_exec:
+            result = await suggest_title("some request", env=custom_env)
+        assert result == "Title from custom env"
+        assert mock_exec.call_args[1].get("env") is custom_env
+
+    @pytest.mark.asyncio
+    async def test_no_env_passes_none_to_subprocess(self):
+        """When env is not provided, subprocess inherits parent environment (env=None)."""
+        proc = _make_proc(b"Default env title\n")
+        with patch("asyncio.create_subprocess_exec", return_value=proc) as mock_exec:
+            await suggest_title("some request")
+        # env keyword should not be set, or should be None
+        assert mock_exec.call_args[1].get("env") is None
+
+    @pytest.mark.asyncio
     async def test_kills_process_on_timeout(self):
         """After asyncio.TimeoutError, proc.kill() and cleanup communicate() are called.
 


### PR DESCRIPTION
## Summary
- Thread title renamer (`suggest_title()`) was spawning `claude -p` without `CCDB_CLI_ENV_FILE` overlay, causing it to use different API credentials than main sessions
- When the bot runs via Azure Foundry (`CLAUDE_CODE_USE_FOUNDRY=1`), the title subprocess tried to hit the default Anthropic API instead, hitting rate limits
- Now passes `runner._build_env()` to the subprocess, ensuring consistent env across all CLI invocations
- Also logs stderr from the subprocess for easier debugging of future issues

## Test plan
- [x] New unit tests for `env` parameter passthrough
- [x] Backward compatibility: `env=None` default preserves existing behavior
- [x] All 24 thread_renamer tests passing
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)