### PR TITLE
chore: switch all workflows to self-hosted runners

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -24,7 +24,7 @@ jobs:
       github.event.pull_request.user.login == 'ebibibi' &&
       github.event.pull_request.draft == false &&
       !contains(github.event.pull_request.labels.*.name, 'external-issue')
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     permissions:
       pull-requests: write
       contents: write

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   version-bump:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     permissions:
       contents: write
 

--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     permissions:
       contents: write
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/consumer-smoke-test.yml
+++ b/.github/workflows/consumer-smoke-test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   ebibot-import:
     name: EbiBot import check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docs-sync-notify.yml
+++ b/.github/workflows/docs-sync-notify.yml
@@ -7,7 +7,7 @@ jobs:
     if: >-
       github.event.check_suite.conclusion == 'failure' &&
       startsWith(github.event.check_suite.head_branch, 'docs-sync/')
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Find the PR
         id: pr

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -12,7 +12,7 @@ jobs:
     if: >-
       !contains(github.event.head_commit.message, '[docs-sync]') &&
       !contains(github.event.head_commit.message, 'docs-sync/')
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Check for recent docs-sync activity
         id: check

--- a/.github/workflows/docs-translate.yml
+++ b/.github/workflows/docs-translate.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   trigger-docs-translate:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Trigger full translation via Discord webhook
         env:


### PR DESCRIPTION
## Summary
- Switch all GitHub Actions workflows to use self-hosted runners
- ci.yml was already using self-hosted; this PR updates the remaining 8 workflows

## Changed files
- auto-approve.yml
- auto-version-bump.yml
- cleanup-branches.yml
- codeql.yml
- consumer-smoke-test.yml
- docs-sync-notify.yml
- docs-sync.yml
- docs-translate.yml

## Test plan
- [ ] Verify self-hosted runner picks up jobs
- [ ] Verify no workflow failures after merge