### PR TITLE
feat: wire MAX_CONCURRENT_SESSIONS through setup_bridge

### DIFF
--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -78,6 +78,7 @@ async def setup_bridge(
     enable_scheduler: bool = True,
     task_db_path: str = "data/tasks.db",
     lounge_channel_id: int | None = None,
+    max_concurrent: int | None = None,
     worktree_base_dir: str | None = None,
     enable_thread_inbox: bool = False,
     auto_rename_threads: bool | None = None,
@@ -202,6 +203,13 @@ async def setup_bridge(
     if monitor_all_channels:
         logger.info("Monitor-all-channels enabled — bot will respond in ANY guild channel")
 
+    # Max concurrent sessions — fall back to MAX_CONCURRENT_SESSIONS env var, then 3
+    if max_concurrent is None:
+        _env_max = os.getenv("MAX_CONCURRENT_SESSIONS", "")
+        max_concurrent = int(_env_max) if _env_max.isdigit() else 3
+    if max_concurrent != 3:
+        logger.info("Max concurrent sessions: %d", max_concurrent)
+
     # WorktreeManager — attach to bot so cogs can access it via bot.worktree_manager
     if worktree_base_dir is None:
         worktree_base_dir = os.getenv("WORKTREE_BASE_DIR")
@@ -237,6 +245,7 @@ async def setup_bridge(
         bot,  # type: ignore[arg-type]  # consumers pass their own Bot subclass
         repo=session_repo,
         runner=runner,
+        max_concurrent=max_concurrent,
         allowed_user_ids=allowed_user_ids,
         ask_repo=ask_repo,
         lounge_repo=lounge_repo,

--- a/examples/ebibot/.env.example
+++ b/examples/ebibot/.env.example
@@ -11,7 +11,7 @@ CLAUDE_MODEL=sonnet
 # For legacy "yolo" mode, use CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true instead
 CLAUDE_PERMISSION_MODE=auto
 CLAUDE_WORKING_DIR=/home/you
-MAX_CONCURRENT_SESSIONS=3
+MAX_CONCURRENT_SESSIONS=5
 SESSION_TIMEOUT_SECONDS=300
 
 # Multi-channel support (comma-separated, optional)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -285,3 +285,86 @@ async def test_setup_bridge_preserves_existing_runner_api_port(tmp_path: object)
 
     # Should NOT overwrite the existing value
     assert runner.api_port == 9999
+
+
+@pytest.mark.asyncio
+async def test_setup_bridge_passes_max_concurrent_to_chat_cog(tmp_path: object) -> None:
+    """max_concurrent parameter should be forwarded to ClaudeChatCog."""
+    from claude_discord.cogs.claude_chat import ClaudeChatCog
+
+    bot = _make_bot()
+    runner = _make_runner()
+
+    await setup_bridge(
+        bot,
+        runner,
+        session_db_path=str(tmp_path / "sessions.db"),  # type: ignore[operator]
+        claude_channel_id=111,
+        max_concurrent=7,
+        enable_scheduler=False,
+    )
+
+    chat_cog = next(
+        call.args[0]
+        for call in bot.add_cog.call_args_list
+        if isinstance(call.args[0], ClaudeChatCog)
+    )
+    assert chat_cog._max_concurrent == 7
+
+
+@pytest.mark.asyncio
+async def test_setup_bridge_reads_max_concurrent_from_env(tmp_path: object) -> None:
+    """MAX_CONCURRENT_SESSIONS env var should be used when parameter is None."""
+    from unittest.mock import patch
+
+    from claude_discord.cogs.claude_chat import ClaudeChatCog
+
+    bot = _make_bot()
+    runner = _make_runner()
+
+    with patch.dict("os.environ", {"MAX_CONCURRENT_SESSIONS": "10"}):
+        await setup_bridge(
+            bot,
+            runner,
+            session_db_path=str(tmp_path / "sessions.db"),  # type: ignore[operator]
+            claude_channel_id=111,
+            enable_scheduler=False,
+        )
+
+    chat_cog = next(
+        call.args[0]
+        for call in bot.add_cog.call_args_list
+        if isinstance(call.args[0], ClaudeChatCog)
+    )
+    assert chat_cog._max_concurrent == 10
+
+
+@pytest.mark.asyncio
+async def test_setup_bridge_defaults_max_concurrent_to_3(tmp_path: object) -> None:
+    """Without env var or parameter, max_concurrent defaults to 3."""
+    from unittest.mock import patch
+
+    from claude_discord.cogs.claude_chat import ClaudeChatCog
+
+    bot = _make_bot()
+    runner = _make_runner()
+
+    with patch.dict("os.environ", {}, clear=False):
+        # Ensure env var is not set
+        import os
+
+        os.environ.pop("MAX_CONCURRENT_SESSIONS", None)
+        await setup_bridge(
+            bot,
+            runner,
+            session_db_path=str(tmp_path / "sessions.db"),  # type: ignore[operator]
+            claude_channel_id=111,
+            enable_scheduler=False,
+        )
+
+    chat_cog = next(
+        call.args[0]
+        for call in bot.add_cog.call_args_list
+        if isinstance(call.args[0], ClaudeChatCog)
+    )
+    assert chat_cog._max_concurrent == 3


### PR DESCRIPTION
## Summary
- `MAX_CONCURRENT_SESSIONS` env var was read in `main.py` but never forwarded to `ClaudeChatCog` — the semaphore was always hardcoded at 3
- Added `max_concurrent` parameter to `setup_bridge()` with env var fallback (`MAX_CONCURRENT_SESSIONS`) and default of 3
- Updated EbiBot example default from 3 → 5

## Test plan
- [x] 3 new tests: explicit param, env var fallback, default value
- [x] All 31 related tests pass
- [x] ruff check + format pass