### PR TITLE
[docs-sync] Document global session semaphore scope for MAX_CONCURRENT_SESSIONS

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ If the bot restarts mid-session, interrupted Claude sessions are automatically r
 - **Chat-only mode** — When `CHAT_ONLY_CHANNEL_IDS` includes a channel, only Claude's text responses are shown; tool embeds, thinking blocks, session start/complete embeds, and todo lists are hidden. Permission requests and `AskUserQuestion` are always shown. Ideal for public channels where non-technical users are watching.
 - **Thread = Session** — 1:1 mapping between Discord thread and Claude Code session
 - **Session persistence** — Resume conversations across messages via `--resume`
-- **Concurrent sessions** — Multiple parallel sessions with configurable limit
+- **Concurrent sessions** — Global limit on concurrent Claude CLI invocations shared across all features (chat, `/skill` commands, webhooks, and scheduled tasks all count against the same pool); configurable via `MAX_CONCURRENT_SESSIONS`
 - **Stop without clearing** — `/stop` halts a session while preserving it for resume
 - **Session interrupt** — Sending a new message to an active thread sends SIGINT to the running session and starts fresh with the new instruction; no manual `/stop` needed
 - **Auto-rename threads** — When `THREAD_AUTO_RENAME=true`, each new thread is automatically renamed with a Claude-generated title derived from the first message (background task, never delays session start)
@@ -525,7 +525,7 @@ In chat-only mode, permission requests and `AskUserQuestion` prompts are **alway
 | `CLAUDE_PERMISSION_MODE` | Permission mode for CLI | `acceptEdits` |
 | `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | Skip all permission checks (use with caution) | `false` |
 | `CLAUDE_WORKING_DIR` | Working directory for Claude | current dir |
-| `MAX_CONCURRENT_SESSIONS` | Max parallel sessions | `3` |
+| `MAX_CONCURRENT_SESSIONS` | Max concurrent Claude CLI invocations; the limit is enforced globally across all features (chat sessions, `/skill` commands, webhook tasks, and scheduled tasks all share the same pool). Callers wait and receive a ⏳ message while a slot is occupied. | `3` |
 | `SESSION_TIMEOUT_SECONDS` | Session inactivity timeout | `300` |
 | `DISCORD_OWNER_ID` | User ID to @-mention when Claude needs input | (optional) |
 | `COORDINATION_CHANNEL_ID` | Channel ID used as default fallback for AI Lounge channel | (optional) |

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -147,7 +147,7 @@ Bot の再起動中にセッションが中断された場合、Bot が再起動
 - **チャットのみモード** — `CHAT_ONLY_CHANNEL_IDS` にチャンネルを設定すると、Claude のテキスト応答のみを表示。ツール embed、思考ブロック、セッション開始/完了 embed、Todo リストはすべて非表示。許可リクエストと `AskUserQuestion` は常に表示。技術的な詳細を見せたくないパブリックチャンネルに最適。
 - **Thread = Session** — Discord スレッドと Claude Code セッションの 1:1 マッピング
 - **セッション永続化** — `--resume` で複数メッセージをまたいだ会話を継続
-- **並行セッション** — 設定可能な上限での複数並行セッション
+- **並行セッション** — Claude CLI 呼び出しに対するグローバル上限。チャット・`/skill` コマンド・Webhook・スケジュールタスクがすべて同じプールを共有する。`MAX_CONCURRENT_SESSIONS` で設定可能
 - **削除せず停止** — `/stop` でセッションを保持したまま停止し、リジューム可能
 - **セッション割り込み** — アクティブなスレッドに新しいメッセージを送ると実行中のセッションに SIGINT を送り、新しい指示で即座に再開。手動での `/stop` 不要
 - **スレッド自動リネーム** — `THREAD_AUTO_RENAME=true` のとき、最初のメッセージをもとに Claude が生成した短いタイトルでスレッドを自動リネーム（バックグラウンドタスクのためセッション開始を遅延させない）
@@ -526,7 +526,7 @@ CHAT_ONLY_CHANNEL_IDS=444,555
 | `CLAUDE_PERMISSION_MODE` | CLI のパーミッションモード | `auto` |
 | `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | 全パーミッションチェックをスキップ（注意して使用） | `false` |
 | `CLAUDE_WORKING_DIR` | Claude の作業ディレクトリ | カレントディレクトリ |
-| `MAX_CONCURRENT_SESSIONS` | 最大並行セッション数 | `3` |
+| `MAX_CONCURRENT_SESSIONS` | Claude CLI 呼び出しの最大同時実行数。チャットセッション・`/skill` コマンド・Webhook タスク・スケジュールタスクすべてが同じプールを共有する。スロットが埋まっている間、呼び出し元は待機し ⏳ メッセージを受け取る。 | `3` |
 | `SESSION_TIMEOUT_SECONDS` | セッション非アクティブタイムアウト | `300` |
 | `DISCORD_OWNER_ID` | Claude が入力待ちのとき @mention する Discord ユーザー ID | （オプション） |
 | `COORDINATION_CHANNEL_ID` | AI Lounge チャンネルのデフォルトフォールバック用チャンネル ID | （オプション） |


### PR DESCRIPTION
## Summary

- Update English `README.md` to clarify that `MAX_CONCURRENT_SESSIONS` applies globally to **all** Claude CLI invocations, not just chat sessions
- Update Japanese `docs/ja/README.md` with the same clarification
- Both the feature bullet and the env var table entry now explain that chat sessions, `/skill` commands, webhook tasks, and scheduled tasks all share the same pool

## Background

PR #379 moved the session semaphore from `ClaudeChatCog` to the shared `_run_helper` layer (`configure_session_limit` / `run_claude_with_config`). After this change, the limit is enforced for every Cog that calls `run_claude_with_config()`. The previous documentation ("Max parallel sessions") did not convey this broader scope, and users might have assumed only chat sessions counted.

## Test plan

- [ ] Review English README line 149 (Concurrent sessions bullet)
- [ ] Review English README line 528 (`MAX_CONCURRENT_SESSIONS` table entry)
- [ ] Review Japanese README equivalents for accuracy
- [ ] Confirm no other documentation files need updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)