### PR TITLE
fix: strip whitespace from session content to prevent empty thread names

### DIFF
--- a/claude_discord/session_sync.py
+++ b/claude_discord/session_sync.py
@@ -169,7 +169,7 @@ def _parse_session_file(path: Path, *, max_lines: int = 20) -> CliSession | None
                 if data.get("isMeta"):
                     continue
 
-                content = _extract_content_text(data.get("message", {}).get("content", ""))
+                content = _extract_content_text(data.get("message", {}).get("content", "")).strip()
                 if not content:
                     continue
 
@@ -265,7 +265,7 @@ def extract_recent_messages(
                 if data.get("isMeta"):
                     continue
 
-                content = _extract_content_text(data.get("message", {}).get("content", ""))
+                content = _extract_content_text(data.get("message", {}).get("content", "")).strip()
                 if not content:
                     continue
 

--- a/tests/test_session_sync.py
+++ b/tests/test_session_sync.py
@@ -210,6 +210,34 @@ class TestScanCliSessions:
         sessions = scan_cli_sessions(str(tmp_path))
         assert sessions[0].summary == "Actual user prompt"
 
+    def test_scan_strips_whitespace_only_content(self, tmp_path):
+        """Whitespace-only content should be treated as empty and skipped."""
+        session_id = "aaa11111-1234-5678-9abc-def012345678"
+        _write_session_jsonl(
+            tmp_path / f"{session_id}.jsonl",
+            session_id,
+            [
+                {
+                    "type": "user",
+                    "isMeta": False,
+                    "sessionId": session_id,
+                    "cwd": "/home",
+                    "timestamp": "2026-02-19T10:00:00.000Z",
+                    "message": {"role": "user", "content": "   \n\t  "},
+                },
+                {
+                    "type": "user",
+                    "isMeta": False,
+                    "sessionId": session_id,
+                    "cwd": "/home",
+                    "timestamp": "2026-02-19T10:00:01.000Z",
+                    "message": {"role": "user", "content": "Real prompt"},
+                },
+            ],
+        )
+        sessions = scan_cli_sessions(str(tmp_path))
+        assert sessions[0].summary == "Real prompt"
+
     def test_scan_truncates_long_summary(self, tmp_path):
         session_id = "222bbbbb-1234-5678-9abc-def012345678"
         long_text = "x" * 200


### PR DESCRIPTION
## Summary

- Strip whitespace from extracted session content in `session_sync.py` to prevent empty thread names
- `/sync-sessions` was crashing with `HTTPException: 400 Bad Request — Must be between 1 and 100 in length` for whitespace-only content

## Context

Cherry-picked from the bug fix portion of PR #356 (closed due to mixed scope / security concerns). Only the one-line `.strip()` fix is included — the `pre_check_command` feature was not ported.

## Test plan

- [x] `test_scan_strips_whitespace_only_content` — whitespace-only content skipped, real prompt used as summary
- [x] All existing `TestScanCliSessions` tests pass
- [x] ruff check + format clean