### PR TITLE
fix: add per-thread lock to prevent duplicate CLI sessions on rapid messages

### DIFF
--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -134,6 +134,7 @@ class ClaudeChatCog(commands.Cog):
         # Used by _handle_thread_reply to wait for an interrupted session
         # to fully clean up before starting the replacement session.
         self._active_tasks: dict[int, asyncio.Task] = {}
+        self._thread_locks: dict[int, asyncio.Lock] = {}
         # Dashboard may be None until bot is ready; resolved lazily in _get_dashboard()
         self._dashboard = dashboard
         # For AskUserQuestion persistence across restarts
@@ -776,17 +777,16 @@ class ClaudeChatCog(commands.Cog):
                 if isinstance(_dashboard, ThreadStatusDashboard):
                     await _dashboard.refresh_inbox(_inbox_repo)
 
-        # Interrupt any active session in this thread before starting a new one.
-        existing_runner = self._active_runners.get(thread.id)
-        existing_task = self._active_tasks.get(thread.id)
-        if existing_runner is not None:
-            await thread.send("-# ⚡ Interrupted. Starting with new instruction...")
-            await existing_runner.interrupt()
-            # Wait for the interrupted _run_claude to finish its finally block
-            # (which releases the semaphore and removes entries from dicts).
-            if existing_task is not None and not existing_task.done():
-                with contextlib.suppress(Exception):
-                    await existing_task
+        lock = self._thread_locks.setdefault(thread.id, asyncio.Lock())
+        async with lock:
+            existing_runner = self._active_runners.get(thread.id)
+            existing_task = self._active_tasks.get(thread.id)
+            if existing_runner is not None:
+                await thread.send("-# ⚡ Interrupted. Starting with new instruction...")
+                await existing_runner.interrupt()
+                if existing_task is not None and not existing_task.done():
+                    with contextlib.suppress(Exception):
+                        await existing_task
 
         # Determine chat_only from the parent channel of this thread.
         chat_only = (thread.parent_id or 0) in self._chat_only_channel_ids
@@ -933,6 +933,7 @@ class ClaudeChatCog(commands.Cog):
                 await stop_view.disable()
             self._active_runners.pop(thread.id, None)
             self._active_tasks.pop(thread.id, None)
+            self._thread_locks.pop(thread.id, None)
 
             # Transition to WAITING_INPUT so owner knows a reply is needed
             if dashboard is not None:

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -318,6 +318,46 @@ class TestInterruptOnNewMessage:
         assert isinstance(cog._active_tasks, dict)
         assert len(cog._active_tasks) == 0
 
+    @pytest.mark.asyncio
+    async def test_thread_locks_dict_initialized(self) -> None:
+        """ClaudeChatCog must initialize _thread_locks as an empty dict."""
+        cog = _make_cog()
+        assert hasattr(cog, "_thread_locks")
+        assert isinstance(cog._thread_locks, dict)
+        assert len(cog._thread_locks) == 0
+
+    @pytest.mark.asyncio
+    async def test_concurrent_messages_only_spawn_one_session(self) -> None:
+        """Two near-simultaneous messages should not both spawn CLI processes."""
+        cog = _make_cog()
+        thread_id = 42
+
+        call_count = 0
+
+        async def slow_run_claude(*args: object, **kwargs: object) -> None:
+            nonlocal call_count
+            call_count += 1
+            runner = MagicMock()
+            runner.interrupt = AsyncMock()
+            cog._active_runners[thread_id] = runner
+            await asyncio.sleep(0.05)
+
+        cog._run_claude = slow_run_claude
+
+        msg1 = self._make_thread_message(thread_id)
+        msg2 = self._make_thread_message(thread_id)
+
+        t1 = asyncio.create_task(cog._handle_thread_reply(msg1))
+        await asyncio.sleep(0)
+        t2 = asyncio.create_task(cog._handle_thread_reply(msg2))
+
+        await asyncio.gather(t1, t2, return_exceptions=True)
+
+        assert call_count == 2
+        thread = msg2.channel
+        send_calls = [c.args[0] for c in thread.send.call_args_list]
+        assert any("⚡" in s for s in send_calls)
+
 
 class TestSpawnSession:
     """Tests for ClaudeChatCog.spawn_session()."""


### PR DESCRIPTION
## Summary

- Add per-thread `asyncio.Lock` to `_handle_thread_reply` to prevent two near-simultaneous messages from both seeing `_active_runners` as empty and spawning duplicate CLI processes
- Lock scope is narrow (check-and-interrupt only), so the interrupt path remains reachable during active sessions
- Clean up `_thread_locks` entries in `_run_claude`'s finally block to prevent unbounded dict growth
- Add tests for lock initialization and concurrent message handling

## Background

This supersedes PR #377 by @Ragingwasabi, who identified the race condition and proposed the per-thread lock approach. The original PR had two iterations:

1. First commit wrapped the entire `_run_claude` call in the lock — too wide, blocked the interrupt path
2. Second commit (after review) narrowed the lock to the check-and-interrupt section — correct approach

This PR applies the narrowed-scope approach from the second commit, rebased on current `main` (which had drifted significantly since #377), and adds test coverage.

Credit: @Ragingwasabi for identifying the bug and the lock-based fix.

## Test plan

- [x] `test_thread_locks_dict_initialized` — verifies `_thread_locks` is initialized
- [x] `test_concurrent_messages_only_spawn_one_session` — two rapid messages: first spawns session, second interrupts and re-spawns (verifies ⚡ interrupt message sent)
- [x] All 72 existing tests pass
- [x] ruff check + ruff format pass