### PR TITLE
[docs-sync] Update MAX_CONCURRENT_SESSIONS docs — applies to all CLI paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ In chat-only mode, permission requests and `AskUserQuestion` prompts are **alway
 | `CLAUDE_PERMISSION_MODE` | Permission mode for CLI | `acceptEdits` |
 | `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | Skip all permission checks (use with caution) | `false` |
 | `CLAUDE_WORKING_DIR` | Working directory for Claude | current dir |
-| `MAX_CONCURRENT_SESSIONS` | Max parallel sessions | `3` |
+| `MAX_CONCURRENT_SESSIONS` | Max parallel Claude CLI sessions across all code paths (chat, skills, scheduler, webhooks) | `3` |
 | `SESSION_TIMEOUT_SECONDS` | Session inactivity timeout | `300` |
 | `DISCORD_OWNER_ID` | User ID to @-mention when Claude needs input | (optional) |
 | `COORDINATION_CHANNEL_ID` | Channel ID used as default fallback for AI Lounge channel | (optional) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -189,7 +189,8 @@ claude-code-discord-bridge is a thin UI layer that bridges Discord messages to t
 
 - Each Claude CLI invocation gets its own `ClaudeRunner` instance via `clone()`.
 - The `_active_runners` dict tracks runners by thread_id for kill-on-demand (`/clear`).
-- The semaphore prevents resource exhaustion — excess requests queue with a "waiting" message.
+- The semaphore is held in `_run_helper.run_claude_with_config()` and applies to **all** code paths — chat, skills, scheduler, and webhooks. It is released in the `finally` block before compact/ask reruns to prevent deadlocks on recursive calls.
+- Excess requests queue with a "waiting" message to prevent resource exhaustion.
 - All I/O is async (asyncio subprocess, aiosqlite), so the event loop is never blocked.
 
 ## Extension Points

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -295,7 +295,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `CLAUDE_PERMISSION_MODE` | Modo de permisos del CLI | `acceptEdits` |
 | `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | Omitir todas las comprobaciones de permisos (usar con precaución) | `false` |
 | `CLAUDE_WORKING_DIR` | Directorio de trabajo para Claude | directorio actual |
-| `MAX_CONCURRENT_SESSIONS` | Máximo de sesiones paralelas | `3` |
+| `MAX_CONCURRENT_SESSIONS` | Máximo de sesiones Claude CLI en paralelo (se aplica a todas las rutas: chat, skills, scheduler, webhooks) | `3` |
 | `SESSION_TIMEOUT_SECONDS` | Timeout de inactividad de sesión | `300` |
 | `DISCORD_OWNER_ID` | ID de usuario para @mencionar cuando Claude necesita entrada | (opcional) |
 | `COORDINATION_CHANNEL_ID` | ID del canal utilizado como fallback predeterminado para el canal AI Lounge | (opcional) |

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -295,7 +295,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `CLAUDE_PERMISSION_MODE` | Mode de permission du CLI | `acceptEdits` |
 | `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | Ignorer toutes les vérifications de permissions (à utiliser avec précaution) | `false` |
 | `CLAUDE_WORKING_DIR` | Répertoire de travail pour Claude | répertoire courant |
-| `MAX_CONCURRENT_SESSIONS` | Nombre maximum de sessions parallèles | `3` |
+| `MAX_CONCURRENT_SESSIONS` | Nombre maximum de sessions Claude CLI parallèles (s'applique à tous les chemins : chat, skills, scheduler, webhooks) | `3` |
 | `SESSION_TIMEOUT_SECONDS` | Timeout d'inactivité de session | `300` |
 | `DISCORD_OWNER_ID` | ID utilisateur à @mentionner quand Claude a besoin d'une saisie | (optionnel) |
 | `COORDINATION_CHANNEL_ID` | ID du canal utilisé comme valeur de repli par défaut pour le canal AI Lounge | (optionnel) |

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -526,7 +526,7 @@ CHAT_ONLY_CHANNEL_IDS=444,555
 | `CLAUDE_PERMISSION_MODE` | CLI のパーミッションモード | `auto` |
 | `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | 全パーミッションチェックをスキップ（注意して使用） | `false` |
 | `CLAUDE_WORKING_DIR` | Claude の作業ディレクトリ | カレントディレクトリ |
-| `MAX_CONCURRENT_SESSIONS` | 最大並行セッション数 | `3` |
+| `MAX_CONCURRENT_SESSIONS` | 最大並行 Claude CLI セッション数（チャット・スキル・スケジューラ・Webhook の全パスに適用） | `3` |
 | `SESSION_TIMEOUT_SECONDS` | セッション非アクティブタイムアウト | `300` |
 | `DISCORD_OWNER_ID` | Claude が入力待ちのとき @mention する Discord ユーザー ID | （オプション） |
 | `COORDINATION_CHANNEL_ID` | AI Lounge チャンネルのデフォルトフォールバック用チャンネル ID | （オプション） |

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -295,7 +295,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `CLAUDE_PERMISSION_MODE` | CLI 권한 모드 | `acceptEdits` |
 | `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | 모든 권한 검사 건너뛰기 (주의하여 사용) | `false` |
 | `CLAUDE_WORKING_DIR` | Claude 작업 디렉토리 | 현재 디렉토리 |
-| `MAX_CONCURRENT_SESSIONS` | 최대 동시 세션 수 | `3` |
+| `MAX_CONCURRENT_SESSIONS` | 최대 동시 Claude CLI 세션 수 (채팅·스킬·스케줄러·웹훅 등 모든 경로에 적용) | `3` |
 | `SESSION_TIMEOUT_SECONDS` | 세션 비활성 시간 초과 | `300` |
 | `DISCORD_OWNER_ID` | Claude가 입력이 필요할 때 @멘션할 사용자 ID | (선택) |
 | `COORDINATION_CHANNEL_ID` | AI Lounge 채널의 기본 폴백 채널 ID | (선택) |

--- a/docs/pt-BR/README.md
+++ b/docs/pt-BR/README.md
@@ -295,7 +295,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `CLAUDE_PERMISSION_MODE` | Modo de permissão do CLI | `acceptEdits` |
 | `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | Pular todas as verificações de permissão (use com cuidado) | `false` |
 | `CLAUDE_WORKING_DIR` | Diretório de trabalho para o Claude | diretório atual |
-| `MAX_CONCURRENT_SESSIONS` | Máximo de sessões paralelas | `3` |
+| `MAX_CONCURRENT_SESSIONS` | Máximo de sessões Claude CLI em paralelo (aplica-se a todos os caminhos: chat, skills, scheduler, webhooks) | `3` |
 | `SESSION_TIMEOUT_SECONDS` | Timeout de inatividade da sessão | `300` |
 | `DISCORD_OWNER_ID` | ID do usuário para @mencionar quando o Claude precisa de input | (opcional) |
 | `COORDINATION_CHANNEL_ID` | ID do canal usado como fallback padrão para o canal AI Lounge | (opcional) |

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -312,7 +312,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `CLAUDE_PERMISSION_MODE` | CLI 权限模式 | `acceptEdits` |
 | `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | 跳过所有权限检查（谨慎使用） | `false` |
 | `CLAUDE_WORKING_DIR` | Claude 的工作目录 | 当前目录 |
-| `MAX_CONCURRENT_SESSIONS` | 最大并发会话数 | `3` |
+| `MAX_CONCURRENT_SESSIONS` | 最大并发 Claude CLI 会话数（适用于所有路径：聊天、技能、调度器、Webhook） | `3` |
 | `SESSION_TIMEOUT_SECONDS` | 会话非活动超时 | `300` |
 | `DISCORD_OWNER_ID` | Claude 需要输入时 @提及的用户 ID | （可选） |
 | `COORDINATION_CHANNEL_ID` | AI Lounge 频道的默认回退频道 ID | （可选） |


### PR DESCRIPTION
## Summary

- Updated `MAX_CONCURRENT_SESSIONS` description in README.md (EN) and all 6 translated READMEs (JA, FR, ES, PT-BR, KO, ZH-CN) to clarify the env var now applies to **all** Claude CLI code paths (chat, skills, scheduler, webhooks), not just chat sessions
- Updated `docs/ARCHITECTURE.md` concurrency section to reflect that the semaphore lives in `_run_helper.run_claude_with_config()` and is released before compact/ask reruns to prevent deadlocks

## Background

PR #378 (feat: wire MAX_CONCURRENT_SESSIONS through setup_bridge) and PR #379 (fix: move session semaphore to shared _run_helper layer) changed how the concurrent-session limit works. Previously the semaphore only lived in `ClaudeChatCog`, so SchedulerCog, SkillCommandCog, and webhook_trigger could bypass the limit entirely. The docs described it as "max parallel sessions" without explaining which sessions were covered.

## Test plan

- [ ] Verify `MAX_CONCURRENT_SESSIONS` description is updated in all 7 README files (EN + 6 languages)
- [ ] Verify `docs/ARCHITECTURE.md` concurrency section accurately reflects the `_run_helper` semaphore placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)
