### PR TITLE
feat: use haiku model for thread title generation

### DIFF
--- a/claude_discord/discord_ui/thread_renamer.py
+++ b/claude_discord/discord_ui/thread_renamer.py
@@ -101,6 +101,8 @@ async def suggest_title(
         proc = await asyncio.create_subprocess_exec(
             claude_command,
             "-p",
+            "--model",
+            "haiku",
             prompt,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,

--- a/tests/test_thread_renamer.py
+++ b/tests/test_thread_renamer.py
@@ -67,12 +67,21 @@ class TestSuggestTitleNormal:
         assert call_args[0] == "/usr/local/bin/claude"
 
     @pytest.mark.asyncio
+    async def test_passes_model_haiku_by_default(self):
+        proc = _make_proc(b"Some Title\n")
+        with patch("asyncio.create_subprocess_exec", return_value=proc) as mock_exec:
+            await suggest_title("some request")
+        args = mock_exec.call_args[0]
+        assert "--model" in args
+        model_idx = args.index("--model")
+        assert args[model_idx + 1] == "haiku"
+
+    @pytest.mark.asyncio
     async def test_prompt_contains_user_message(self):
         proc = _make_proc(b"Some Title\n")
         with patch("asyncio.create_subprocess_exec", return_value=proc) as mock_exec:
             await suggest_title("please help me with authentication")
-        # The prompt argument (3rd positional arg) should contain the message
-        prompt_arg = mock_exec.call_args[0][2]
+        prompt_arg = mock_exec.call_args[0][4]
         assert "please help me with authentication" in prompt_arg
 
 


### PR DESCRIPTION
## Summary
- スレッドタイトル生成に `--model haiku` を明示指定
- デフォルトモデル設定に依存しなくなり、存在しないモデルへの参照でエラーになる問題を防止
- タイトル生成は軽量タスクなのでHaikuが最適

## Test plan
- [x] 新テスト: `test_passes_model_haiku_by_default` — `--model haiku` が引数に含まれることを確認
- [x] 既存テスト全26件パス
- [x] ruff check/format パス