### PR TITLE
feat: enhance /resume with search, orphaned filter, and working_dir tracking

### DIFF
--- a/claude_code_core/session_repo.py
+++ b/claude_code_core/session_repo.py
@@ -119,6 +119,57 @@ class SessionRepository:
             rows = await cursor.fetchall()
             return [SessionRecord(**dict(row)) for row in rows]
 
+    async def search(
+        self,
+        query: str | None = None,
+        *,
+        origin: str | None = None,
+        limit: int = 50,
+        thread_ids: list[int] | None = None,
+        exclude_thread_ids: list[int] | None = None,
+    ) -> list[SessionRecord]:
+        """Search sessions by keyword with optional filters.
+
+        Args:
+            query: Search term matched against summary and working_dir (LIKE).
+                   Empty string or None returns all sessions.
+            origin: Filter by origin ('discord', 'cli'). None returns all.
+            limit: Maximum number of records to return.
+            thread_ids: If set, only return sessions with these thread IDs.
+            exclude_thread_ids: If set, exclude sessions with these thread IDs.
+        """
+        conditions: list[str] = []
+        params: list[object] = []
+
+        if query:
+            conditions.append("(summary LIKE ? OR working_dir LIKE ?)")
+            like = f"%{query}%"
+            params.extend([like, like])
+
+        if origin:
+            conditions.append("origin = ?")
+            params.append(origin)
+
+        if thread_ids is not None:
+            placeholders = ",".join("?" for _ in thread_ids)
+            conditions.append(f"thread_id IN ({placeholders})")
+            params.extend(thread_ids)
+
+        if exclude_thread_ids:
+            placeholders = ",".join("?" for _ in exclude_thread_ids)
+            conditions.append(f"thread_id NOT IN ({placeholders})")
+            params.extend(exclude_thread_ids)
+
+        where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
+        sql = f"SELECT * FROM sessions{where} ORDER BY last_used_at DESC LIMIT ?"  # noqa: S608
+        params.append(limit)
+
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(sql, params)
+            rows = await cursor.fetchall()
+            return [SessionRecord(**dict(row)) for row in rows]
+
     async def delete(self, thread_id: int) -> bool:
         """Delete a session mapping. Returns True if a row was deleted."""
         async with aiosqlite.connect(self.db_path) as db:

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -262,15 +262,21 @@ class EventProcessor:
 
         self._state.session_id = event.session_id
         if self._config.repo:
+            wd = getattr(self._config.runner, "working_dir", None)
             # For new sessions, save the prompt as the summary so /resume can display it.
             # For resumed sessions (config.session_id is set), pass no summary to keep
             # the existing one via COALESCE in the SQL query.
             if self._config.session_id:
-                await self._config.repo.save(self._config.thread.id, self._state.session_id)
+                await self._config.repo.save(
+                    self._config.thread.id, self._state.session_id, working_dir=wd
+                )
             else:
                 summary = self._config.prompt[:100] if self._config.prompt else None
                 await self._config.repo.save(
-                    self._config.thread.id, self._state.session_id, summary=summary
+                    self._config.thread.id,
+                    self._state.session_id,
+                    working_dir=wd,
+                    summary=summary,
                 )
 
         # Guard: post session_start_embed only once (Claude can emit multiple SYSTEM events).

--- a/claude_discord/cogs/session_manage.py
+++ b/claude_discord/cogs/session_manage.py
@@ -530,22 +530,73 @@ class SessionManageCog(commands.Cog):
         name="resume",
         description="Resume a previous session in a new thread",
     )
-    async def resume_session(self, interaction: discord.Interaction) -> None:
+    @app_commands.describe(
+        query="Search sessions by keyword (matches summary and working directory)",
+        filter="Filter sessions: all (default), orphaned (deleted threads only)",
+    )
+    @app_commands.choices(
+        filter=[
+            app_commands.Choice(name="All sessions", value="all"),
+            app_commands.Choice(name="Orphaned (deleted threads)", value="orphaned"),
+        ]
+    )
+    async def resume_session(
+        self,
+        interaction: discord.Interaction,
+        query: str | None = None,
+        filter: str | None = None,  # noqa: A002
+    ) -> None:
         """Show a select menu of recent sessions to resume."""
-        records = await self.repo.list_all(limit=25)
-        if not records:
-            await interaction.response.send_message(
-                "No sessions found. Start a conversation first!",
+        if query or filter:
+            await interaction.response.defer(ephemeral=True)
+            exclude_ids: list[int] | None = None
+
+            if filter == "orphaned":
+                all_records = await self.repo.list_all(limit=200)
+                live_ids: list[int] = []
+                for rec in all_records:
+                    try:
+                        ch = await self.bot.fetch_channel(rec.thread_id)
+                        if ch is not None:
+                            live_ids.append(rec.thread_id)
+                    except Exception:  # noqa: BLE001
+                        pass
+                exclude_ids = live_ids if live_ids else None
+
+            records = await self.repo.search(
+                query=query or "",
+                limit=25,
+                exclude_thread_ids=exclude_ids,
+            )
+
+            if not records:
+                await interaction.followup.send(
+                    "No sessions found matching your search.",
+                    ephemeral=True,
+                )
+                return
+
+            view = ResumeSelectView(records=records, bot=self.bot)
+            await interaction.followup.send(
+                f"\U0001f504 **Resume** — {len(records)} session(s) found:",
+                view=view,
                 ephemeral=True,
             )
-            return
+        else:
+            records = await self.repo.list_all(limit=25)
+            if not records:
+                await interaction.response.send_message(
+                    "No sessions found. Start a conversation first!",
+                    ephemeral=True,
+                )
+                return
 
-        view = ResumeSelectView(records=records, bot=self.bot)
-        await interaction.response.send_message(
-            "\U0001f504 **Resume** — select a session to continue:",
-            view=view,
-            ephemeral=True,
-        )
+            view = ResumeSelectView(records=records, bot=self.bot)
+            await interaction.response.send_message(
+                "\U0001f504 **Resume** — select a session to continue:",
+                view=view,
+                ephemeral=True,
+            )
 
     @app_commands.command(
         name="resume-info",

--- a/claude_discord/discord_ui/views.py
+++ b/claude_discord/discord_ui/views.py
@@ -325,8 +325,7 @@ class ResumeSelectView(discord.ui.View):
     def _build_description(record: SessionRecord) -> str | None:
         parts: list[str] = []
         if record.working_dir:
-            dir_short = record.working_dir.rsplit("/", 1)[-1]
-            parts.append(dir_short)
+            parts.append(record.working_dir)
         parts.append(record.last_used_at[:16])
         desc = " | ".join(parts)
         return desc[:100] if desc else None

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -111,7 +111,9 @@ class TestOnSystem:
 
         await p.process(StreamEvent(message_type=MessageType.SYSTEM, session_id="s1"))
 
-        repo.save.assert_called_once_with(thread.id, "s1", summary="test prompt")
+        repo.save.assert_called_once_with(
+            thread.id, "s1", working_dir=runner.working_dir, summary="test prompt"
+        )
 
     @pytest.mark.asyncio
     async def test_saves_to_repo_without_summary_for_resumed_session(
@@ -125,7 +127,9 @@ class TestOnSystem:
 
         await p.process(StreamEvent(message_type=MessageType.SYSTEM, session_id="existing-sess"))
 
-        repo.save.assert_called_once_with(thread.id, "existing-sess")
+        repo.save.assert_called_once_with(
+            thread.id, "existing-sess", working_dir=runner.working_dir
+        )
 
     @pytest.mark.asyncio
     async def test_summary_truncated_to_100_chars(
@@ -140,7 +144,9 @@ class TestOnSystem:
 
         await p.process(StreamEvent(message_type=MessageType.SYSTEM, session_id="s1"))
 
-        repo.save.assert_called_once_with(thread.id, "s1", summary="x" * 100)
+        repo.save.assert_called_once_with(
+            thread.id, "s1", working_dir=runner.working_dir, summary="x" * 100
+        )
 
     @pytest.mark.asyncio
     async def test_sends_start_embed_for_new_session(

--- a/tests/test_resume_command.py
+++ b/tests/test_resume_command.py
@@ -16,6 +16,7 @@ def _make_record(
     summary: str | None = "Fix login bug",
     working_dir: str | None = "/home/user/project",
     model: str | None = "sonnet",
+    last_used_at: str = "2026-02-19 11:00:00",
 ) -> SessionRecord:
     return SessionRecord(
         thread_id=thread_id,
@@ -25,7 +26,7 @@ def _make_record(
         origin=origin,
         summary=summary,
         created_at="2026-02-19 10:00:00",
-        last_used_at="2026-02-19 11:00:00",
+        last_used_at=last_used_at,
     )
 
 
@@ -162,3 +163,89 @@ class TestResumeSelectView:
         view = ResumeSelectView(records=records, bot=MagicMock())
         selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
         assert "myproject" in (selects[0].options[0].description or "")
+
+    async def test_description_contains_full_working_dir(self):
+        """ResumeSelectView description shows full working_dir path."""
+        from claude_discord.discord_ui.views import ResumeSelectView
+
+        records = [
+            _make_record(
+                session_id="aaa-111",
+                summary="Task",
+                working_dir="/home/user/myproject",
+            ),
+        ]
+        view = ResumeSelectView(records=records, bot=MagicMock())
+        selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+        desc = selects[0].options[0].description or ""
+        assert "/home/user/myproject" in desc
+
+    async def test_description_contains_last_used_date(self):
+        """ResumeSelectView description shows last_used_at date."""
+        from claude_discord.discord_ui.views import ResumeSelectView
+
+        records = [
+            _make_record(
+                session_id="aaa-111",
+                summary="Task",
+                last_used_at="2026-04-25 14:30:00",
+            ),
+        ]
+        view = ResumeSelectView(records=records, bot=MagicMock())
+        selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+        desc = selects[0].options[0].description or ""
+        assert "2026-04-25" in desc
+
+
+class TestResumeCommandWithQuery:
+    """Tests for /resume with query parameter."""
+
+    async def test_resume_with_query_calls_search(self):
+        """When query is provided, /resume uses repo.search() instead of list_all()."""
+        cog = _make_cog()
+        records = [
+            _make_record(thread_id=100, session_id="aaa-111", summary="Fix login bug"),
+        ]
+        cog.repo.search = AsyncMock(return_value=records)
+        interaction = _make_interaction()
+        await cog.resume_session.callback(cog, interaction, query="login")
+        cog.repo.search.assert_called_once()
+        call_kwargs = cog.repo.search.call_args.kwargs
+        assert call_kwargs["query"] == "login"
+
+    async def test_resume_without_query_calls_list_all(self):
+        """When no query is provided, /resume uses list_all() as before."""
+        cog = _make_cog()
+        cog.repo.list_all = AsyncMock(return_value=[])
+        interaction = _make_interaction()
+        await cog.resume_session.callback(cog, interaction)
+        cog.repo.list_all.assert_called_once()
+
+    async def test_resume_query_no_results(self):
+        """When query matches nothing, shows ephemeral followup message."""
+        cog = _make_cog()
+        cog.repo.search = AsyncMock(return_value=[])
+        interaction = _make_interaction()
+        await cog.resume_session.callback(cog, interaction, query="nonexistent")
+        interaction.response.defer.assert_called_once()
+        call_args = interaction.followup.send.call_args
+        assert call_args.kwargs.get("ephemeral") is True
+
+    async def test_resume_with_orphaned_filter(self):
+        """When filter='orphaned', passes exclude_thread_ids of live threads."""
+        cog = _make_cog()
+        records = [_make_record(thread_id=999)]
+        cog.repo.search = AsyncMock(return_value=records)
+
+        # Mock bot.fetch_channel to simulate thread lookup
+        async def fake_fetch(tid):
+            if tid == 100:
+                return MagicMock(spec=discord.Thread)
+            raise discord.NotFound(MagicMock(), "Not found")
+
+        cog.bot.fetch_channel = AsyncMock(side_effect=fake_fetch)
+
+        interaction = _make_interaction()
+        await cog.resume_session.callback(cog, interaction, filter="orphaned")
+        # Should have called search with exclude_thread_ids
+        cog.repo.search.assert_called_once()

--- a/tests/test_session_search.py
+++ b/tests/test_session_search.py
@@ -1,0 +1,150 @@
+"""Tests for SessionRepository.search() — keyword search and date filtering."""
+
+from __future__ import annotations
+
+import pytest
+
+from claude_discord.database.models import init_db
+from claude_discord.database.repository import SessionRepository
+
+
+@pytest.fixture
+async def repo(tmp_path):
+    """Create a repository backed by a temporary database."""
+    db_path = str(tmp_path / "test.db")
+    await init_db(db_path)
+    return SessionRepository(db_path)
+
+
+async def _seed(repo: SessionRepository) -> None:
+    """Insert several sessions for search tests."""
+    await repo.save(
+        thread_id=1,
+        session_id="sess-aaa",
+        summary="Fix login bug",
+        working_dir="/home/user/webapp",
+        origin="discord",
+    )
+    await repo.save(
+        thread_id=2,
+        session_id="sess-bbb",
+        summary="Add dark mode feature",
+        working_dir="/home/user/webapp",
+        origin="discord",
+    )
+    await repo.save(
+        thread_id=3,
+        session_id="sess-ccc",
+        summary="Deploy to production",
+        working_dir="/home/user/infra",
+        origin="cli",
+    )
+    await repo.save(
+        thread_id=4,
+        session_id="sess-ddd",
+        summary="Refactor database layer",
+        working_dir="/home/user/ccdb",
+        origin="discord",
+    )
+    await repo.save(
+        thread_id=5,
+        session_id="sess-eee",
+        summary=None,
+        working_dir=None,
+        origin="discord",
+    )
+
+
+class TestSearchByKeyword:
+    async def test_search_matches_summary(self, repo):
+        await _seed(repo)
+        results = await repo.search(query="login")
+        assert len(results) == 1
+        assert results[0].summary == "Fix login bug"
+
+    async def test_search_matches_working_dir(self, repo):
+        await _seed(repo)
+        results = await repo.search(query="infra")
+        assert len(results) == 1
+        assert results[0].working_dir == "/home/user/infra"
+
+    async def test_search_case_insensitive(self, repo):
+        await _seed(repo)
+        results = await repo.search(query="DARK MODE")
+        assert len(results) == 1
+        assert "dark mode" in results[0].summary.lower()
+
+    async def test_search_multiple_matches(self, repo):
+        await _seed(repo)
+        results = await repo.search(query="webapp")
+        assert len(results) == 2
+
+    async def test_search_no_match(self, repo):
+        await _seed(repo)
+        results = await repo.search(query="nonexistent")
+        assert len(results) == 0
+
+    async def test_search_empty_query_returns_all(self, repo):
+        await _seed(repo)
+        results = await repo.search(query="")
+        assert len(results) == 5
+
+    async def test_search_none_query_returns_all(self, repo):
+        await _seed(repo)
+        results = await repo.search(query=None)
+        assert len(results) == 5
+
+
+class TestSearchWithOriginFilter:
+    async def test_filter_by_origin(self, repo):
+        await _seed(repo)
+        results = await repo.search(query="", origin="cli")
+        assert len(results) == 1
+        assert results[0].origin == "cli"
+
+    async def test_combined_keyword_and_origin(self, repo):
+        await _seed(repo)
+        results = await repo.search(query="webapp", origin="discord")
+        assert len(results) == 2
+
+
+class TestSearchLimit:
+    async def test_respects_limit(self, repo):
+        await _seed(repo)
+        results = await repo.search(query="", limit=2)
+        assert len(results) == 2
+
+    async def test_default_limit(self, repo):
+        await _seed(repo)
+        results = await repo.search(query="")
+        assert len(results) <= 50
+
+
+class TestSearchOrdering:
+    async def test_ordered_by_last_used_desc(self, repo):
+        await _seed(repo)
+        results = await repo.search(query="")
+        for i in range(len(results) - 1):
+            assert results[i].last_used_at >= results[i + 1].last_used_at
+
+
+class TestSearchByThreadIds:
+    """Filter to specific thread IDs (for orphaned thread detection)."""
+
+    async def test_filter_by_thread_ids(self, repo):
+        await _seed(repo)
+        results = await repo.search(query="", thread_ids=[1, 3])
+        assert len(results) == 2
+        assert {r.thread_id for r in results} == {1, 3}
+
+    async def test_exclude_thread_ids(self, repo):
+        await _seed(repo)
+        results = await repo.search(query="", exclude_thread_ids=[1, 2, 3])
+        assert len(results) == 2
+        assert {r.thread_id for r in results} == {4, 5}
+
+    async def test_combined_query_and_exclude(self, repo):
+        await _seed(repo)
+        results = await repo.search(query="webapp", exclude_thread_ids=[1])
+        assert len(results) == 1
+        assert results[0].thread_id == 2


### PR DESCRIPTION
## Summary
- Add `SessionRepository.search()` with keyword search across summary and working_dir, origin filtering, and thread ID include/exclude support
- Enhance `/resume` command with optional `query` (keyword search) and `filter` (orphaned sessions) parameters
- Show full `working_dir` path in ResumeSelectView description (was only showing last directory component)
- Save `working_dir` from runner when persisting Discord chat sessions (was only saved for CLI-synced sessions)

## Test plan
- [x] 15 new search tests (keyword, origin filter, limit, ordering, thread ID filtering)
- [x] 4 new resume command tests (query, orphaned filter, no results)
- [x] 3 existing event_processor tests updated for working_dir
- [x] All 135 related tests passing
- [x] Lint and format checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)