### PR TITLE
fix: Issue #306 自動修正

### DIFF
--- a/claude_discord/cogs/_run_helper.py
+++ b/claude_discord/cogs/_run_helper.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import re
+from dataclasses import replace
 
 import discord
 
@@ -200,8 +201,6 @@ async def run_claude_with_config(config: RunConfig) -> str | None:
         # Without this, compact_boundary and AskUserQuestion interrupt the
         # original (process-less) runner — a no-op that leaves Claude running
         # invisibly.  See: https://github.com/ebibibi/claude-code-discord-bridge/issues/306
-        from dataclasses import replace
-
         config = replace(config, runner=runner)
 
     processor = EventProcessor(config)
@@ -234,8 +233,6 @@ async def run_claude_with_config(config: RunConfig) -> str | None:
     # After compact_boundary, rerun with a guardrail to prevent Claude from
     # auto-executing "pending tasks" from the compacted context summary.
     if processor.compact_occurred:
-        from dataclasses import replace
-
         session_id = processor.session_id or config.session_id
         logger.info(
             "Compact detected for session %s — rerunning with post-compact guardrail", session_id


### PR DESCRIPTION
Closes #306

Issue #306 を `claude -p` で自動解決しました。

### 変更内容

全テスト通過 ✅

---

## 変更内容まとめ

**修正対象: `claude_discord/cogs/_run_helper.py`**

### 問題
`run_claude_with_config()` 内に `from dataclasses import replace` が2箇所ありました:
1. **204行目付近** — cloned runner を config に反映するため（Issue #306の本修正）
2. **236行目付近** — compact 後の再実行用 `guardrail_config` 作成時

Pythonの仕様で、関数内に `from X import name` が1つでも存在すると `name` は**関数全体でローカル変数扱い**になります。そのため204行目の `replace(config, runner=runner)` が236行目のローカルインポートより前に実行されると `UnboundLocalError` が発生していました。

### 修正
1. `from dataclasses import replace` をモジュール先頭のインポートセクションへ移動
2. 関数内の2つの重複インポート (`from dataclasses import replace`) を両方削除

これにより、Issue #306 の本質的な修正（cloned runner を `config.runner` に反映して `EventProcessor` が正しいプロセスに `interrupt()` を送れるようにする）が正しく動作するようになりました。


---
*issue_resolver.py による自動修正*