### PR TITLE
[docs-sync] Update test count to 1300+

### DIFF
--- a/README.md
+++ b/README.md
@@ -896,7 +896,7 @@ examples/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-1050+ tests covering parser, chunker, repository, runner, streaming, webhook triggers, auto-upgrade (including `/upgrade` slash command, thread-invocation, and approval button), REST API, AskUserQuestion UI, thread dashboard, scheduled tasks, session sync, AI Lounge, startup resume, model switching, compact detection, TodoWrite progress embeds, custom Cog loader, permission/elicitation/plan-mode event parsing, and thread inbox classification.
+1300+ tests covering parser, chunker, repository, runner, streaming, webhook triggers, auto-upgrade (including `/upgrade` slash command, thread-invocation, and approval button), REST API, AskUserQuestion UI, thread dashboard, scheduled tasks, session sync, AI Lounge, startup resume, model switching, compact detection, TodoWrite progress embeds, custom Cog loader, permission/elicitation/plan-mode event parsing, thread inbox classification, and per-thread lock behavior.
 
 ---
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -897,7 +897,7 @@ examples/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-1050 件以上のテストがパーサー、チャンカー、リポジトリ、ランナー、ストリーミング、Webhook トリガー、自動アップグレード（`/upgrade` スラッシュコマンド、スレッド内実行、承認ボタン含む）、REST API、AskUserQuestion UI、スレッドダッシュボード、スケジュールタスク、セッション同期、AI Lounge、スタートアップリジューム、モデル切り替え、コンパクト検出、TodoWrite 進捗 embed、カスタム Cog ローダー、許可／Elicitation／Plan Mode イベントパース、スレッドインボックス分類をカバーしています。
+1300 件以上のテストがパーサー、チャンカー、リポジトリ、ランナー、ストリーミング、Webhook トリガー、自動アップグレード（`/upgrade` スラッシュコマンド、スレッド内実行、承認ボタン含む）、REST API、AskUserQuestion UI、スレッドダッシュボード、スケジュールタスク、セッション同期、AI Lounge、スタートアップリジューム、モデル切り替え、コンパクト検出、TodoWrite 進捗 embed、カスタム Cog ローダー、許可／Elicitation／Plan Mode イベントパース、スレッドインボックス分類、スレッドごとのロック動作をカバーしています。
 
 ---
 


### PR DESCRIPTION
## Summary

- Updated test count from 1050+ to 1300+ in README.md and docs/ja/README.md to reflect the current actual count (1308 tests)
- Added "per-thread lock behavior" to the test coverage list, reflecting the new locking tests from PR #393

## Related

PR #393: fix: add per-thread lock to prevent duplicate CLI sessions on rapid messages

## Test plan

- [ ] Verify test count is accurate (`uv run pytest tests/ --co -q | tail -1` → 1308 tests collected)
- [ ] Verify Japanese README reflects the same changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
