### PR TITLE
fix: enforce session limit across all Cogs via global semaphore

### DIFF
--- a/claude_discord/cogs/_run_helper.py
+++ b/claude_discord/cogs/_run_helper.py
@@ -15,6 +15,7 @@ Legacy shim:
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import logging
 import re
@@ -29,6 +30,25 @@ from .event_processor import EventProcessor
 from .run_config import RunConfig
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Global session slot limiter
+# ---------------------------------------------------------------------------
+_global_semaphore: asyncio.Semaphore | None = None
+_max_concurrent: int = 3
+
+
+def configure_session_limit(max_concurrent: int) -> None:
+    """Set the process-wide concurrent session limit.
+
+    Called once from ``setup_bridge()`` during startup.  All subsequent calls to
+    ``run_claude_with_config()`` — regardless of which Cog invokes them — will
+    honour the limit.
+    """
+    global _global_semaphore, _max_concurrent  # noqa: PLW0603
+    _max_concurrent = max_concurrent
+    _global_semaphore = asyncio.Semaphore(max_concurrent)
+
 
 # Max characters for tool result display (re-exported for backward compat).
 TOOL_RESULT_MAX_CHARS = 3000
@@ -205,6 +225,17 @@ async def run_claude_with_config(config: RunConfig) -> str | None:
 
     processor = EventProcessor(config)
 
+    # --- Session slot limiter (global semaphore) ---
+    sem = _global_semaphore
+    if sem is not None and sem.locked():
+        with contextlib.suppress(discord.HTTPException):
+            await config.thread.send(
+                f"\u23f3 Waiting for a free session slot\u2026 "
+                f"({_max_concurrent} max sessions running)"
+            )
+    if sem is not None:
+        await sem.acquire()
+
     try:
         async for event in runner.run(config.prompt, session_id=config.session_id):
             if processor.should_drain:
@@ -212,8 +243,6 @@ async def run_claude_with_config(config: RunConfig) -> str | None:
             await processor.process(event)
     except Exception as exc:
         logger.exception("Error running Claude CLI for thread %d", config.thread.id)
-        # Wrap Discord sends in suppress — the connection may already be closed
-        # (e.g. ServerDisconnectedError on bot shutdown), and sending would fail too.
         with contextlib.suppress(Exception):
             detail = f"{type(exc).__name__}: {exc}"
             await config.thread.send(
@@ -224,6 +253,8 @@ async def run_claude_with_config(config: RunConfig) -> str | None:
                 await config.status.set_error()
         return processor.session_id
     finally:
+        if sem is not None:
+            sem.release()
         await processor.finalize()
         if config.registry is not None:
             config.registry.unregister(config.thread.id)

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -129,7 +129,6 @@ class ClaudeChatCog(commands.Cog):
         # Channels where only text responses are shown (no tool embeds, thinking, etc.).
         self._chat_only_channel_ids: set[int] = chat_only_channel_ids or set()
         self._registry = registry or getattr(bot, "session_registry", None)
-        self._semaphore = asyncio.Semaphore(max_concurrent)
         self._active_runners: dict[int, ClaudeRunner] = {}
         # Tracks the asyncio.Task running _run_claude for each thread.
         # Used by _handle_thread_reply to wait for an interrupted session
@@ -851,102 +850,95 @@ class ClaudeChatCog(commands.Cog):
         chat_only: bool = False,
     ) -> None:
         """Execute Claude Code CLI and stream results to the thread."""
-        if self._semaphore.locked():
-            await thread.send(
-                f"\u23f3 Waiting for a free session slot... "
-                f"({self._max_concurrent} max sessions running)"
+        dashboard = self._get_dashboard()
+        description = prompt[:100].replace("\n", " ")
+
+        # Register the current asyncio Task so _handle_thread_reply can
+        # await it after sending SIGINT to the runner.
+        current_task = asyncio.current_task()
+        if current_task is not None:
+            self._active_tasks[thread.id] = current_task
+
+        # Mark thread as PROCESSING when Claude starts
+        if dashboard is not None:
+            await dashboard.set_state(
+                thread.id,
+                ThreadState.PROCESSING,
+                description,
+                thread=thread,
             )
 
-        async with self._semaphore:
-            dashboard = self._get_dashboard()
-            description = prompt[:100].replace("\n", " ")
+        model_override = await self._get_current_model()
+        effective_model = model_override or self.runner.model
 
-            # Register the current asyncio Task so _handle_thread_reply can
-            # await it after sending SIGINT to the runner.
-            current_task = asyncio.current_task()
-            if current_task is not None:
-                self._active_tasks[thread.id] = current_task
+        async def _notify_stall() -> None:
+            threshold = status._stall_hard
+            await thread.send(
+                f"-# \u26a0\ufe0f No activity for {threshold}s — could be extended thinking "
+                "or context compression. Will resume automatically."
+            )
 
-            # Mark thread as PROCESSING when Claude starts
+        status = StatusManager(
+            user_message,
+            on_hard_stall=_notify_stall,
+            model=effective_model,
+        )
+        await status.set_thinking()
+
+        tools_override = await self._get_allowed_tools()
+        effort_override = await self._get_current_effort()
+        from ..claude.runner import _UNSET
+
+        runner = self.runner.clone(
+            thread_id=thread.id,
+            model=model_override,
+            allowed_tools=tools_override if tools_override is not None else _UNSET,
+            fork_session=fork,
+            working_dir=working_dir_override if working_dir_override is not None else _UNSET,
+            effort=effort_override if effort_override is not None else _UNSET,
+        )
+        self._active_runners[thread.id] = runner
+
+        # In chat_only mode, skip the "Session running" message and stop button.
+        stop_view: StopView | None = None
+        if not chat_only:
+            stop_view = StopView(runner)
+            stop_msg = await thread.send("-# ⏺ Session running", view=stop_view)
+            stop_view.set_message(stop_msg)
+
+        try:
+            await run_claude_with_config(
+                RunConfig(
+                    thread=thread,
+                    runner=runner,
+                    repo=self.repo,
+                    prompt=prompt,
+                    session_id=session_id,
+                    status=status,
+                    registry=self._registry,
+                    ask_repo=self._ask_repo,
+                    lounge_repo=self._lounge_repo,
+                    stop_view=stop_view,
+                    worktree_manager=getattr(self.bot, "worktree_manager", None),
+                    images=images,
+                    attach_on_request=wants_file_attachment(prompt),
+                    inbox_repo=getattr(self.bot, "inbox_repo", None),
+                    inbox_dashboard=dashboard,
+                    claude_command=runner.command,
+                    chat_only=chat_only,
+                )
+            )
+        finally:
+            if stop_view is not None:
+                await stop_view.disable()
+            self._active_runners.pop(thread.id, None)
+            self._active_tasks.pop(thread.id, None)
+
+            # Transition to WAITING_INPUT so owner knows a reply is needed
             if dashboard is not None:
                 await dashboard.set_state(
                     thread.id,
-                    ThreadState.PROCESSING,
+                    ThreadState.WAITING_INPUT,
                     description,
                     thread=thread,
                 )
-
-            model_override = await self._get_current_model()
-            effective_model = model_override or self.runner.model
-
-            async def _notify_stall() -> None:
-                threshold = status._stall_hard
-                await thread.send(
-                    f"-# \u26a0\ufe0f No activity for {threshold}s — could be extended thinking "
-                    "or context compression. Will resume automatically."
-                )
-
-            status = StatusManager(
-                user_message,
-                on_hard_stall=_notify_stall,
-                model=effective_model,
-            )
-            await status.set_thinking()
-
-            tools_override = await self._get_allowed_tools()
-            effort_override = await self._get_current_effort()
-            from ..claude.runner import _UNSET
-
-            runner = self.runner.clone(
-                thread_id=thread.id,
-                model=model_override,
-                allowed_tools=tools_override if tools_override is not None else _UNSET,
-                fork_session=fork,
-                working_dir=working_dir_override if working_dir_override is not None else _UNSET,
-                effort=effort_override if effort_override is not None else _UNSET,
-            )
-            self._active_runners[thread.id] = runner
-
-            # In chat_only mode, skip the "Session running" message and stop button.
-            stop_view: StopView | None = None
-            if not chat_only:
-                stop_view = StopView(runner)
-                stop_msg = await thread.send("-# ⏺ Session running", view=stop_view)
-                stop_view.set_message(stop_msg)
-
-            try:
-                await run_claude_with_config(
-                    RunConfig(
-                        thread=thread,
-                        runner=runner,
-                        repo=self.repo,
-                        prompt=prompt,
-                        session_id=session_id,
-                        status=status,
-                        registry=self._registry,
-                        ask_repo=self._ask_repo,
-                        lounge_repo=self._lounge_repo,
-                        stop_view=stop_view,
-                        worktree_manager=getattr(self.bot, "worktree_manager", None),
-                        images=images,
-                        attach_on_request=wants_file_attachment(prompt),
-                        inbox_repo=getattr(self.bot, "inbox_repo", None),
-                        inbox_dashboard=dashboard,
-                        claude_command=runner.command,
-                        chat_only=chat_only,
-                    )
-                )
-            finally:
-                if stop_view is not None:
-                    await stop_view.disable()
-                self._active_runners.pop(thread.id, None)
-                self._active_tasks.pop(thread.id, None)
-
-                # Transition to WAITING_INPUT so owner knows a reply is needed
-                if dashboard is not None:
-                    await dashboard.set_state(
-                        thread.id,
-                        ThreadState.WAITING_INPUT,
-                        description,
-                        thread=thread,
-                    )

--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -210,6 +210,10 @@ async def setup_bridge(
     if max_concurrent != 3:
         logger.info("Max concurrent sessions: %d", max_concurrent)
 
+    from .cogs._run_helper import configure_session_limit
+
+    configure_session_limit(max_concurrent)
+
     # WorktreeManager — attach to bot so cogs can access it via bot.worktree_manager
     if worktree_base_dir is None:
         worktree_base_dir = os.getenv("WORKTREE_BASE_DIR")

--- a/tests/test_run_helper.py
+++ b/tests/test_run_helper.py
@@ -16,10 +16,12 @@ from claude_discord.claude.types import (
     ToolCategory,
     ToolUseEvent,
 )
+from claude_discord.cogs import _run_helper as _rh_module
 from claude_discord.cogs._run_helper import (
     TOOL_RESULT_MAX_CHARS,
     _make_error_embed,
     _truncate_result,
+    configure_session_limit,
     run_claude_in_thread,
     run_claude_with_config,
 )
@@ -1403,3 +1405,201 @@ class TestCompactRerun:
         cloned_runner.interrupt.assert_awaited()
         # The original runner must NOT be interrupted (it has no process).
         original_runner.interrupt.assert_not_awaited()
+
+
+class TestGlobalSessionSemaphore:
+    """Tests for the global session slot limiter in _run_helper."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_semaphore(self):
+        """Save and restore module-level semaphore state around each test."""
+        orig_sem = _rh_module._global_semaphore
+        orig_max = _rh_module._max_concurrent
+        yield
+        _rh_module._global_semaphore = orig_sem
+        _rh_module._max_concurrent = orig_max
+
+    @pytest.fixture
+    def thread(self) -> MagicMock:
+        t = MagicMock(spec=discord.Thread)
+        t.id = 77777
+        t.send = AsyncMock(return_value=MagicMock(spec=discord.Message))
+        return t
+
+    def _simple_events(self, session_id: str = "sess-sem") -> list[StreamEvent]:
+        return [
+            StreamEvent(message_type=MessageType.SYSTEM, session_id=session_id),
+            StreamEvent(
+                message_type=MessageType.RESULT,
+                is_complete=True,
+                session_id=session_id,
+                cost_usd=0.001,
+                duration_ms=100,
+            ),
+        ]
+
+    def _make_async_gen(self, events: list[StreamEvent]):
+        async def gen(*args, **kwargs):
+            for e in events:
+                yield e
+
+        return gen
+
+    def test_configure_session_limit_sets_semaphore(self) -> None:
+        configure_session_limit(5)
+        assert _rh_module._max_concurrent == 5
+        assert isinstance(_rh_module._global_semaphore, asyncio.Semaphore)
+
+    @pytest.mark.asyncio
+    async def test_semaphore_limits_concurrent_sessions(self, thread: MagicMock) -> None:
+        """With max=2, a 3rd session must wait until one finishes."""
+        configure_session_limit(2)
+
+        gate = asyncio.Event()
+        started = asyncio.Event()
+
+        async def slow_gen(*args, **kwargs):
+            started.set()
+            await gate.wait()
+            for e in self._simple_events():
+                yield e
+
+        runner = MagicMock()
+        runner.working_dir = None
+        runner.images = None
+        runner.run = slow_gen
+
+        config = RunConfig(thread=thread, runner=runner, prompt="test")
+
+        # Start 2 sessions that block on `gate`
+        t1 = asyncio.create_task(run_claude_with_config(config))
+        await started.wait()
+        started.clear()
+
+        t2 = asyncio.create_task(run_claude_with_config(config))
+        await started.wait()
+        started.clear()
+
+        # 3rd session should not start immediately
+        t3 = asyncio.create_task(run_claude_with_config(config))
+        await asyncio.sleep(0.05)
+        assert not started.is_set(), "3rd session should be waiting for a semaphore slot"
+
+        # Release all
+        gate.set()
+        await asyncio.gather(t1, t2, t3)
+
+    @pytest.mark.asyncio
+    async def test_waiting_message_sent_when_full(self, thread: MagicMock) -> None:
+        """When all slots are taken, a waiting message should be posted."""
+        configure_session_limit(1)
+
+        gate = asyncio.Event()
+        started = asyncio.Event()
+
+        async def slow_gen(*args, **kwargs):
+            started.set()
+            await gate.wait()
+            for e in self._simple_events():
+                yield e
+
+        runner = MagicMock()
+        runner.working_dir = None
+        runner.images = None
+        runner.run = slow_gen
+
+        config = RunConfig(thread=thread, runner=runner, prompt="test")
+
+        t1 = asyncio.create_task(run_claude_with_config(config))
+        await started.wait()
+
+        # 2nd session should see the semaphore locked and post a waiting message
+        t2 = asyncio.create_task(run_claude_with_config(config))
+        await asyncio.sleep(0.05)
+
+        gate.set()
+        await asyncio.gather(t1, t2)
+
+        waiting_msgs = [
+            c
+            for c in thread.send.call_args_list
+            if c.args and isinstance(c.args[0], str) and "\u23f3" in c.args[0]
+        ]
+        assert len(waiting_msgs) >= 1
+
+    @pytest.mark.asyncio
+    async def test_semaphore_released_on_error(self, thread: MagicMock) -> None:
+        """Semaphore must be released even when runner.run() raises."""
+        configure_session_limit(1)
+
+        async def failing_gen(*args, **kwargs):
+            raise RuntimeError("boom")
+            yield  # noqa: E501
+
+        runner = MagicMock()
+        runner.working_dir = None
+        runner.images = None
+        runner.run = failing_gen
+
+        config = RunConfig(thread=thread, runner=runner, prompt="test")
+        await run_claude_with_config(config)
+
+        sem = _rh_module._global_semaphore
+        assert not sem.locked(), "Semaphore should be released after error"
+
+    @pytest.mark.asyncio
+    async def test_no_semaphore_when_not_configured(self, thread: MagicMock) -> None:
+        """When configure_session_limit was never called, no limiting occurs."""
+        _rh_module._global_semaphore = None
+
+        runner = MagicMock()
+        runner.working_dir = None
+        runner.images = None
+        runner.run = self._make_async_gen(self._simple_events())
+
+        config = RunConfig(thread=thread, runner=runner, prompt="test")
+        result = await run_claude_with_config(config)
+        assert result == "sess-sem"
+
+    @pytest.mark.asyncio
+    async def test_compact_rerun_does_not_deadlock(self, thread: MagicMock) -> None:
+        """With max=1, compact rerun must not deadlock (semaphore released before rerun)."""
+        configure_session_limit(1)
+
+        compact_events = [
+            StreamEvent(message_type=MessageType.SYSTEM, session_id="sess-dl"),
+            StreamEvent(message_type=MessageType.SYSTEM, is_compact=True),
+        ]
+        rerun_events = [
+            StreamEvent(message_type=MessageType.SYSTEM, session_id="sess-dl"),
+            StreamEvent(
+                message_type=MessageType.RESULT,
+                is_complete=True,
+                session_id="sess-dl",
+                cost_usd=0.01,
+                duration_ms=100,
+            ),
+        ]
+
+        call_count = 0
+
+        async def mock_run(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            events = compact_events if call_count == 1 else rerun_events
+            for e in events:
+                yield e
+
+        runner = MagicMock()
+        runner.working_dir = None
+        runner.images = None
+        runner.interrupt = AsyncMock()
+        runner.run = mock_run
+        runner.clone = MagicMock(return_value=runner)
+
+        config = RunConfig(thread=thread, runner=runner, prompt="test", session_id="sess-dl")
+
+        # Must complete within 5 seconds — deadlock would hang forever
+        result = await asyncio.wait_for(run_claude_with_config(config), timeout=5.0)
+        assert result == "sess-dl"
+        assert call_count == 2


### PR DESCRIPTION
## Summary

- **Bug**: `MAX_CONCURRENT_SESSIONS` was only enforced in `ClaudeChatCog._run_claude()`. Sessions started by `SchedulerCog`, `SkillCommandCog`, and `webhook_trigger` called `run_claude_with_config()` directly, bypassing the semaphore entirely — allowing more concurrent sessions than configured.
- **Fix**: Moved the `asyncio.Semaphore` to the shared `run_claude_with_config()` in `_run_helper.py`. All code paths now honour the limit without any changes to individual Cogs (Zero-Config Principle).
- **Design**: Semaphore is released in `finally` before compact/ask recursive reruns, preventing deadlocks with `asyncio.Semaphore` (which is non-reentrant).

## Changes

| File | Change |
|------|--------|
| `cogs/_run_helper.py` | Added `_global_semaphore`, `configure_session_limit()`, acquire/release in `run_claude_with_config()` |
| `cogs/claude_chat.py` | Removed local `self._semaphore` from `__init__` and `_run_claude()` |
| `setup.py` | Calls `configure_session_limit(max_concurrent)` during startup |
| `tests/test_run_helper.py` | Added `TestGlobalSessionSemaphore` (6 tests including deadlock check) |

## Test plan

- [x] `test_configure_session_limit_sets_semaphore` — module state
- [x] `test_semaphore_limits_concurrent_sessions` — max=2, 3rd waits
- [x] `test_waiting_message_sent_when_full` — "⏳ Waiting" message
- [x] `test_semaphore_released_on_error` — no leak on exception
- [x] `test_no_semaphore_when_not_configured` — None = no limit
- [x] `test_compact_rerun_does_not_deadlock` — max=1, compact rerun OK (5s timeout)

Closes #379