### PR TITLE
fix: isolate attachment marker per thread

### DIFF
--- a/claude_discord/cogs/_run_helper.py
+++ b/claude_discord/cogs/_run_helper.py
@@ -124,14 +124,17 @@ async def _build_system_context(config: RunConfig) -> str | None:
 
     # File attachment instruction: injected only when the user asked for files.
     if config.attach_on_request:
+        from .event_processor import _attachment_marker_name
+
         wd = config.runner.working_dir or "your current working directory"
+        marker = _attachment_marker_name(config.thread.id)
         parts.append(
             "## File Delivery\n"
             "The user wants you to send specific files to Discord.\n"
             "After creating the file(s) to deliver, use your Bash tool to append "
             "each file's ABSOLUTE path (one path per line, UTF-8) to:\n"
-            f"  {wd}/.ccdb-attachments\n"
-            f"Example: `echo /absolute/path/to/file >> {wd}/.ccdb-attachments`\n"
+            f"  {wd}/{marker}\n"
+            f"Example: `echo /absolute/path/to/file >> {wd}/{marker}`\n"
             "The bot will attach those files to Discord when this session ends.\n"
             "Only include files the user explicitly asked to receive — "
             "not everything you create."

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -40,15 +40,21 @@ from .run_config import RunConfig
 
 logger = logging.getLogger(__name__)
 
-# Marker file written by Claude when the user asks to receive specific files.
-_ATTACHMENT_MARKER = ".ccdb-attachments"
+# Marker file prefix. The full name includes the thread ID to prevent
+# cross-contamination when multiple sessions share the same working_dir.
+_ATTACHMENT_MARKER_PREFIX = ".ccdb-attachments"
+
+
+def _attachment_marker_name(thread_id: int) -> str:
+    return f"{_ATTACHMENT_MARKER_PREFIX}-{thread_id}"
 
 
 async def _send_attachment_requests(
     thread: object,
     working_dir: str | None,
+    thread_id: int,
 ) -> None:
-    """Read .ccdb-attachments and send listed files to Discord.
+    """Read .ccdb-attachments-{thread_id} and send listed files to Discord.
 
     If the marker file does not exist or is empty, this is a no-op.
     The marker file is deleted after sending so it does not persist into
@@ -58,7 +64,7 @@ async def _send_attachment_requests(
     if not working_dir:
         logger.debug("_send_attachment_requests: no working_dir, skipping")
         return
-    marker = Path(working_dir) / _ATTACHMENT_MARKER
+    marker = Path(working_dir) / _attachment_marker_name(thread_id)
     if not marker.exists():
         logger.debug("_send_attachment_requests: %s not found, skipping", marker)
         return
@@ -425,10 +431,11 @@ class EventProcessor:
                     last_assistant_url = last_sent.jump_url
                 last_assistant_text = response_text
 
-            # Send files listed in the .ccdb-attachments marker file, if present.
+            # Send files listed in the .ccdb-attachments-{thread_id} marker file.
             await _send_attachment_requests(
                 self._config.thread,
                 self._config.runner.working_dir,
+                self._config.thread.id,
             )
 
             # In chat_only mode, skip session_complete embed, statusline, and inbox.

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -795,7 +795,10 @@ class TestTodoWrite:
 
 
 class TestCcdbAttachmentsDelivery:
-    """_on_complete() reads .ccdb-attachments and sends listed files."""
+    """_on_complete() reads .ccdb-attachments-{thread_id} and sends listed files."""
+
+    def _marker_name(self, thread: MagicMock) -> str:
+        return f".ccdb-attachments-{thread.id}"
 
     @pytest.mark.asyncio
     async def test_sends_files_listed_in_marker(
@@ -806,7 +809,7 @@ class TestCcdbAttachmentsDelivery:
         runner.working_dir = str(tmp_path)
         f = tmp_path / "out.py"
         f.write_text("result = 42", encoding="utf-8")
-        (tmp_path / ".ccdb-attachments").write_text(str(f) + "\n", encoding="utf-8")
+        (tmp_path / self._marker_name(thread)).write_text(str(f) + "\n", encoding="utf-8")
 
         config = _make_config(thread, runner)
         p = EventProcessor(config)
@@ -828,7 +831,7 @@ class TestCcdbAttachmentsDelivery:
         runner.working_dir = str(tmp_path)
         f = tmp_path / "out.py"
         f.write_text("x = 1", encoding="utf-8")
-        marker = tmp_path / ".ccdb-attachments"
+        marker = tmp_path / self._marker_name(thread)
         marker.write_text(str(f) + "\n", encoding="utf-8")
 
         config = _make_config(thread, runner)
@@ -841,7 +844,7 @@ class TestCcdbAttachmentsDelivery:
 
     @pytest.mark.asyncio
     async def test_no_marker_no_send(self, thread: MagicMock, runner: MagicMock, tmp_path) -> None:
-        """When .ccdb-attachments is absent nothing is sent."""
+        """When the marker is absent nothing is sent."""
         from unittest.mock import patch
 
         runner.working_dir = str(tmp_path)
@@ -864,7 +867,7 @@ class TestCcdbAttachmentsDelivery:
         runner.working_dir = str(tmp_path)
         f = tmp_path / "out.py"
         f.write_text("x = 1", encoding="utf-8")
-        (tmp_path / ".ccdb-attachments").write_text(str(f) + "\n", encoding="utf-8")
+        (tmp_path / self._marker_name(thread)).write_text(str(f) + "\n", encoding="utf-8")
 
         config = _make_config(thread, runner)
         p = EventProcessor(config)
@@ -881,14 +884,14 @@ class TestCcdbAttachmentsDelivery:
     async def test_logging_when_marker_found(
         self, thread: MagicMock, runner: MagicMock, tmp_path, caplog
     ) -> None:
-        """INFO log is emitted when .ccdb-attachments is found and processed."""
+        """INFO log is emitted when marker is found and processed."""
         import logging
         from unittest.mock import patch
 
         runner.working_dir = str(tmp_path)
         f = tmp_path / "out.py"
         f.write_text("x = 1", encoding="utf-8")
-        (tmp_path / ".ccdb-attachments").write_text(str(f) + "\n", encoding="utf-8")
+        (tmp_path / self._marker_name(thread)).write_text(str(f) + "\n", encoding="utf-8")
 
         config = _make_config(thread, runner)
         p = EventProcessor(config)
@@ -905,7 +908,7 @@ class TestCcdbAttachmentsDelivery:
     async def test_logging_when_marker_absent(
         self, thread: MagicMock, runner: MagicMock, tmp_path, caplog
     ) -> None:
-        """DEBUG log is emitted when .ccdb-attachments is absent."""
+        """DEBUG log is emitted when marker is absent."""
         import logging
         from unittest.mock import patch
 
@@ -925,7 +928,7 @@ class TestCcdbAttachmentsDelivery:
     async def test_relative_path_resolved_against_working_dir(
         self, thread: MagicMock, runner: MagicMock, tmp_path
     ) -> None:
-        """Relative paths in .ccdb-attachments are resolved against working_dir.
+        """Relative paths are resolved against working_dir.
 
         Claude may write a bare filename instead of an absolute path.
         The bot must resolve it against the session working directory so the
@@ -936,8 +939,7 @@ class TestCcdbAttachmentsDelivery:
         runner.working_dir = str(tmp_path)
         f = tmp_path / "out.py"
         f.write_text("result = 42", encoding="utf-8")
-        # Write only the bare filename (relative path) — no directory prefix
-        (tmp_path / ".ccdb-attachments").write_text("out.py\n", encoding="utf-8")
+        (tmp_path / self._marker_name(thread)).write_text("out.py\n", encoding="utf-8")
 
         config = _make_config(thread, runner)
         p = EventProcessor(config)
@@ -948,8 +950,59 @@ class TestCcdbAttachmentsDelivery:
         ) as mock_send:
             await p.process(_make_result_event(session_id="s1"))
 
-        # "out.py" must be resolved to tmp_path / "out.py"
         mock_send.assert_called_once_with(thread, [str(f)], str(tmp_path))
+
+
+class TestAttachmentThreadIsolation:
+    """Marker file must be per-thread to prevent cross-contamination."""
+
+    @pytest.mark.asyncio
+    async def test_marker_uses_thread_id_in_filename(
+        self, thread: MagicMock, runner: MagicMock, tmp_path
+    ) -> None:
+        """The marker file must include the thread ID to isolate concurrent sessions."""
+        from unittest.mock import patch
+
+        runner.working_dir = str(tmp_path)
+        f = tmp_path / "out.py"
+        f.write_text("result = 42", encoding="utf-8")
+        # Write to the thread-specific marker (thread.id = 12345 from conftest)
+        (tmp_path / f".ccdb-attachments-{thread.id}").write_text(str(f) + "\n", encoding="utf-8")
+
+        config = _make_config(thread, runner)
+        p = EventProcessor(config)
+
+        with patch(
+            "claude_discord.cogs.event_processor.send_files",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            await p.process(_make_result_event(session_id="s1"))
+
+        mock_send.assert_called_once_with(thread, [str(f)], str(tmp_path))
+
+    @pytest.mark.asyncio
+    async def test_other_thread_marker_not_read(
+        self, thread: MagicMock, runner: MagicMock, tmp_path
+    ) -> None:
+        """A marker for thread 99999 must NOT be read by thread 12345."""
+        from unittest.mock import patch
+
+        runner.working_dir = str(tmp_path)
+        f = tmp_path / "secret.py"
+        f.write_text("secret = True", encoding="utf-8")
+        # Write to a DIFFERENT thread's marker
+        (tmp_path / ".ccdb-attachments-99999").write_text(str(f) + "\n", encoding="utf-8")
+
+        config = _make_config(thread, runner)
+        p = EventProcessor(config)
+
+        with patch(
+            "claude_discord.cogs.event_processor.send_files",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            await p.process(_make_result_event(session_id="s1"))
+
+        mock_send.assert_not_called()
 
 
 class TestToolUseCount:


### PR DESCRIPTION
## Summary

- `.ccdb-attachments` マーカーファイルが全セッションで共有されていたため、複数スレッド同時稼働時に別スレッドの添付ファイルが混入するバグを修正
- マーカーファイル名を `.ccdb-attachments-{thread_id}` に変更し、スレッドごとに分離
- Claude へのシステムプロンプト（File Delivery 指示）も同様にスレッドID入りのマーカー名を使用

## Changed files

| File | Change |
|------|--------|
| `claude_discord/cogs/event_processor.py` | `_ATTACHMENT_MARKER` 定数 → `_attachment_marker_name(thread_id)` 関数に変更。`_send_attachment_requests` に `thread_id` パラメータ追加 |
| `claude_discord/cogs/_run_helper.py` | `_build_system_context` でスレッドID付きマーカー名をClaudeに指示 |
| `tests/test_event_processor.py` | スレッド分離テスト2件追加。既存テストを新マーカー名に更新 |

## Root cause

`_send_attachment_requests()` は `working_dir/.ccdb-attachments` を読んでいたが、`working_dir` は通常 `/home/ebi` で全セッション共通。複数スレッドが同時にファイル添付を使うと、同じマーカーファイルに書き込み/読み取りが発生し、別スレッドの添付ファイルが混入していた。

## Test plan

- [x] `TestAttachmentThreadIsolation::test_marker_uses_thread_id_in_filename` — 自スレッドのマーカーだけ読む
- [x] `TestAttachmentThreadIsolation::test_other_thread_marker_not_read` — 他スレッドのマーカーは無視
- [x] 既存の `TestCcdbAttachmentsDelivery` 全7テスト通過
- [x] ruff check + ruff format 通過