### PR TITLE
Fix race condition causing duplicate sessions per thread

### DIFF
--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -781,8 +781,10 @@ class ClaudeChatCog(commands.Cog):
                 if isinstance(_dashboard, ThreadStatusDashboard):
                     await _dashboard.refresh_inbox(_inbox_repo)
 
-        # Per-thread lock prevents race conditions where two messages both
-        # see _active_runners as empty and spawn duplicate CLI processes.
+        # Per-thread lock guards only the check-and-interrupt critical section,
+        # preventing two messages from both seeing _active_runners as empty and
+        # spawning duplicate CLI processes. The lock is released before _run_claude
+        # so that subsequent messages can reach the interrupt path while a session runs.
         lock = self._thread_locks.setdefault(thread.id, asyncio.Lock())
         async with lock:
             # Interrupt any active session in this thread before starting a new one.
@@ -797,17 +799,17 @@ class ClaudeChatCog(commands.Cog):
                     with contextlib.suppress(Exception):
                         await existing_task
 
-            # Determine chat_only from the parent channel of this thread.
-            chat_only = (thread.parent_id or 0) in self._chat_only_channel_ids
-            await self._run_claude(
-                message,
-                thread,
-                prompt,
-                session_id=session_id,
-                images=images,
-                working_dir_override=record.working_dir if record else None,
-                chat_only=chat_only,
-            )
+        # Determine chat_only from the parent channel of this thread.
+        chat_only = (thread.parent_id or 0) in self._chat_only_channel_ids
+        await self._run_claude(
+            message,
+            thread,
+            prompt,
+            session_id=session_id,
+            images=images,
+            working_dir_override=record.working_dir if record else None,
+            chat_only=chat_only,
+        )
 
     async def _build_prompt_and_images(
         self, message: discord.Message
@@ -949,6 +951,7 @@ class ClaudeChatCog(commands.Cog):
                     await stop_view.disable()
                 self._active_runners.pop(thread.id, None)
                 self._active_tasks.pop(thread.id, None)
+                self._thread_locks.pop(thread.id, None)
 
                 # Transition to WAITING_INPUT so owner knows a reply is needed
                 if dashboard is not None:

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -135,6 +135,10 @@ class ClaudeChatCog(commands.Cog):
         # Used by _handle_thread_reply to wait for an interrupted session
         # to fully clean up before starting the replacement session.
         self._active_tasks: dict[int, asyncio.Task] = {}
+        # Per-thread locks to prevent race conditions where two messages
+        # for the same thread both see _active_runners as empty and both
+        # spawn independent CLI processes.
+        self._thread_locks: dict[int, asyncio.Lock] = {}
         # Dashboard may be None until bot is ready; resolved lazily in _get_dashboard()
         self._dashboard = dashboard
         # For AskUserQuestion persistence across restarts
@@ -777,29 +781,33 @@ class ClaudeChatCog(commands.Cog):
                 if isinstance(_dashboard, ThreadStatusDashboard):
                     await _dashboard.refresh_inbox(_inbox_repo)
 
-        # Interrupt any active session in this thread before starting a new one.
-        existing_runner = self._active_runners.get(thread.id)
-        existing_task = self._active_tasks.get(thread.id)
-        if existing_runner is not None:
-            await thread.send("-# ⚡ Interrupted. Starting with new instruction...")
-            await existing_runner.interrupt()
-            # Wait for the interrupted _run_claude to finish its finally block
-            # (which releases the semaphore and removes entries from dicts).
-            if existing_task is not None and not existing_task.done():
-                with contextlib.suppress(Exception):
-                    await existing_task
+        # Per-thread lock prevents race conditions where two messages both
+        # see _active_runners as empty and spawn duplicate CLI processes.
+        lock = self._thread_locks.setdefault(thread.id, asyncio.Lock())
+        async with lock:
+            # Interrupt any active session in this thread before starting a new one.
+            existing_runner = self._active_runners.get(thread.id)
+            existing_task = self._active_tasks.get(thread.id)
+            if existing_runner is not None:
+                await thread.send("-# ⚡ Interrupted. Starting with new instruction...")
+                await existing_runner.interrupt()
+                # Wait for the interrupted _run_claude to finish its finally block
+                # (which releases the semaphore and removes entries from dicts).
+                if existing_task is not None and not existing_task.done():
+                    with contextlib.suppress(Exception):
+                        await existing_task
 
-        # Determine chat_only from the parent channel of this thread.
-        chat_only = (thread.parent_id or 0) in self._chat_only_channel_ids
-        await self._run_claude(
-            message,
-            thread,
-            prompt,
-            session_id=session_id,
-            images=images,
-            working_dir_override=record.working_dir if record else None,
-            chat_only=chat_only,
-        )
+            # Determine chat_only from the parent channel of this thread.
+            chat_only = (thread.parent_id or 0) in self._chat_only_channel_ids
+            await self._run_claude(
+                message,
+                thread,
+                prompt,
+                session_id=session_id,
+                images=images,
+                working_dir_override=record.working_dir if record else None,
+                chat_only=chat_only,
+            )
 
     async def _build_prompt_and_images(
         self, message: discord.Message


### PR DESCRIPTION
## Summary

`_handle_thread_reply` has a race condition where two messages arriving close together for the same thread can both see `_active_runners` as empty and both call `_run_claude`, spawning independent CLI processes in the same thread.

This PR adds a per-thread `asyncio.Lock` (`_thread_locks` dict) wrapping the check-and-spawn sequence so it's atomic. The second message will wait for the lock, then correctly see the active runner and interrupt it before starting a new session.

## Changes

- Added `_thread_locks: dict[int, asyncio.Lock]` to `ClaudeChatCog.__init__`
- Wrapped the interrupt-check and `_run_claude` call in `_handle_thread_reply` with `async with lock`
- No behavior change for normal (non-concurrent) usage

## Test plan

- [ ] Send two messages rapidly in the same thread — only one CLI process should spawn
- [ ] Verify normal conversation flow is unaffected (single message → session → response)
- [ ] Verify interrupt behavior still works (new message while session is active sends SIGINT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)