### PR TITLE
feat: add /compact slash command

### DIFF
--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -57,6 +57,7 @@ _HELP_CATEGORY: dict[str, str | None] = {
     "stop": "📌 Session",
     "clear": "📌 Session",
     "rewind": "📌 Session",
+    "compact": "📌 Session",
     "fork": "📌 Session",
     "context": "📌 Session",
     "usage": "📌 Session",
@@ -300,6 +301,46 @@ class ClaudeChatCog(commands.Cog):
         # _active_runners cleanup is handled by _run_claude's finally block.
         # We intentionally do NOT delete from the session DB so the user can resume.
         await interaction.response.send_message(embed=stopped_embed())
+
+    @app_commands.command(
+        name="compact",
+        description="Manually compact (summarize) the conversation to free context space",
+    )
+    async def compact_session(self, interaction: discord.Interaction) -> None:
+        """Trigger manual context compaction via the CLI's /compact command."""
+        if not isinstance(interaction.channel, discord.Thread):
+            await interaction.response.send_message(
+                "This command can only be used in a Claude chat thread.", ephemeral=True
+            )
+            return
+
+        thread_id = interaction.channel.id
+        record = await self.repo.get(thread_id)
+        if record is None:
+            await interaction.response.send_message(
+                "No active session found for this thread.", ephemeral=True
+            )
+            return
+
+        if thread_id in self._active_runners:
+            await interaction.response.send_message(
+                "A session is currently running. Wait for it to finish before compacting.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.defer()
+
+        seed_message = await interaction.followup.send("🗜️ Compacting conversation...", wait=True)
+
+        await self._run_claude(
+            user_message=seed_message,
+            thread=interaction.channel,
+            prompt="/compact",
+            session_id=record.session_id,
+            working_dir_override=record.working_dir,
+            chat_only=True,
+        )
 
     @app_commands.command(name="clear", description="Reset the Claude Code session for this thread")
     async def clear_session(self, interaction: discord.Interaction) -> None:

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -1391,3 +1391,72 @@ class TestAutoRenameThreads:
         ):
             # Should not raise
             await cog._background_rename_thread(mock_thread, "some message")
+
+
+class TestCompactCommand:
+    """Tests for /compact slash command."""
+
+    @pytest.mark.asyncio
+    async def test_compact_outside_thread_sends_ephemeral(self) -> None:
+        cog = _make_cog()
+        interaction = _make_channel_interaction()
+
+        await cog.compact_session.callback(cog, interaction)
+
+        interaction.response.send_message.assert_called_once()
+        call_kwargs = interaction.response.send_message.call_args.kwargs
+        assert call_kwargs.get("ephemeral") is True
+
+    @pytest.mark.asyncio
+    async def test_compact_no_session_sends_ephemeral(self) -> None:
+        cog = _make_cog()
+        interaction = _make_thread_interaction(thread_id=12345)
+        cog.repo.get = AsyncMock(return_value=None)
+
+        await cog.compact_session.callback(cog, interaction)
+
+        interaction.response.send_message.assert_called_once()
+        call_kwargs = interaction.response.send_message.call_args.kwargs
+        assert call_kwargs.get("ephemeral") is True
+
+    @pytest.mark.asyncio
+    async def test_compact_while_running_sends_ephemeral(self) -> None:
+        cog = _make_cog()
+        thread_id = 12345
+        interaction = _make_thread_interaction(thread_id=thread_id)
+        record = MagicMock()
+        record.session_id = "abc-123"
+        record.working_dir = None
+        cog.repo.get = AsyncMock(return_value=record)
+        cog._active_runners[thread_id] = MagicMock()
+
+        await cog.compact_session.callback(cog, interaction)
+
+        interaction.response.send_message.assert_called_once()
+        call_kwargs = interaction.response.send_message.call_args.kwargs
+        assert call_kwargs.get("ephemeral") is True
+        assert "running" in interaction.response.send_message.call_args.args[0].lower()
+
+    @pytest.mark.asyncio
+    async def test_compact_defers_and_calls_run_claude(self) -> None:
+        cog = _make_cog()
+        thread_id = 12345
+        interaction = _make_thread_interaction(thread_id=thread_id)
+        record = MagicMock()
+        record.session_id = "abc-123"
+        record.working_dir = "/tmp/test"
+        cog.repo.get = AsyncMock(return_value=record)
+
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+
+        cog._run_claude = AsyncMock()
+
+        await cog.compact_session.callback(cog, interaction)
+
+        interaction.response.defer.assert_called_once()
+        cog._run_claude.assert_called_once()
+        call_kwargs = cog._run_claude.call_args.kwargs
+        assert call_kwargs["prompt"] == "/compact"
+        assert call_kwargs["session_id"] == "abc-123"


### PR DESCRIPTION
## Summary
- Discordスレッド内で `/compact` コマンドを実行すると、Claude Codeのコンテキスト圧縮を手動トリガーできる
- CLIに `/compact` をプロンプトテキストとして送信、`chat_only=True` でUI表示を最小化
- スレッド外・セッション未存在・実行中の各ケースでエラーハンドリング済み

## Test plan
- [x] 4テスト追加（outside-thread, no-session, active-runner, happy-path）
- [x] Discord上で実際に `/compact` を実行して動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)