### PR TITLE
fix: disable background tasks in CLI subprocess

### DIFF
--- a/claude_discord/claude/runner.py
+++ b/claude_discord/claude/runner.py
@@ -429,6 +429,7 @@ class ClaudeRunner:
             env["CCDB_API_SECRET"] = self.api_secret
         if self.thread_id is not None:
             env["DISCORD_THREAD_ID"] = str(self.thread_id)
+        env["CLAUDE_CODE_DISABLE_BACKGROUND_TASKS"] = "1"
         return env
 
     async def _read_stream(self) -> AsyncGenerator[StreamEvent, None]:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -301,6 +301,11 @@ class TestBuildEnv:
             if original is not None:
                 os.environ["CCDB_CLI_ENV_FILE"] = original
 
+    def test_disables_background_tasks(self) -> None:
+        runner = ClaudeRunner()
+        env = runner._build_env()
+        assert env["CLAUDE_CODE_DISABLE_BACKGROUND_TASKS"] == "1"
+
     def test_cli_env_overlay_overrides_process_env(self, tmp_path: Path) -> None:
         overlay = tmp_path / "overlay.env"
         overlay.write_text("PATH=/custom/path\n")


### PR DESCRIPTION
## Summary
- `claude -p` モードでは `run_in_background` が事実上動作しない（TaskOutput無効＋プロセス終了で結果消失）
- `_build_env()` に `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` を注入し、ツールスキーマから `run_in_background` を除去
- フレームワーク全体のデフォルトとして全ユーザーに適用（Zero-Config原則）

## Background
Claude Code CLI の `-p` モードでバックグラウンドタスクを使うと:
1. `run_in_background` パラメータ自体はスキーマで有効
2. しかし `TaskOutput`/`TaskStop` が `-p` モードでは無効
3. メインレスポンス完了後にCLIプロセスが終了→バックグラウンドタスクも死亡

結果、Claudeが「バックグラウンドでやってるよ」と言いながら実際には何も完了しない状態が頻発していた。

## Test plan
- [x] `test_disables_background_tasks` — 新テスト追加
- [x] 既存の `TestBuildEnv` テスト全パス（14件）
- [x] 全テストスイート79件パス
- [x] ruff lint + format チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)