### PR TITLE
feat: clickable obsidian links via HTTP redirect + buttons

### DIFF
--- a/claude_discord/cogs/context_links.py
+++ b/claude_discord/cogs/context_links.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import os
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
 
@@ -30,6 +31,16 @@ COLOR_CONTEXT = 0x95A5A6
 def build_obsidian_uri(vault: str, file_path: str) -> str:
     """Build an ``obsidian://open`` URI from a vault name and file path."""
     return f"obsidian://open?vault={quote(vault, safe='')}&file={quote(file_path, safe='')}"
+
+
+def build_obsidian_redirect_url(base_url: str, vault: str, file_path: str) -> str:
+    """Build an HTTPS redirect URL that 302s to ``obsidian://open``.
+
+    Requires the ccdb API server (or any HTTP server) to serve a redirect
+    at ``/open/obsidian``.
+    """
+    base = base_url.rstrip("/")
+    return f"{base}/open/obsidian?vault={quote(vault, safe='')}&file={quote(file_path, safe='')}"
 
 
 def load_config(path: str) -> dict[str, Any] | None:
@@ -54,12 +65,17 @@ def load_config(path: str) -> dict[str, Any] | None:
 def match_project(
     thread_name: str,
     config: dict[str, Any],
+    *,
+    public_api_url: str | None = None,
 ) -> list[dict[str, str]] | None:
     """Return resolved links for the first project whose keywords match *thread_name*.
 
     Matching is case-insensitive substring search.  Returns ``None`` when no
     project matches.  Each returned link dict includes a ``_resolved`` key with
     the final URL string.
+
+    When *public_api_url* is set, obsidian links resolve to an HTTPS redirect
+    URL (clickable in Discord buttons).  Otherwise they use ``obsidian://``.
     """
     if not thread_name:
         return None
@@ -74,7 +90,12 @@ def match_project(
             for link in project.get("links", []):
                 entry = dict(link)
                 if "obsidian" in link:
-                    entry["_resolved"] = build_obsidian_uri(vault, link["obsidian"])
+                    if public_api_url:
+                        entry["_resolved"] = build_obsidian_redirect_url(
+                            public_api_url, vault, link["obsidian"]
+                        )
+                    else:
+                        entry["_resolved"] = build_obsidian_uri(vault, link["obsidian"])
                 elif "url" in link:
                     entry["_resolved"] = link["url"]
                 else:
@@ -85,18 +106,22 @@ def match_project(
 
 
 def build_context_embed(links: list[dict[str, str]]) -> discord.Embed:
-    """Build a Discord embed with obsidian links as clickable markdown links.
+    """Build a Discord embed for links that cannot be rendered as buttons.
 
-    HTTPS links are excluded from the embed — they go into ``build_link_view``
-    as proper Discord link buttons instead.
+    Links with HTTPS ``_resolved`` URLs are excluded — they go into
+    ``build_link_view`` as proper Discord link buttons instead.  Only
+    non-HTTPS links (e.g. ``obsidian://``) appear here as readable text.
     """
     lines: list[str] = []
     for link in links:
-        if "obsidian" not in link:
+        url = link.get("_resolved", "")
+        if url.startswith(("http://", "https://")):
             continue
         label = link.get("label", "Link")
-        uri = link.get("_resolved", "")
-        lines.append(f"[{label}]({uri})")
+        if "obsidian" in link:
+            lines.append(f"{label} — `{link['obsidian']}`")
+        else:
+            lines.append(f"{label} — `{url}`")
 
     return discord.Embed(
         title="\U0001f4ce Context Links",
@@ -131,10 +156,12 @@ class ContextLinksCog(commands.Cog):
         *,
         config_path: str | None = None,
         channel_ids: set[int] | None = None,
+        public_api_url: str | None = None,
     ) -> None:
         self.bot = bot
         self._channel_ids = channel_ids
         self._config = load_config(config_path or "")
+        self._public_api_url = public_api_url or os.getenv("CCDB_PUBLIC_API_URL")
 
     @commands.Cog.listener()
     async def on_thread_create(self, thread: discord.Thread) -> None:
@@ -150,7 +177,7 @@ class ContextLinksCog(commands.Cog):
         if self._channel_ids is not None and thread.parent_id not in self._channel_ids:
             return
 
-        links = match_project(thread.name, self._config)
+        links = match_project(thread.name, self._config, public_api_url=self._public_api_url)
         if links is None:
             return
 

--- a/claude_discord/cogs/context_links.py
+++ b/claude_discord/cogs/context_links.py
@@ -85,21 +85,41 @@ def match_project(
 
 
 def build_context_embed(links: list[dict[str, str]]) -> discord.Embed:
-    """Build a compact Discord embed listing context links."""
+    """Build a Discord embed with obsidian links as clickable markdown links.
+
+    HTTPS links are excluded from the embed — they go into ``build_link_view``
+    as proper Discord link buttons instead.
+    """
     lines: list[str] = []
     for link in links:
+        if "obsidian" not in link:
+            continue
         label = link.get("label", "Link")
-        url = link.get("_resolved", "")
-        if url.startswith(("http://", "https://")):
-            lines.append(f"{label} — {url}")
-        else:
-            lines.append(f"{label} — `{url}`")
+        uri = link.get("_resolved", "")
+        lines.append(f"[{label}]({uri})")
 
     return discord.Embed(
         title="\U0001f4ce Context Links",
-        description="\n".join(lines),
+        description="\n".join(lines) or None,
         color=COLOR_CONTEXT,
     )
+
+
+def build_link_view(links: list[dict[str, str]]) -> discord.ui.View | None:
+    """Build a ``discord.ui.View`` with link buttons for HTTPS URLs.
+
+    Returns ``None`` when there are no HTTPS links.
+    """
+    view = discord.ui.View()
+    count = 0
+    for link in links:
+        url = link.get("_resolved", "")
+        if not url.startswith(("http://", "https://")):
+            continue
+        label = link.get("label", "Link")
+        view.add_item(discord.ui.Button(style=discord.ButtonStyle.link, label=label, url=url))
+        count += 1
+    return view if count > 0 else None
 
 
 class ContextLinksCog(commands.Cog):
@@ -118,6 +138,13 @@ class ContextLinksCog(commands.Cog):
 
     @commands.Cog.listener()
     async def on_thread_create(self, thread: discord.Thread) -> None:
+        logger.debug(
+            "on_thread_create fired: name=%r parent_id=%s channel_ids=%s config=%s",
+            thread.name,
+            thread.parent_id,
+            self._channel_ids,
+            self._config is not None,
+        )
         if self._config is None:
             return
         if self._channel_ids is not None and thread.parent_id not in self._channel_ids:
@@ -127,6 +154,8 @@ class ContextLinksCog(commands.Cog):
         if links is None:
             return
 
+        logger.info("Context links matched for thread %r: %d link(s)", thread.name, len(links))
         embed = build_context_embed(links)
+        view = build_link_view(links)
         with contextlib.suppress(discord.HTTPException):
-            await thread.send(embed=embed)
+            await thread.send(embed=embed, view=view or discord.utils.MISSING)

--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -100,7 +100,7 @@ class ApiServer:
 
     def _setup_routes(self) -> None:
         self.app.router.add_get("/api/health", self.health)
-        self.app.router.add_get("/open/obsidian", self.open_obsidian)
+        self.app.router.add_get("/obsidian", self.open_obsidian)
         self.app.router.add_post("/api/notify", self.notify)
         self.app.router.add_post("/api/schedule", self.schedule)
         self.app.router.add_get("/api/scheduled", self.list_scheduled)
@@ -125,7 +125,7 @@ class ApiServer:
         handler: Callable[[web.Request], Awaitable[web.StreamResponse]],
     ) -> web.StreamResponse:
         """Bearer token authentication middleware."""
-        if request.path == "/api/health" or request.path.startswith("/open/"):
+        if request.path == "/api/health" or request.path == "/obsidian":
             return await handler(request)
 
         auth_header = request.headers.get("Authorization", "")

--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -100,6 +100,7 @@ class ApiServer:
 
     def _setup_routes(self) -> None:
         self.app.router.add_get("/api/health", self.health)
+        self.app.router.add_get("/open/obsidian", self.open_obsidian)
         self.app.router.add_post("/api/notify", self.notify)
         self.app.router.add_post("/api/schedule", self.schedule)
         self.app.router.add_get("/api/scheduled", self.list_scheduled)
@@ -124,7 +125,7 @@ class ApiServer:
         handler: Callable[[web.Request], Awaitable[web.StreamResponse]],
     ) -> web.StreamResponse:
         """Bearer token authentication middleware."""
-        if request.path == "/api/health":
+        if request.path == "/api/health" or request.path.startswith("/open/"):
             return await handler(request)
 
         auth_header = request.headers.get("Authorization", "")
@@ -158,6 +159,23 @@ class ApiServer:
                 "timestamp": datetime.now().isoformat(),
             }
         )
+
+    async def open_obsidian(self, request: web.Request) -> web.Response:
+        """GET /open/obsidian — redirect to ``obsidian://open`` URI.
+
+        No authentication required.  Used by Discord link buttons to open
+        Obsidian notes on the user's machine.
+        """
+        from urllib.parse import quote
+
+        vault = request.rel_url.query.get("vault", "")
+        file_path = request.rel_url.query.get("file", "")
+        if not vault or not file_path:
+            return web.json_response(
+                {"error": "vault and file query parameters are required"}, status=400
+            )
+        target = f"obsidian://open?vault={quote(vault, safe='')}&file={quote(file_path, safe='')}"
+        raise web.HTTPFound(location=target)
 
     async def notify(self, request: web.Request) -> web.Response:
         """POST /api/notify — send an immediate notification."""

--- a/tests/test_context_links.py
+++ b/tests/test_context_links.py
@@ -14,6 +14,7 @@ from claude_discord.cogs.context_links import (
     ContextLinksCog,
     build_context_embed,
     build_link_view,
+    build_obsidian_redirect_url,
     build_obsidian_uri,
     load_config,
     match_project,
@@ -42,6 +43,31 @@ class TestBuildObsidianUri:
     def test_path_with_spaces(self) -> None:
         uri = build_obsidian_uri("vault", "My Notes/project a/status.md")
         assert "My%20Notes" in uri or "My+Notes" in uri
+
+
+# ---------------------------------------------------------------------------
+# Pure function tests: build_obsidian_redirect_url
+# ---------------------------------------------------------------------------
+
+
+class TestBuildObsidianRedirectUrl:
+    def test_basic(self) -> None:
+        url = build_obsidian_redirect_url(
+            "https://example.com", "MyVault", "Projects/ccdb/status.md"
+        )
+        assert url.startswith("https://example.com/open/obsidian?")
+        assert "vault=MyVault" in url
+        assert "file=Projects%2Fccdb%2Fstatus.md" in url
+
+    def test_strips_trailing_slash(self) -> None:
+        url = build_obsidian_redirect_url("https://example.com/", "vault", "path.md")
+        assert "example.com/open/obsidian?" in url
+        assert "//open" not in url
+
+    def test_unicode_path(self) -> None:
+        url = build_obsidian_redirect_url("https://example.com", "obsidian", "個人開発/status.md")
+        assert url.startswith("https://example.com/open/obsidian?")
+        assert "vault=obsidian" in url
 
 
 # ---------------------------------------------------------------------------
@@ -151,6 +177,20 @@ class TestMatchProject:
         assert result is not None
         assert len(result) == 2  # ccdb project has 2 links
 
+    def test_with_public_api_url(self, sample_config: dict[str, Any]) -> None:
+        result = match_project("ccdb", sample_config, public_api_url="https://example.com")
+        assert result is not None
+        obsidian_link = next(lnk for lnk in result if "obsidian" in lnk)
+        assert obsidian_link["_resolved"].startswith("https://example.com/open/obsidian?")
+
+    def test_without_public_api_url_uses_obsidian_scheme(
+        self, sample_config: dict[str, Any]
+    ) -> None:
+        result = match_project("ccdb", sample_config)
+        assert result is not None
+        obsidian_link = next(lnk for lnk in result if "obsidian" in lnk)
+        assert obsidian_link["_resolved"].startswith("obsidian://open?")
+
 
 # ---------------------------------------------------------------------------
 # Pure function tests: build_context_embed
@@ -158,7 +198,7 @@ class TestMatchProject:
 
 
 class TestBuildContextEmbed:
-    def test_obsidian_links_as_markdown_links(self) -> None:
+    def test_obsidian_links_as_text_when_no_redirect(self) -> None:
         links = [
             {
                 "label": "Status",
@@ -168,8 +208,19 @@ class TestBuildContextEmbed:
         ]
         embed = build_context_embed(links)
         desc = embed.description or ""
-        assert "[Status](" in desc
-        assert "obsidian://open" in desc
+        assert "Status" in desc
+        assert "`Projects/ccdb/status.md`" in desc
+
+    def test_obsidian_excluded_when_redirect_url(self) -> None:
+        links = [
+            {
+                "label": "Status",
+                "obsidian": "path.md",
+                "_resolved": "https://example.com/open/obsidian?vault=v&file=path.md",
+            },
+        ]
+        embed = build_context_embed(links)
+        assert embed.description is None or embed.description == ""
 
     def test_https_links_excluded_from_embed(self) -> None:
         links = [
@@ -182,7 +233,7 @@ class TestBuildContextEmbed:
         embed = build_context_embed(links)
         assert embed.description is None or embed.description == ""
 
-    def test_mixed_links_only_obsidian_in_embed(self) -> None:
+    def test_mixed_links_only_non_https_in_embed(self) -> None:
         links = [
             {
                 "label": "Status",
@@ -211,9 +262,14 @@ class TestBuildContextEmbed:
         embed = build_context_embed(links)
         assert embed.title is not None
 
-    def test_no_embed_when_only_https(self) -> None:
+    def test_all_links_are_https_empty_embed(self) -> None:
         links = [
             {"label": "Test", "url": "https://example.com", "_resolved": "https://example.com"},
+            {
+                "label": "Status",
+                "obsidian": "path.md",
+                "_resolved": "https://redirect.com/open/obsidian?vault=v&file=path.md",
+            },
         ]
         embed = build_context_embed(links)
         assert embed.description is None or embed.description == ""
@@ -285,6 +341,40 @@ class TestBuildLinkView:
                 "label": "Docs",
                 "url": "https://docs.example.com",
                 "_resolved": "https://docs.example.com",
+            },
+        ]
+        view = build_link_view(links)
+        assert view is not None
+        buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+        assert len(buttons) == 2
+
+    @pytest.mark.asyncio()
+    async def test_obsidian_redirect_becomes_button(self) -> None:
+        links = [
+            {
+                "label": "Status",
+                "obsidian": "path.md",
+                "_resolved": "https://example.com/open/obsidian?vault=v&file=path.md",
+            },
+        ]
+        view = build_link_view(links)
+        assert view is not None
+        buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+        assert len(buttons) == 1
+        assert buttons[0].label == "Status"
+
+    @pytest.mark.asyncio()
+    async def test_all_links_as_buttons_with_redirect(self) -> None:
+        links = [
+            {
+                "label": "Status",
+                "obsidian": "path.md",
+                "_resolved": "https://example.com/open/obsidian?vault=v&file=path.md",
+            },
+            {
+                "label": "GitHub",
+                "url": "https://github.com/test",
+                "_resolved": "https://github.com/test",
             },
         ]
         view = build_link_view(links)

--- a/tests/test_context_links.py
+++ b/tests/test_context_links.py
@@ -13,6 +13,7 @@ import pytest
 from claude_discord.cogs.context_links import (
     ContextLinksCog,
     build_context_embed,
+    build_link_view,
     build_obsidian_uri,
     load_config,
     match_project,
@@ -157,7 +158,20 @@ class TestMatchProject:
 
 
 class TestBuildContextEmbed:
-    def test_https_links_are_markdown(self) -> None:
+    def test_obsidian_links_as_markdown_links(self) -> None:
+        links = [
+            {
+                "label": "Status",
+                "obsidian": "Projects/ccdb/status.md",
+                "_resolved": "obsidian://open?vault=v&file=Projects%2Fccdb%2Fstatus.md",
+            },
+        ]
+        embed = build_context_embed(links)
+        desc = embed.description or ""
+        assert "[Status](" in desc
+        assert "obsidian://open" in desc
+
+    def test_https_links_excluded_from_embed(self) -> None:
         links = [
             {
                 "label": "GitHub",
@@ -166,23 +180,9 @@ class TestBuildContextEmbed:
             },
         ]
         embed = build_context_embed(links)
-        assert isinstance(embed, discord.Embed)
-        assert "GitHub" in (embed.description or "")
-        assert "https://github.com/example/ccdb" in (embed.description or "")
+        assert embed.description is None or embed.description == ""
 
-    def test_obsidian_links_as_code(self) -> None:
-        links = [
-            {
-                "label": "Status",
-                "obsidian": "path.md",
-                "_resolved": "obsidian://open?vault=v&file=path.md",
-            },
-        ]
-        embed = build_context_embed(links)
-        desc = embed.description or ""
-        assert "`obsidian://open" in desc
-
-    def test_mixed_links(self) -> None:
+    def test_mixed_links_only_obsidian_in_embed(self) -> None:
         links = [
             {
                 "label": "Status",
@@ -198,14 +198,99 @@ class TestBuildContextEmbed:
         embed = build_context_embed(links)
         desc = embed.description or ""
         assert "Status" in desc
-        assert "GitHub" in desc
+        assert "GitHub" not in desc
 
     def test_embed_title(self) -> None:
+        links = [
+            {
+                "label": "Status",
+                "obsidian": "path.md",
+                "_resolved": "obsidian://open?vault=v&file=path.md",
+            },
+        ]
+        embed = build_context_embed(links)
+        assert embed.title is not None
+
+    def test_no_embed_when_only_https(self) -> None:
         links = [
             {"label": "Test", "url": "https://example.com", "_resolved": "https://example.com"},
         ]
         embed = build_context_embed(links)
-        assert embed.title is not None
+        assert embed.description is None or embed.description == ""
+
+
+# ---------------------------------------------------------------------------
+# Pure function tests: build_link_view
+# ---------------------------------------------------------------------------
+
+
+class TestBuildLinkView:
+    @pytest.mark.asyncio()
+    async def test_https_links_become_buttons(self) -> None:
+        links = [
+            {
+                "label": "GitHub",
+                "url": "https://github.com/example/ccdb",
+                "_resolved": "https://github.com/example/ccdb",
+            },
+        ]
+        view = build_link_view(links)
+        assert view is not None
+        buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+        assert len(buttons) == 1
+        assert buttons[0].url == "https://github.com/example/ccdb"
+        assert buttons[0].label == "GitHub"
+
+    @pytest.mark.asyncio()
+    async def test_obsidian_links_excluded(self) -> None:
+        links = [
+            {
+                "label": "Status",
+                "obsidian": "path.md",
+                "_resolved": "obsidian://open?vault=v&file=path.md",
+            },
+        ]
+        view = build_link_view(links)
+        assert view is None
+
+    @pytest.mark.asyncio()
+    async def test_mixed_links_only_https_buttons(self) -> None:
+        links = [
+            {
+                "label": "Status",
+                "obsidian": "path.md",
+                "_resolved": "obsidian://open?vault=v&file=path.md",
+            },
+            {
+                "label": "GitHub",
+                "url": "https://github.com/test",
+                "_resolved": "https://github.com/test",
+            },
+        ]
+        view = build_link_view(links)
+        assert view is not None
+        buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+        assert len(buttons) == 1
+        assert buttons[0].label == "GitHub"
+
+    @pytest.mark.asyncio()
+    async def test_multiple_https_buttons(self) -> None:
+        links = [
+            {
+                "label": "GitHub",
+                "url": "https://github.com/test",
+                "_resolved": "https://github.com/test",
+            },
+            {
+                "label": "Docs",
+                "url": "https://docs.example.com",
+                "_resolved": "https://docs.example.com",
+            },
+        ]
+        view = build_link_view(links)
+        assert view is not None
+        buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+        assert len(buttons) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -261,6 +346,7 @@ class TestContextLinksCog:
         thread.send.assert_called_once()
         call_kwargs = thread.send.call_args
         assert "embed" in call_kwargs.kwargs
+        assert "view" in call_kwargs.kwargs
 
     @pytest.mark.asyncio()
     async def test_on_thread_create_no_match(self, bot: MagicMock, config_file: str) -> None:


### PR DESCRIPTION
## Summary
- Obsidian links in Context Links Cog now open Obsidian via clickable Discord buttons
- Added `GET /obsidian` redirect endpoint to API server (302 → `obsidian://open`)
- `CCDB_PUBLIC_API_URL` env var enables HTTPS redirect URLs for all obsidian links
- Without the env var, obsidian links fall back to text display (backward compatible)

## How it works
1. Discord button → `https://public-url/open/obsidian?vault=x&file=y`
2. Tailscale Funnel (or any reverse proxy) strips prefix, forwards to API server
3. API server returns 302 redirect → `obsidian://open?vault=x&file=y`
4. Browser follows redirect → Obsidian opens

## Test plan
- [x] 42 unit tests pass (pure functions + Cog integration)
- [x] Verified redirect works via Tailscale Funnel
- [x] Confirmed Obsidian opens from Discord button click

🤖 Generated with [Claude Code](https://claude.com/claude-code)