### PR TITLE
fix: reject CLI error output as thread title

### DIFF
--- a/claude_discord/discord_ui/thread_renamer.py
+++ b/claude_discord/discord_ui/thread_renamer.py
@@ -114,6 +114,10 @@ async def suggest_title(
             logger.warning("thread title renamer timed out after %ds", _TIMEOUT_SECONDS)
             return None
 
+        if proc.returncode != 0:
+            logger.warning("thread title renamer exited with code %d", proc.returncode)
+            return None
+
         raw = stdout.decode(errors="replace")
         stderr_text = _stderr.decode(errors="replace").strip()
         if stderr_text:

--- a/tests/test_thread_renamer.py
+++ b/tests/test_thread_renamer.py
@@ -261,6 +261,17 @@ class TestSuggestTitleErrors:
         assert mock_exec.call_args[1].get("env") is None
 
     @pytest.mark.asyncio
+    async def test_returns_none_on_nonzero_exit_code(self):
+        """CLI errors (e.g. bad model) should not become thread titles."""
+        proc = _make_proc(
+            b"There's an issue with the selected model (claude-haiku-4-5).",
+            returncode=1,
+        )
+        with patch("asyncio.create_subprocess_exec", return_value=proc):
+            result = await suggest_title("some request")
+        assert result is None
+
+    @pytest.mark.asyncio
     async def test_kills_process_on_timeout(self):
         """After asyncio.TimeoutError, proc.kill() and cleanup communicate() are called.
 


### PR DESCRIPTION
## Summary
- `claude -p` がエラー終了（例: 無効なモデル指定）した場合、エラーメッセージがそのままスレッドタイトルとして使われていたバグを修正
- `proc.returncode != 0` をチェックし、異常終了時は `None` を返してタイトル変更をスキップ

## Root Cause
`suggest_title()` が `proc.returncode` を確認していなかったため、`claude -p` が `There's an issue with the selected model (claude-haiku-4-5)` のようなエラーをstdoutに出力すると、それがタイトルになっていた

## Test plan
- [x] 新テスト: `test_returns_none_on_nonzero_exit_code` — 終了コード1でNoneが返ることを確認
- [x] 既存テスト全25件パス
- [x] ruff check/format パス