### PR TITLE
fix: actually attach WorktreeManager to bot in setup_bridge

### DIFF
--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -224,7 +224,7 @@ async def setup_bridge(
     if worktree_base_dir is None:
         worktree_base_dir = os.getenv("WORKTREE_BASE_DIR")
     if worktree_base_dir is not None:
-        if not hasattr(bot, "worktree_manager"):
+        if getattr(bot, "worktree_manager", None) is None:
             bot.worktree_manager = WorktreeManager(base_dir=worktree_base_dir)  # type: ignore[attr-defined]
         logger.info("WorktreeManager enabled (base_dir=%s)", worktree_base_dir)
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -340,6 +340,34 @@ async def test_setup_bridge_reads_max_concurrent_from_env(tmp_path: object) -> N
 
 
 @pytest.mark.asyncio
+async def test_setup_bridge_attaches_worktree_manager_when_pre_initialized_to_none(
+    tmp_path: object,
+) -> None:
+    """Regression: WorktreeManager must attach when bot pre-initializes the attr to None.
+
+    ClaudeDiscordBot.__init__ sets ``self.worktree_manager = None`` so the attribute
+    always exists. A ``not hasattr(bot, "worktree_manager")`` gate would silently skip
+    the assignment, leaving the bot without a manager while the log line still claimed
+    it was enabled.
+    """
+    from claude_discord.worktree import WorktreeManager
+
+    bot = _make_bot()
+    bot.worktree_manager = None  # mirror ClaudeDiscordBot.__init__ behaviour
+    runner = _make_runner()
+
+    await setup_bridge(
+        bot,
+        runner,
+        session_db_path=str(tmp_path / "sessions.db"),  # type: ignore[operator]
+        worktree_base_dir=str(tmp_path),  # type: ignore[arg-type]
+        enable_scheduler=False,
+    )
+
+    assert isinstance(bot.worktree_manager, WorktreeManager)
+
+
+@pytest.mark.asyncio
 async def test_setup_bridge_defaults_max_concurrent_to_3(tmp_path: object) -> None:
     """Without env var or parameter, max_concurrent defaults to 3."""
     from unittest.mock import patch


### PR DESCRIPTION
## Problem

`WorktreeManager` was never attached to the bot, even though startup logs claimed it was. Slash commands (`/worktree-list`, etc.) reported "Worktree manager is not configured" while logs simultaneously said `WorktreeManager enabled (base_dir=...)`.

## Cause

`ClaudeDiscordBot.__init__` (`claude_discord/bot.py:57`) pre-initializes `self.worktree_manager = None`, so the `hasattr(bot, "worktree_manager")` check in `setup_bridge()` was always `True`, skipping the assignment. The `logger.info("WorktreeManager enabled ...")` call sits outside the `if` block, so it fired regardless — making the bug invisible.

## Fix

Switch the gate from `not hasattr(...)` to `getattr(..., None) is None`. Now the assignment runs whether the attribute is unset or pre-initialized to `None`. One-line change in `claude_discord/setup.py`.

## Test

Added a regression test in `tests/test_setup.py` that mirrors the real bot's behaviour by pre-setting `bot.worktree_manager = None`, then asserts `setup_bridge` attaches a real `WorktreeManager`. Confirmed RED → GREEN: the test fails against the previous code and passes after the fix.

Full suite: 1309 passed. `ruff check` and `ruff format --check` clean.

## Test plan
- [ ] Set `WORKTREE_BASE_DIR=/some/path` and run `ccdb`
- [ ] Confirm startup log emits `WorktreeManager enabled (base_dir=...)`
- [ ] In Discord, run `/worktree-list` — should NOT say "not configured"
- [ ] Start a session, verify `git worktree list` shows a `session/<id>` worktree

I verified the fix against a live ccdb pointed at this branch — `/worktree-list` now returns `"no session worktrees found"` instead of the configuration-missing error.