### PR TITLE
feat: add ContextLinksCog for project-aware resource links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ build/
 # Database
 data/
 
+# User-specific config
+context_links.json
+
 # IDE
 .vscode/
 .idea/

--- a/claude_discord/__init__.py
+++ b/claude_discord/__init__.py
@@ -14,6 +14,7 @@ from .claude.types import MessageType, StreamEvent, ToolCategory, ToolUseEvent
 from .cog_loader import load_custom_cogs
 from .cogs.auto_upgrade import AutoUpgradeCog, UpgradeConfig
 from .cogs.claude_chat import ClaudeChatCog
+from .cogs.context_links import ContextLinksCog
 from .cogs.event_processor import EventProcessor
 from .cogs.run_config import RunConfig
 from .cogs.scheduler import SchedulerCog
@@ -41,6 +42,7 @@ __all__ = [
     # Core
     "ClaudeRunner",
     "ClaudeChatCog",
+    "ContextLinksCog",
     "RunConfig",
     "EventProcessor",
     # Concurrency

--- a/claude_discord/cogs/__init__.py
+++ b/claude_discord/cogs/__init__.py
@@ -2,6 +2,7 @@
 
 from .auto_upgrade import AutoUpgradeCog
 from .claude_chat import ClaudeChatCog
+from .context_links import ContextLinksCog
 from .event_processor import EventProcessor
 from .run_config import RunConfig
 from .scheduler import SchedulerCog
@@ -12,6 +13,7 @@ from .webhook_trigger import WebhookTriggerCog
 __all__ = [
     "AutoUpgradeCog",
     "ClaudeChatCog",
+    "ContextLinksCog",
     "EventProcessor",
     "RunConfig",
     "SchedulerCog",

--- a/claude_discord/cogs/context_links.py
+++ b/claude_discord/cogs/context_links.py
@@ -1,0 +1,132 @@
+"""ContextLinksCog — post project-relevant links when a thread is created.
+
+Reads an optional JSON config that maps project keywords to external
+resource links (Obsidian notes, GitHub repos, documentation, etc.).
+When a new Discord thread matches a configured project, the Cog posts
+a compact embed with the relevant links.
+
+Zero-config: if no config file exists, the Cog does nothing.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
+
+import discord
+from discord.ext import commands
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+COLOR_CONTEXT = 0x95A5A6
+
+
+def build_obsidian_uri(vault: str, file_path: str) -> str:
+    """Build an ``obsidian://open`` URI from a vault name and file path."""
+    return f"obsidian://open?vault={quote(vault, safe='')}&file={quote(file_path, safe='')}"
+
+
+def load_config(path: str) -> dict[str, Any] | None:
+    """Load and validate a context-links JSON config file.
+
+    Returns ``None`` when the file is missing, malformed, or has no projects.
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+    if not isinstance(data, dict):
+        return None
+    projects = data.get("projects")
+    if not isinstance(projects, list) or len(projects) == 0:
+        return None
+    return data
+
+
+def match_project(
+    thread_name: str,
+    config: dict[str, Any],
+) -> list[dict[str, str]] | None:
+    """Return resolved links for the first project whose keywords match *thread_name*.
+
+    Matching is case-insensitive substring search.  Returns ``None`` when no
+    project matches.  Each returned link dict includes a ``_resolved`` key with
+    the final URL string.
+    """
+    if not thread_name:
+        return None
+
+    name_lower = thread_name.lower()
+    vault = config.get("obsidian_vault", "")
+
+    for project in config.get("projects", []):
+        keywords: list[str] = project.get("match", [])
+        if any(kw.lower() in name_lower for kw in keywords):
+            resolved: list[dict[str, str]] = []
+            for link in project.get("links", []):
+                entry = dict(link)
+                if "obsidian" in link:
+                    entry["_resolved"] = build_obsidian_uri(vault, link["obsidian"])
+                elif "url" in link:
+                    entry["_resolved"] = link["url"]
+                else:
+                    continue
+                resolved.append(entry)
+            return resolved if resolved else None
+    return None
+
+
+def build_context_embed(links: list[dict[str, str]]) -> discord.Embed:
+    """Build a compact Discord embed listing context links."""
+    lines: list[str] = []
+    for link in links:
+        label = link.get("label", "Link")
+        url = link.get("_resolved", "")
+        if url.startswith(("http://", "https://")):
+            lines.append(f"{label} — {url}")
+        else:
+            lines.append(f"{label} — `{url}`")
+
+    return discord.Embed(
+        title="\U0001f4ce Context Links",
+        description="\n".join(lines),
+        color=COLOR_CONTEXT,
+    )
+
+
+class ContextLinksCog(commands.Cog):
+    """Posts project-relevant resource links when a matching thread is created."""
+
+    def __init__(
+        self,
+        bot: commands.Bot,
+        *,
+        config_path: str | None = None,
+        channel_ids: set[int] | None = None,
+    ) -> None:
+        self.bot = bot
+        self._channel_ids = channel_ids
+        self._config = load_config(config_path or "")
+
+    @commands.Cog.listener()
+    async def on_thread_create(self, thread: discord.Thread) -> None:
+        if self._config is None:
+            return
+        if self._channel_ids is not None and thread.parent_id not in self._channel_ids:
+            return
+
+        links = match_project(thread.name, self._config)
+        if links is None:
+            return
+
+        embed = build_context_embed(links)
+        with contextlib.suppress(discord.HTTPException):
+            await thread.send(embed=embed)

--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -83,6 +83,7 @@ async def setup_bridge(
     enable_thread_inbox: bool = False,
     auto_rename_threads: bool | None = None,
     monitor_all_channels: bool | None = None,
+    context_links_config: str | None = None,
 ) -> BridgeComponents:
     """Initialize and register all ccdb Cogs in one call.
 
@@ -132,11 +133,16 @@ async def setup_bridge(
                              title derived from the first user message.  Runs as a
                              background task so it never delays the session start.
                              Defaults to THREAD_AUTO_RENAME env var (off by default).
+        context_links_config: Path to a JSON config that maps project keywords to
+                              external resource links (Obsidian notes, GitHub repos,
+                              etc.).  Defaults to CONTEXT_LINKS_CONFIG env var, or
+                              ``context_links.json`` in the working directory.
 
     Returns:
         BridgeComponents with references to initialized repositories.
     """
     from .cogs.claude_chat import ClaudeChatCog
+    from .cogs.context_links import ContextLinksCog
     from .cogs.scheduler import SchedulerCog
     from .cogs.session_manage import SessionManageCog
     from .cogs.skill_command import SkillCommandCog
@@ -300,6 +306,18 @@ async def setup_bridge(
         scheduler_cog = SchedulerCog(bot, runner, repo=task_repo, session_repo=session_repo)
         await bot.add_cog(scheduler_cog)
         logger.info("Registered SchedulerCog")
+
+    # --- ContextLinksCog (optional — CONTEXT_LINKS_CONFIG or context_links.json) ---
+    if context_links_config is None:
+        context_links_config = os.getenv("CONTEXT_LINKS_CONFIG", "context_links.json")
+    context_links_cog = ContextLinksCog(
+        bot,
+        config_path=context_links_config,
+        channel_ids=_all_channel_ids or None,
+    )
+    await bot.add_cog(context_links_cog)
+    if context_links_cog._config is not None:
+        logger.info("Registered ContextLinksCog (config=%s)", context_links_config)
 
     components = BridgeComponents(
         session_repo=session_repo,

--- a/examples/context_links.json
+++ b/examples/context_links.json
@@ -1,0 +1,35 @@
+{
+  "obsidian_vault": "MyVault",
+  "projects": [
+    {
+      "match": ["my-project", "project alpha"],
+      "links": [
+        {
+          "label": "📓 Project Notes",
+          "obsidian": "Projects/my-project/status.md"
+        },
+        {
+          "label": "🔗 GitHub",
+          "url": "https://github.com/example/my-project"
+        }
+      ]
+    },
+    {
+      "match": ["website", "landing page"],
+      "links": [
+        {
+          "label": "📓 Design Doc",
+          "obsidian": "Projects/website/design.md"
+        },
+        {
+          "label": "🌐 Staging",
+          "url": "https://staging.example.com"
+        },
+        {
+          "label": "📊 Analytics",
+          "url": "https://analytics.example.com/dashboard"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_context_links.py
+++ b/tests/test_context_links.py
@@ -1,0 +1,323 @@
+"""Tests for ContextLinksCog — project-aware context link posting."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from claude_discord.cogs.context_links import (
+    ContextLinksCog,
+    build_context_embed,
+    build_obsidian_uri,
+    load_config,
+    match_project,
+)
+
+# ---------------------------------------------------------------------------
+# Pure function tests: build_obsidian_uri
+# ---------------------------------------------------------------------------
+
+
+class TestBuildObsidianUri:
+    def test_basic_ascii_path(self) -> None:
+        uri = build_obsidian_uri("MyVault", "Projects/ccdb/status.md")
+        assert uri == "obsidian://open?vault=MyVault&file=Projects%2Fccdb%2Fstatus.md"
+
+    def test_unicode_path(self) -> None:
+        uri = build_obsidian_uri("obsidian", "02_Contexts/個人開発/ccdb/status.md")
+        assert "vault=obsidian" in uri
+        assert "file=" in uri
+        assert "obsidian://open?" in uri
+
+    def test_empty_vault_name(self) -> None:
+        uri = build_obsidian_uri("", "path.md")
+        assert "vault=" in uri
+
+    def test_path_with_spaces(self) -> None:
+        uri = build_obsidian_uri("vault", "My Notes/project a/status.md")
+        assert "My%20Notes" in uri or "My+Notes" in uri
+
+
+# ---------------------------------------------------------------------------
+# Pure function tests: load_config
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfig:
+    def test_valid_config(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "context_links.json"
+        config_data = {
+            "obsidian_vault": "obsidian",
+            "projects": [
+                {
+                    "match": ["ccdb", "discord bot"],
+                    "links": [
+                        {"label": "Status", "obsidian": "Projects/ccdb/status.md"},
+                        {"label": "GitHub", "url": "https://github.com/example/ccdb"},
+                    ],
+                }
+            ],
+        }
+        config_file.write_text(json.dumps(config_data))
+        result = load_config(str(config_file))
+        assert result is not None
+        assert result["obsidian_vault"] == "obsidian"
+        assert len(result["projects"]) == 1
+
+    def test_missing_file_returns_none(self) -> None:
+        result = load_config("/nonexistent/path/context_links.json")
+        assert result is None
+
+    def test_invalid_json_returns_none(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "bad.json"
+        config_file.write_text("not valid json {{{")
+        result = load_config(str(config_file))
+        assert result is None
+
+    def test_missing_projects_key_returns_none(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "empty.json"
+        config_file.write_text(json.dumps({"obsidian_vault": "test"}))
+        result = load_config(str(config_file))
+        assert result is None
+
+    def test_empty_projects_returns_none(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "empty_projects.json"
+        config_file.write_text(json.dumps({"projects": []}))
+        result = load_config(str(config_file))
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Pure function tests: match_project
+# ---------------------------------------------------------------------------
+
+
+class TestMatchProject:
+    @pytest.fixture()
+    def sample_config(self) -> dict[str, Any]:
+        return {
+            "obsidian_vault": "obsidian",
+            "projects": [
+                {
+                    "match": ["ccdb", "discord bot"],
+                    "links": [
+                        {"label": "Status", "obsidian": "Projects/ccdb/status.md"},
+                        {"label": "GitHub", "url": "https://github.com/example/ccdb"},
+                    ],
+                },
+                {
+                    "match": ["NearJam"],
+                    "links": [
+                        {"label": "Notes", "obsidian": "Projects/NearJam/status.md"},
+                    ],
+                },
+            ],
+        }
+
+    def test_exact_match(self, sample_config: dict[str, Any]) -> None:
+        result = match_project("ccdb", sample_config)
+        assert result is not None
+        assert len(result) == 2
+
+    def test_case_insensitive(self, sample_config: dict[str, Any]) -> None:
+        result = match_project("CCDB", sample_config)
+        assert result is not None
+
+    def test_substring_match(self, sample_config: dict[str, Any]) -> None:
+        result = match_project("ccdb改修の相談", sample_config)
+        assert result is not None
+
+    def test_no_match(self, sample_config: dict[str, Any]) -> None:
+        result = match_project("unrelated topic", sample_config)
+        assert result is None
+
+    def test_second_project_match(self, sample_config: dict[str, Any]) -> None:
+        result = match_project("NearJamのバグ修正", sample_config)
+        assert result is not None
+        assert len(result) == 1
+
+    def test_empty_thread_name(self, sample_config: dict[str, Any]) -> None:
+        result = match_project("", sample_config)
+        assert result is None
+
+    def test_first_match_wins(self, sample_config: dict[str, Any]) -> None:
+        result = match_project("ccdb and NearJam", sample_config)
+        assert result is not None
+        assert len(result) == 2  # ccdb project has 2 links
+
+
+# ---------------------------------------------------------------------------
+# Pure function tests: build_context_embed
+# ---------------------------------------------------------------------------
+
+
+class TestBuildContextEmbed:
+    def test_https_links_are_markdown(self) -> None:
+        links = [
+            {
+                "label": "GitHub",
+                "url": "https://github.com/example/ccdb",
+                "_resolved": "https://github.com/example/ccdb",
+            },
+        ]
+        embed = build_context_embed(links)
+        assert isinstance(embed, discord.Embed)
+        assert "GitHub" in (embed.description or "")
+        assert "https://github.com/example/ccdb" in (embed.description or "")
+
+    def test_obsidian_links_as_code(self) -> None:
+        links = [
+            {
+                "label": "Status",
+                "obsidian": "path.md",
+                "_resolved": "obsidian://open?vault=v&file=path.md",
+            },
+        ]
+        embed = build_context_embed(links)
+        desc = embed.description or ""
+        assert "`obsidian://open" in desc
+
+    def test_mixed_links(self) -> None:
+        links = [
+            {
+                "label": "Status",
+                "obsidian": "path.md",
+                "_resolved": "obsidian://open?vault=v&file=path.md",
+            },
+            {
+                "label": "GitHub",
+                "url": "https://github.com/test",
+                "_resolved": "https://github.com/test",
+            },
+        ]
+        embed = build_context_embed(links)
+        desc = embed.description or ""
+        assert "Status" in desc
+        assert "GitHub" in desc
+
+    def test_embed_title(self) -> None:
+        links = [
+            {"label": "Test", "url": "https://example.com", "_resolved": "https://example.com"},
+        ]
+        embed = build_context_embed(links)
+        assert embed.title is not None
+
+
+# ---------------------------------------------------------------------------
+# Cog integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestContextLinksCog:
+    @pytest.fixture()
+    def config_file(self, tmp_path: Path) -> str:
+        config_data = {
+            "obsidian_vault": "obsidian",
+            "projects": [
+                {
+                    "match": ["ccdb", "discord bot"],
+                    "links": [
+                        {"label": "Status", "obsidian": "Projects/ccdb/status.md"},
+                        {"label": "GitHub", "url": "https://github.com/example/ccdb"},
+                    ],
+                },
+            ],
+        }
+        config_file = tmp_path / "context_links.json"
+        config_file.write_text(json.dumps(config_data))
+        return str(config_file)
+
+    @pytest.fixture()
+    def bot(self) -> MagicMock:
+        return MagicMock(spec=discord.ext.commands.Bot)
+
+    def test_init_with_valid_config(self, bot: MagicMock, config_file: str) -> None:
+        cog = ContextLinksCog(bot, config_path=config_file)
+        assert cog._config is not None
+
+    def test_init_with_no_config(self, bot: MagicMock) -> None:
+        cog = ContextLinksCog(bot, config_path="/nonexistent/path.json")
+        assert cog._config is None
+
+    def test_init_with_channel_ids(self, bot: MagicMock, config_file: str) -> None:
+        cog = ContextLinksCog(bot, config_path=config_file, channel_ids={123, 456})
+        assert cog._channel_ids == {123, 456}
+
+    @pytest.mark.asyncio()
+    async def test_on_thread_create_matching(self, bot: MagicMock, config_file: str) -> None:
+        cog = ContextLinksCog(bot, config_path=config_file, channel_ids={100})
+        thread = AsyncMock(spec=discord.Thread)
+        thread.name = "ccdbのバグ修正"
+        thread.parent_id = 100
+        thread.send = AsyncMock()
+
+        await cog.on_thread_create(thread)
+
+        thread.send.assert_called_once()
+        call_kwargs = thread.send.call_args
+        assert "embed" in call_kwargs.kwargs
+
+    @pytest.mark.asyncio()
+    async def test_on_thread_create_no_match(self, bot: MagicMock, config_file: str) -> None:
+        cog = ContextLinksCog(bot, config_path=config_file, channel_ids={100})
+        thread = AsyncMock(spec=discord.Thread)
+        thread.name = "unrelated topic"
+        thread.parent_id = 100
+        thread.send = AsyncMock()
+
+        await cog.on_thread_create(thread)
+
+        thread.send.assert_not_called()
+
+    @pytest.mark.asyncio()
+    async def test_on_thread_create_wrong_channel(self, bot: MagicMock, config_file: str) -> None:
+        cog = ContextLinksCog(bot, config_path=config_file, channel_ids={100})
+        thread = AsyncMock(spec=discord.Thread)
+        thread.name = "ccdb"
+        thread.parent_id = 999
+        thread.send = AsyncMock()
+
+        await cog.on_thread_create(thread)
+
+        thread.send.assert_not_called()
+
+    @pytest.mark.asyncio()
+    async def test_on_thread_create_no_channel_filter(
+        self, bot: MagicMock, config_file: str
+    ) -> None:
+        cog = ContextLinksCog(bot, config_path=config_file, channel_ids=None)
+        thread = AsyncMock(spec=discord.Thread)
+        thread.name = "ccdb"
+        thread.parent_id = 999
+        thread.send = AsyncMock()
+
+        await cog.on_thread_create(thread)
+
+        thread.send.assert_called_once()
+
+    @pytest.mark.asyncio()
+    async def test_on_thread_create_no_config(self, bot: MagicMock) -> None:
+        cog = ContextLinksCog(bot, config_path="/nonexistent.json")
+        thread = AsyncMock(spec=discord.Thread)
+        thread.name = "ccdb"
+        thread.parent_id = 100
+        thread.send = AsyncMock()
+
+        await cog.on_thread_create(thread)
+
+        thread.send.assert_not_called()
+
+    @pytest.mark.asyncio()
+    async def test_discord_error_suppressed(self, bot: MagicMock, config_file: str) -> None:
+        cog = ContextLinksCog(bot, config_path=config_file, channel_ids=None)
+        thread = AsyncMock(spec=discord.Thread)
+        thread.name = "ccdb"
+        thread.parent_id = 100
+        thread.send = AsyncMock(side_effect=discord.HTTPException(MagicMock(), "error"))
+
+        await cog.on_thread_create(thread)


### PR DESCRIPTION
## Summary
- New `ContextLinksCog` that automatically posts an embed with relevant links (Obsidian notes, GitHub repos, documentation, etc.) when a Discord thread name matches a configured project keyword
- Zero-config compatible: does nothing unless `context_links.json` exists (env var `CONTEXT_LINKS_CONFIG` or CWD default)
- Supports any URI scheme — `https://` links shown as clickable, `obsidian://` and other custom schemes shown as copyable inline code

## Config format

```json
{
  "obsidian_vault": "MyVault",
  "projects": [
    {
      "match": ["my-project", "project alpha"],
      "links": [
        { "label": "📓 Notes", "obsidian": "Projects/my-project/status.md" },
        { "label": "🔗 GitHub", "url": "https://github.com/example/my-project" }
      ]
    }
  ]
}
```

## How it works
1. `on_thread_create` event fires when a new thread is created
2. Thread name is matched (case-insensitive substring) against project keywords
3. First match wins → compact embed posted with resolved links
4. `obsidian` shorthand auto-generates `obsidian://open?vault=...&file=...` URI

## Files changed
- `claude_discord/cogs/context_links.py` — new Cog (120 lines)
- `claude_discord/setup.py` — registers Cog in `setup_bridge()`
- `claude_discord/cogs/__init__.py` / `claude_discord/__init__.py` — exports
- `tests/test_context_links.py` — 29 tests (pure functions + Cog integration)
- `examples/context_links.json` — sample config

## Test plan
- [x] 29 unit tests covering:
  - `build_obsidian_uri()` — ASCII, Unicode, spaces, empty vault
  - `load_config()` — valid, missing, invalid JSON, missing/empty projects
  - `match_project()` — exact, case-insensitive, substring, no match, first-match-wins
  - `build_context_embed()` — HTTPS links, obsidian links, mixed, title
  - `ContextLinksCog` — matching/no-match/wrong-channel/no-filter/no-config/error-suppressed
- [x] Existing `test_setup.py` + `test_architecture.py` pass (48 tests total)
- [ ] Manual test: deploy with dev-on, create thread with matching keyword, verify embed appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)