### PR TITLE
fix: コンテキスト利用率をper-turn usageベースに修正

### DIFF
--- a/claude_discord/claude/parser.py
+++ b/claude_discord/claude/parser.py
@@ -153,6 +153,16 @@ def _parse_assistant(data: dict[str, Any], event: StreamEvent) -> None:
     if thinking_parts:
         event.thinking = "\n".join(thinking_parts)
 
+    # Extract per-turn usage from the assistant message.
+    # Unlike the cumulative usage in RESULT, this reflects the actual token
+    # counts for this single API call — essential for accurate context tracking.
+    usage = message.get("usage", {})
+    if usage:
+        event.input_tokens = usage.get("input_tokens")
+        event.output_tokens = usage.get("output_tokens")
+        event.cache_read_tokens = usage.get("cache_read_input_tokens")
+        event.cache_creation_tokens = usage.get("cache_creation_input_tokens")
+
 
 def _parse_user(data: dict[str, Any], event: StreamEvent) -> None:
     """Parse user message (tool_result blocks with content)."""

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -145,6 +145,15 @@ class EventProcessor:
         # Triggers interrupt → rerun-with-guardrail in _run_helper.
         self._compact_occurred: bool = False
 
+        # Per-turn usage from the last assistant message. The RESULT message
+        # reports cumulative token counts across all API calls, which inflates
+        # context utilization (each turn re-sends the full conversation).
+        # We track the last turn's values and prefer them over RESULT's.
+        self._last_turn_input_tokens: int | None = None
+        self._last_turn_output_tokens: int | None = None
+        self._last_turn_cache_read_tokens: int | None = None
+        self._last_turn_cache_creation_tokens: int | None = None
+
     # ------------------------------------------------------------------
     # Public properties
     # ------------------------------------------------------------------
@@ -299,6 +308,13 @@ class EventProcessor:
         if event.is_plan_approval and not event.is_partial and not self._chat_only:
             await self._handle_plan_approval(event)
 
+        # Track per-turn usage from assistant messages for accurate context stats.
+        if event.input_tokens is not None:
+            self._last_turn_input_tokens = event.input_tokens
+            self._last_turn_output_tokens = event.output_tokens
+            self._last_turn_cache_read_tokens = event.cache_read_tokens
+            self._last_turn_cache_creation_tokens = event.cache_creation_tokens
+
         # AskUserQuestion — set pending and signal caller to interrupt runner.
         # Always handled — interactive flow is needed regardless of mode.
         if event.ask_questions:
@@ -373,6 +389,14 @@ class EventProcessor:
         )
         from ..discord_ui.streaming_manager import StreamingMessageManager
         from ._run_helper import _make_error_embed
+
+        # Prefer per-turn usage (last assistant message) over cumulative RESULT usage.
+        # The RESULT sums tokens across ALL API calls, inflating context utilization.
+        if self._last_turn_input_tokens is not None:
+            event.input_tokens = self._last_turn_input_tokens
+            event.output_tokens = self._last_turn_output_tokens
+            event.cache_read_tokens = self._last_turn_cache_read_tokens
+            event.cache_creation_tokens = self._last_turn_cache_creation_tokens
 
         # Finalize any in-progress streaming message.
         # Capture the URL before sending session_complete_embed (which would

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -1040,6 +1040,110 @@ class TestContextStatsPersistence:
         assert record is None or record.context_window is None
 
 
+class TestContextStatsUsesPerTurnUsage:
+    """Context stats must use per-turn (last assistant) usage, not cumulative RESULT usage.
+
+    The RESULT message's usage field sums token counts across ALL API calls in a session.
+    For multi-turn sessions (tool use loops), this cumulative sum can easily exceed the
+    context window size, producing wildly inaccurate context utilization percentages.
+
+    The fix: track per-turn usage from assistant messages and use the last turn's values.
+    """
+
+    @pytest.mark.asyncio
+    async def test_context_used_from_last_assistant_not_cumulative_result(
+        self, thread: MagicMock, runner: MagicMock, tmp_path
+    ) -> None:
+        """Multi-turn session: context_used should reflect last turn, not cumulative."""
+        from claude_discord.database.models import init_db
+        from claude_discord.database.repository import SessionRepository
+
+        db_path = str(tmp_path / "sessions.db")
+        await init_db(db_path)
+        repo = SessionRepository(db_path)
+        await repo.save(thread_id=thread.id, session_id="s-per-turn")
+
+        config = _make_config(thread, runner, repo=repo)
+        p = EventProcessor(config)
+
+        # Simulate turn 1: assistant with tool_use (35k context)
+        turn1 = StreamEvent(
+            message_type=MessageType.ASSISTANT,
+            is_partial=False,
+            input_tokens=3,
+            output_tokens=44,
+            cache_read_tokens=0,
+            cache_creation_tokens=35000,
+        )
+        turn1.tool_use = ToolUseEvent(
+            tool_id="t1",
+            tool_name="Read",
+            tool_input={},
+            category=ToolCategory.READ,
+        )
+        await p.process(turn1)
+
+        # Simulate turn 2: assistant final response (36k context, cache hit)
+        turn2 = StreamEvent(
+            message_type=MessageType.ASSISTANT,
+            text="done",
+            is_partial=False,
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_tokens=35000,
+            cache_creation_tokens=1000,
+        )
+        await p.process(turn2)
+
+        # RESULT with cumulative usage (would be 71k+ if summed naively)
+        result = _make_result_event(
+            session_id="s-per-turn",
+            input_tokens=103,  # cumulative: 3 + 100
+            output_tokens=64,  # cumulative
+            cache_read_tokens=35000,  # cumulative
+            cache_creation_tokens=36000,  # cumulative: 35000 + 1000
+            context_window=200000,
+        )
+        await p.process(result)
+
+        record = await repo.get(thread.id)
+        assert record is not None
+        # Should use last turn's values: 100 + 35000 + 1000 = 36100
+        # NOT cumulative: 103 + 35000 + 36000 = 71103
+        assert record.context_used == 100 + 35000 + 1000
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_result_when_no_assistant_usage(
+        self, thread: MagicMock, runner: MagicMock, tmp_path
+    ) -> None:
+        """If no assistant usage was tracked, fall back to RESULT usage."""
+        from claude_discord.database.models import init_db
+        from claude_discord.database.repository import SessionRepository
+
+        db_path = str(tmp_path / "sessions.db")
+        await init_db(db_path)
+        repo = SessionRepository(db_path)
+        await repo.save(thread_id=thread.id, session_id="s-fallback")
+
+        config = _make_config(thread, runner, repo=repo)
+        p = EventProcessor(config)
+
+        # Only RESULT, no assistant messages with usage
+        result = _make_result_event(
+            session_id="s-fallback",
+            input_tokens=5000,
+            output_tokens=200,
+            cache_read_tokens=30000,
+            cache_creation_tokens=0,
+            context_window=200000,
+        )
+        await p.process(result)
+
+        record = await repo.get(thread.id)
+        assert record is not None
+        assert record.context_used == 5000 + 30000 + 0
+
+
 class TestRateLimitEventProcessing:
     """rate_limit_event is saved to usage_stats table."""
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -266,6 +266,74 @@ class TestTokenUsage:
         assert event.input_tokens is None
 
 
+class TestAssistantUsage:
+    """Tests for per-turn usage extraction from assistant messages."""
+
+    def test_assistant_message_extracts_usage(self):
+        """Assistant messages contain per-turn usage that should be extracted."""
+        line = json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [{"type": "text", "text": "hello"}],
+                    "stop_reason": "end_turn",
+                    "usage": {
+                        "input_tokens": 1000,
+                        "cache_creation_input_tokens": 35000,
+                        "cache_read_input_tokens": 0,
+                        "output_tokens": 50,
+                    },
+                },
+            }
+        )
+        event = parse_line(line)
+        assert event is not None
+        assert event.input_tokens == 1000
+        assert event.cache_creation_tokens == 35000
+        assert event.cache_read_tokens == 0
+        assert event.output_tokens == 50
+
+    def test_assistant_message_without_usage(self):
+        """Assistant messages without usage should leave token fields as None."""
+        line = json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [{"type": "text", "text": "hi"}],
+                    "stop_reason": "end_turn",
+                },
+            }
+        )
+        event = parse_line(line)
+        assert event is not None
+        assert event.input_tokens is None
+        assert event.cache_read_tokens is None
+
+    def test_assistant_partial_message_extracts_usage(self):
+        """Partial assistant messages also carry per-turn usage."""
+        line = json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [{"type": "text", "text": "hel"}],
+                    "stop_reason": None,
+                    "usage": {
+                        "input_tokens": 500,
+                        "cache_creation_input_tokens": 30000,
+                        "cache_read_input_tokens": 10000,
+                        "output_tokens": 3,
+                    },
+                },
+            }
+        )
+        event = parse_line(line)
+        assert event is not None
+        assert event.is_partial is True
+        assert event.input_tokens == 500
+        assert event.cache_creation_tokens == 30000
+        assert event.cache_read_tokens == 10000
+
+
 class TestRedactedThinking:
     def test_redacted_thinking_sets_flag(self):
         line = (

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "2.1.25"
+version = "2.1.26"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- RESULTメッセージの`usage`は全ターンの累計値で、マルチターンセッションでは実際のコンテキスト使用量の数倍になっていた
- assistantメッセージのper-turn `usage`を追跡し、最後のターンの値を使うように修正
- assistantメッセージにusageがない場合はRESULTにフォールバック

## 原因
各APIコールで会話履歴全体が再送されるため、RESULTの累計`input_tokens + cache_read + cache_creation`はターン数に比例して膨張する。例: 10ターンのセッションでシステムプロンプト35k → 累計cache_readだけで350k、200kのcontext windowを超える。

## 変更ファイル
- `claude_discord/claude/parser.py` — assistantメッセージからusageを抽出
- `claude_discord/cogs/event_processor.py` — 最後のターンのusageを追跡、RESULT処理時に上書き

## Test plan
- [x] parser: assistant usage抽出テスト（3件追加）
- [x] event_processor: per-turn usage優先テスト + フォールバックテスト（2件追加）
- [x] 既存テスト232件パス
- [x] ruff lint/format パス
- [ ] dev-onで動作確認（コンテキスト%が現実的な値になること）