### PR TITLE
feat: add SessionBackend protocol + Codex CLI backend (dual Claude/Codex support)

### DIFF
--- a/claude_code_core/__init__.py
+++ b/claude_code_core/__init__.py
@@ -24,6 +24,10 @@ Usage::
 
 from __future__ import annotations
 
+# Backend
+from .backend import SessionBackend, create_backend
+from .codex_runner import CodexRunner, parse_codex_line
+
 # Database
 from .lounge_repo import LoungeMessage, LoungeRepository
 from .models import init_db
@@ -72,6 +76,11 @@ __all__ = [
     "ToolUseEvent",
     # Parser
     "parse_line",
+    # Backend
+    "CodexRunner",
+    "SessionBackend",
+    "create_backend",
+    "parse_codex_line",
     # Runner
     "ClaudeRunner",
     # Database

--- a/claude_code_core/backend.py
+++ b/claude_code_core/backend.py
@@ -1,0 +1,63 @@
+"""SessionBackend protocol and factory.
+
+Defines the common interface that all CLI backends (Claude, Codex, etc.)
+must satisfy, plus a factory function to instantiate them by name.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from .types import ImageData, StreamEvent
+
+
+@runtime_checkable
+class SessionBackend(Protocol):
+    """Protocol that all CLI backends must satisfy."""
+
+    model: str
+    working_dir: str | None
+    permission_mode: str
+    images: list[ImageData] | None
+
+    async def run(
+        self,
+        prompt: str,
+        session_id: str | None = None,
+    ) -> AsyncGenerator[StreamEvent, None]: ...
+
+    def clone(self, **kwargs: object) -> SessionBackend: ...
+
+    async def interrupt(self) -> None: ...
+
+    async def kill(self) -> None: ...
+
+    async def inject_tool_result(self, request_id: str, data: dict) -> None: ...
+
+
+def create_backend(
+    *,
+    backend: str = "claude",
+    model: str,
+    **kwargs: object,
+) -> SessionBackend:
+    """Create a backend runner by name.
+
+    Args:
+        backend: "claude" or "codex".
+        model: Model identifier (e.g. "sonnet", "o4-mini").
+        **kwargs: Forwarded to the runner constructor.
+    """
+    if backend == "claude":
+        from .runner import ClaudeRunner
+
+        return ClaudeRunner(model=model, **kwargs)  # type: ignore[arg-type]
+
+    if backend == "codex":
+        from .codex_runner import CodexRunner
+
+        return CodexRunner(model=model, **kwargs)  # type: ignore[arg-type]
+
+    raise ValueError(f"Unknown backend: {backend!r}")

--- a/claude_code_core/backend.py
+++ b/claude_code_core/backend.py
@@ -17,12 +17,17 @@ if TYPE_CHECKING:
 class SessionBackend(Protocol):
     """Protocol that all CLI backends must satisfy."""
 
+    command: str
     model: str
     working_dir: str | None
     permission_mode: str
     images: list[ImageData] | None
+    api_port: int | None
+    timeout_seconds: int
+    dangerously_skip_permissions: bool
+    allowed_tools: list[str] | None
 
-    async def run(
+    def run(
         self,
         prompt: str,
         session_id: str | None = None,
@@ -35,6 +40,8 @@ class SessionBackend(Protocol):
     async def kill(self) -> None: ...
 
     async def inject_tool_result(self, request_id: str, data: dict) -> None: ...
+
+    def _build_env(self) -> dict[str, str]: ...
 
 
 def create_backend(

--- a/claude_code_core/codex_runner.py
+++ b/claude_code_core/codex_runner.py
@@ -132,6 +132,7 @@ class CodexRunner:
         working_dir: str | None = None,
         timeout_seconds: int = 300,
         dangerously_skip_permissions: bool = False,
+        allowed_tools: list[str] | None = None,
         api_port: int | None = None,
         api_secret: str | None = None,
         thread_id: int | None = None,
@@ -144,6 +145,7 @@ class CodexRunner:
         self.working_dir = working_dir
         self.timeout_seconds = timeout_seconds
         self.dangerously_skip_permissions = dangerously_skip_permissions
+        self.allowed_tools = allowed_tools
         self.api_port = api_port
         self.api_secret = api_secret
         self.thread_id = thread_id
@@ -205,6 +207,7 @@ class CodexRunner:
             ),
             timeout_seconds=self.timeout_seconds,
             dangerously_skip_permissions=self.dangerously_skip_permissions,
+            allowed_tools=self.allowed_tools,
             api_port=self.api_port,
             api_secret=self.api_secret,
             thread_id=thread_id if thread_id is not None else self.thread_id,

--- a/claude_code_core/codex_runner.py
+++ b/claude_code_core/codex_runner.py
@@ -1,0 +1,318 @@
+"""OpenAI Codex CLI runner.
+
+Spawns the codex CLI as an async subprocess and yields StreamEvent
+objects, providing the same interface as ClaudeRunner.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import signal
+from collections.abc import AsyncGenerator
+
+from .types import (
+    ImageData,
+    MessageType,
+    StreamEvent,
+    ToolCategory,
+    ToolUseEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+_UNSET = object()
+
+_APPROVAL_MODE_MAP: dict[str, str] = {
+    "acceptEdits": "except-edit",
+    "full": "always",
+    "none": "never",
+}
+
+
+def parse_codex_line(line: str) -> StreamEvent | None:
+    """Parse a single Codex JSONL line into a StreamEvent."""
+    line = line.strip()
+    if not line:
+        return None
+
+    try:
+        data = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+
+    event_type = data.get("type", "")
+
+    if event_type == "thread.started":
+        return StreamEvent(
+            raw=data,
+            message_type=MessageType.SYSTEM,
+            session_id=data.get("thread_id"),
+        )
+
+    if event_type == "turn.started":
+        return StreamEvent(raw=data, message_type=MessageType.SYSTEM)
+
+    if event_type == "turn.completed":
+        usage = data.get("usage", {})
+        return StreamEvent(
+            raw=data,
+            message_type=MessageType.SYSTEM,
+            is_complete=True,
+            input_tokens=usage.get("input_tokens"),
+            output_tokens=usage.get("output_tokens"),
+            cache_read_tokens=usage.get("cached_input_tokens"),
+        )
+
+    if event_type == "error":
+        return StreamEvent(
+            raw=data,
+            message_type=MessageType.RESULT,
+            is_complete=True,
+            error=data.get("message", "Unknown error"),
+        )
+
+    item = data.get("item", {})
+    item_type = item.get("type", "")
+
+    if event_type == "item.started" and item_type == "command_execution":
+        return StreamEvent(
+            raw=data,
+            message_type=MessageType.ASSISTANT,
+            tool_use=ToolUseEvent(
+                tool_id=item.get("id", ""),
+                tool_name="Bash",
+                tool_input={"command": item.get("command", "")},
+                category=ToolCategory.COMMAND,
+            ),
+        )
+
+    if event_type == "item.completed":
+        if item_type == "agent_message":
+            return StreamEvent(
+                raw=data,
+                message_type=MessageType.ASSISTANT,
+                text=item.get("text", ""),
+            )
+
+        if item_type == "command_execution":
+            return StreamEvent(
+                raw=data,
+                message_type=MessageType.ASSISTANT,
+                tool_result_id=item.get("id", ""),
+                tool_result_content=item.get("output", ""),
+            )
+
+        if item_type == "file_changes":
+            return StreamEvent(
+                raw=data,
+                message_type=MessageType.ASSISTANT,
+                tool_use=ToolUseEvent(
+                    tool_id=item.get("id", ""),
+                    tool_name="Edit",
+                    tool_input={"description": item.get("text", "")},
+                    category=ToolCategory.EDIT,
+                ),
+            )
+
+    return None
+
+
+class CodexRunner:
+    """Manages OpenAI Codex CLI subprocess."""
+
+    def __init__(
+        self,
+        command: str = "codex",
+        model: str = "o4-mini",
+        permission_mode: str = "default",
+        working_dir: str | None = None,
+        timeout_seconds: int = 300,
+        dangerously_skip_permissions: bool = False,
+        api_port: int | None = None,
+        api_secret: str | None = None,
+        thread_id: int | None = None,
+        images: list[ImageData] | None = None,
+        **_kwargs: object,
+    ) -> None:
+        self.command = command
+        self.model = model
+        self.permission_mode = permission_mode
+        self.working_dir = working_dir
+        self.timeout_seconds = timeout_seconds
+        self.dangerously_skip_permissions = dangerously_skip_permissions
+        self.api_port = api_port
+        self.api_secret = api_secret
+        self.thread_id = thread_id
+        self.images = images
+        self._process: asyncio.subprocess.Process | None = None
+
+    async def run(
+        self,
+        prompt: str,
+        session_id: str | None = None,
+    ) -> AsyncGenerator[StreamEvent, None]:
+        """Run Codex CLI and yield stream events."""
+        args = self._build_args(prompt, session_id)
+        env = self._build_env()
+        cwd = self.working_dir or os.getcwd()
+
+        logger.info("Starting Codex CLI: %s (cwd=%s)", " ".join(args[:6]) + " ...", cwd)
+
+        self._process = await asyncio.create_subprocess_exec(
+            *args,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=cwd,
+            env=env,
+            limit=10 * 1024 * 1024,
+        )
+
+        logger.info("Codex CLI started: pid=%s", self._process.pid)
+
+        try:
+            async for event in self._read_stream():
+                yield event
+        except TimeoutError:
+            logger.warning("Codex CLI timed out after %ds", self.timeout_seconds)
+            yield StreamEvent(
+                raw={},
+                message_type=MessageType.RESULT,
+                is_complete=True,
+                error=f"Timed out after {self.timeout_seconds} seconds",
+            )
+        finally:
+            await self._cleanup()
+
+    def clone(
+        self,
+        model: str | None = None,
+        working_dir: str | None | object = _UNSET,
+        thread_id: int | None = None,
+        **_kwargs: object,
+    ) -> CodexRunner:
+        """Create a fresh runner with the same configuration but no active process."""
+        return CodexRunner(
+            command=self.command,
+            model=model if model is not None else self.model,
+            permission_mode=self.permission_mode,
+            working_dir=(
+                self.working_dir if working_dir is _UNSET else working_dir  # type: ignore[arg-type]
+            ),
+            timeout_seconds=self.timeout_seconds,
+            dangerously_skip_permissions=self.dangerously_skip_permissions,
+            api_port=self.api_port,
+            api_secret=self.api_secret,
+            thread_id=thread_id if thread_id is not None else self.thread_id,
+            images=self.images,
+        )
+
+    async def interrupt(self) -> None:
+        """Interrupt the subprocess with SIGINT."""
+        if self._process and self._process.returncode is None:
+            if os.name == "nt":
+                self._process.terminate()
+            else:
+                self._process.send_signal(signal.SIGINT)
+            try:
+                await asyncio.wait_for(self._process.wait(), timeout=10)
+            except TimeoutError:
+                await self.kill()
+
+    async def kill(self) -> None:
+        """Terminate the subprocess."""
+        if self._process and self._process.returncode is None:
+            self._process.terminate()
+            try:
+                await asyncio.wait_for(self._process.wait(), timeout=5)
+            except TimeoutError:
+                self._process.kill()
+                await self._process.wait()
+
+    async def inject_tool_result(self, request_id: str, data: dict) -> None:
+        """Codex CLI does not support stdin injection; this is a no-op."""
+        logger.debug("inject_tool_result called on CodexRunner (no-op): %s", request_id)
+
+    def _build_args(self, prompt: str, session_id: str | None) -> list[str]:
+        """Build command-line arguments for codex CLI."""
+        if session_id:
+            if not re.match(r"^[a-f0-9\-]+$", session_id):
+                raise ValueError(f"Invalid session_id format: {session_id!r}")
+            args = [self.command, "resume", session_id, "--json", "--model", self.model]
+        else:
+            args = [self.command, "exec", "--json", "--model", self.model]
+
+        if self.dangerously_skip_permissions:
+            args.append("--dangerously-bypass-approvals-and-sandbox")
+        elif self.permission_mode in _APPROVAL_MODE_MAP:
+            args.extend(["--ask-for-approval", _APPROVAL_MODE_MAP[self.permission_mode]])
+
+        if self.working_dir:
+            args.extend(["--cd", self.working_dir])
+
+        args.append(prompt)
+        return args
+
+    _STRIPPED_ENV_KEYS = frozenset(
+        {
+            "CLAUDECODE",
+            "DISCORD_BOT_TOKEN",
+            "DISCORD_TOKEN",
+            "API_SECRET_KEY",
+        }
+    )
+
+    def _build_env(self) -> dict[str, str]:
+        """Build environment variables for the subprocess."""
+        env = {k: v for k, v in os.environ.items() if k not in self._STRIPPED_ENV_KEYS}
+        if self.api_port is not None:
+            env["CCDB_API_URL"] = f"http://127.0.0.1:{self.api_port}"
+        if self.api_secret is not None:
+            env["CCDB_API_SECRET"] = self.api_secret
+        if self.thread_id is not None:
+            env["DISCORD_THREAD_ID"] = str(self.thread_id)
+        return env
+
+    async def _read_stream(self) -> AsyncGenerator[StreamEvent, None]:
+        """Read and parse stdout line by line."""
+        if self._process is None or self._process.stdout is None:
+            raise RuntimeError("Process not started")
+
+        while True:
+            line = await self._process.stdout.readline()
+            if not line:
+                break
+            decoded = line.decode("utf-8", errors="replace")
+            event = parse_codex_line(decoded)
+            if event:
+                yield event
+                if event.is_complete:
+                    return
+
+        if self._process.returncode is None:
+            await asyncio.wait_for(self._process.wait(), timeout=10)
+
+        if self._process.returncode is not None and self._process.returncode > 0:
+            stderr_data = b""
+            if self._process.stderr:
+                stderr_data = await self._process.stderr.read()
+            stderr_text = stderr_data.decode("utf-8", errors="replace").strip()
+            logger.error(
+                "Codex CLI exited with code %d: %s",
+                self._process.returncode,
+                stderr_text[:200],
+            )
+            yield StreamEvent(
+                raw={},
+                message_type=MessageType.RESULT,
+                is_complete=True,
+                error=f"CLI exited with code {self._process.returncode}",
+            )
+
+    async def _cleanup(self) -> None:
+        """Ensure the subprocess is properly terminated."""
+        await self.kill()

--- a/claude_discord/cog_loader.py
+++ b/claude_discord/cog_loader.py
@@ -16,7 +16,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from discord.ext.commands import Bot
 
-    from .claude.runner import ClaudeRunner
+    from claude_code_core.backend import SessionBackend
+
     from .setup import BridgeComponents
 
 logger = logging.getLogger(__name__)
@@ -25,7 +26,7 @@ logger = logging.getLogger(__name__)
 async def load_custom_cogs(
     cogs_dir: Path,
     bot: Bot,
-    runner: ClaudeRunner | None,
+    runner: SessionBackend | None,
     components: BridgeComponents,
 ) -> int:
     """Load custom Cog files from *cogs_dir*.

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -58,6 +58,7 @@ _HELP_CATEGORY: dict[str, str | None] = {
     "clear": "📌 Session",
     "rewind": "📌 Session",
     "compact": "📌 Session",
+    "goal": "📌 Session",
     "fork": "📌 Session",
     "context": "📌 Session",
     "usage": "📌 Session",
@@ -351,6 +352,66 @@ class ClaudeChatCog(commands.Cog):
             session_id=record.session_id,
             working_dir_override=record.working_dir,
             chat_only=True,
+        )
+
+    @app_commands.command(
+        name="goal",
+        description="Set a completion condition — Claude keeps working until it's met",
+    )
+    @app_commands.describe(condition="Goal condition (omit to check status, 'clear' to cancel)")
+    async def goal_session(
+        self,
+        interaction: discord.Interaction,
+        condition: str | None = None,
+    ) -> None:
+        """Set, check, or clear a goal via the CLI's /goal command."""
+        if not isinstance(interaction.channel, discord.Thread):
+            await interaction.response.send_message(
+                "This command can only be used in a Claude chat thread.", ephemeral=True
+            )
+            return
+
+        thread_id = interaction.channel.id
+        record = await self.repo.get(thread_id)
+        if record is None:
+            await interaction.response.send_message(
+                "No active session found for this thread.", ephemeral=True
+            )
+            return
+
+        if thread_id in self._active_runners:
+            await interaction.response.send_message(
+                "A session is currently running. Use /stop to interrupt it first.",
+                ephemeral=True,
+            )
+            return
+
+        prompt = f"/goal {condition}" if condition else "/goal"
+
+        await interaction.response.defer()
+
+        if condition and condition.strip().lower() not in (
+            "clear",
+            "stop",
+            "off",
+            "reset",
+            "none",
+            "cancel",
+        ):
+            label = f"◎ Setting goal: {condition[:80]}"
+        elif not condition:
+            label = "◎ Checking goal status..."
+        else:
+            label = "◎ Clearing goal..."
+
+        seed_message = await interaction.followup.send(label, wait=True)
+
+        await self._run_claude(
+            user_message=seed_message,
+            thread=interaction.channel,
+            prompt=prompt,
+            session_id=record.session_id,
+            working_dir_override=record.working_dir,
         )
 
     @app_commands.command(name="clear", description="Reset the Claude Code session for this thread")

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -21,8 +21,9 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from claude_code_core.backend import SessionBackend
+
 from ..claude.rewind import find_session_jsonl, parse_user_turns
-from ..claude.runner import ClaudeRunner
 from ..claude.types import ImageData
 from ..concurrency import SessionRegistry
 from ..database.ask_repo import PendingAskRepository
@@ -92,7 +93,7 @@ class ClaudeChatCog(commands.Cog):
         self,
         bot: ClaudeDiscordBot,
         repo: SessionRepository,
-        runner: ClaudeRunner,
+        runner: SessionBackend,
         max_concurrent: int = 3,
         allowed_user_ids: set[int] | None = None,
         registry: SessionRegistry | None = None,
@@ -130,7 +131,7 @@ class ClaudeChatCog(commands.Cog):
         # Channels where only text responses are shown (no tool embeds, thinking, etc.).
         self._chat_only_channel_ids: set[int] = chat_only_channel_ids or set()
         self._registry = registry or getattr(bot, "session_registry", None)
-        self._active_runners: dict[int, ClaudeRunner] = {}
+        self._active_runners: dict[int, SessionBackend] = {}
         # Tracks the asyncio.Task running _run_claude for each thread.
         # Used by _handle_thread_reply to wait for an interrupted session
         # to fully clean up before starting the replacement session.

--- a/claude_discord/cogs/run_config.py
+++ b/claude_discord/cogs/run_config.py
@@ -13,7 +13,8 @@ from typing import TYPE_CHECKING
 
 import discord
 
-from ..claude.runner import ClaudeRunner
+from claude_code_core.backend import SessionBackend
+
 from ..claude.types import ImageData
 from ..concurrency import SessionRegistry
 from ..database.ask_repo import PendingAskRepository
@@ -56,7 +57,7 @@ class RunConfig:
     """
 
     thread: discord.Thread | discord.TextChannel
-    runner: ClaudeRunner
+    runner: SessionBackend
     prompt: str
     session_id: str | None = None
     repo: SessionRepository | None = None

--- a/claude_discord/cogs/scheduler.py
+++ b/claude_discord/cogs/scheduler.py
@@ -25,7 +25,8 @@ from ._run_helper import run_claude_with_config
 from .run_config import RunConfig
 
 if TYPE_CHECKING:
-    from ..claude.runner import ClaudeRunner
+    from claude_code_core.backend import SessionBackend
+
     from ..database.repository import SessionRepository
     from ..database.task_repo import TaskRepository
 
@@ -47,7 +48,7 @@ class SchedulerCog(commands.Cog):
     def __init__(
         self,
         bot: commands.Bot,
-        runner: ClaudeRunner,
+        runner: SessionBackend,
         *,
         repo: TaskRepository,
         session_repo: SessionRepository | None = None,

--- a/claude_discord/cogs/skill_command.py
+++ b/claude_discord/cogs/skill_command.py
@@ -25,7 +25,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from ..claude.runner import ClaudeRunner
+from claude_code_core.backend import SessionBackend
+
 from ..concurrency import SessionRegistry
 from ..database.repository import SessionRepository
 from ._run_helper import run_claude_with_config
@@ -137,7 +138,7 @@ class SkillCommandCog(commands.Cog):
         self,
         bot: commands.Bot,
         repo: SessionRepository,
-        runner: ClaudeRunner,
+        runner: SessionBackend,
         claude_channel_id: int,
         skills_dir: Path | str | None = None,
         allowed_user_ids: set[int] | None = None,

--- a/claude_discord/cogs/webhook_trigger.py
+++ b/claude_discord/cogs/webhook_trigger.py
@@ -25,7 +25,7 @@ from ..cogs.run_config import RunConfig
 from ..concurrency import SessionRegistry
 
 if TYPE_CHECKING:
-    from ..claude.runner import ClaudeRunner
+    from claude_code_core.backend import SessionBackend
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +69,7 @@ class WebhookTriggerCog(commands.Cog):
     def __init__(
         self,
         bot: commands.Bot,
-        runner: ClaudeRunner,
+        runner: SessionBackend,
         triggers: dict[str, WebhookTrigger],
         allowed_webhook_ids: set[int] | None = None,
         channel_ids: set[int] | None = None,

--- a/claude_discord/discord_ui/views.py
+++ b/claude_discord/discord_ui/views.py
@@ -9,8 +9,9 @@ from typing import TYPE_CHECKING, Any, cast
 
 import discord
 
+from claude_code_core.backend import SessionBackend
+
 from ..claude.rewind import TurnEntry, truncate_jsonl_at_line
-from ..claude.runner import ClaudeRunner
 from .embeds import COLOR_SUCCESS, stopped_embed, tool_result_embed, tool_result_preview_embed
 
 if TYPE_CHECKING:
@@ -33,7 +34,7 @@ class StopView(discord.ui.View):
     button at the bottom of the thread (most recently visible position).
     """
 
-    def __init__(self, runner: ClaudeRunner) -> None:
+    def __init__(self, runner: SessionBackend) -> None:
         super().__init__(timeout=None)
         self._runner = runner
         self._stopped = False
@@ -43,7 +44,7 @@ class StopView(discord.ui.View):
         """Store the message this view is attached to."""
         self._message = message
 
-    def update_runner(self, runner: ClaudeRunner) -> None:
+    def update_runner(self, runner: SessionBackend) -> None:
         """Replace the runner reference with the one that owns the live subprocess.
 
         ``run_claude_with_config`` may clone the runner to inject an

--- a/claude_discord/main.py
+++ b/claude_discord/main.py
@@ -40,29 +40,36 @@ def load_config() -> dict[str, str]:
         logger.error("DISCORD_CHANNEL_ID is required")
         sys.exit(1)
 
+    def _env(new: str, old: str, default: str = "") -> str:
+        """Read CCDB_* env var with CLAUDE_* fallback."""
+        return os.getenv(new) or os.getenv(old, default)
+
     return {
         "token": token,
         "channel_id": channel_id,
-        "claude_command": os.getenv("CLAUDE_COMMAND", "claude"),
-        "claude_model": os.getenv("CLAUDE_MODEL", "sonnet"),
-        "claude_permission_mode": os.getenv("CLAUDE_PERMISSION_MODE", "acceptEdits"),
-        "claude_working_dir": os.getenv("CLAUDE_WORKING_DIR", ""),
+        "backend": os.getenv("CCDB_BACKEND", "claude"),
+        "command": _env("CCDB_COMMAND", "CLAUDE_COMMAND", ""),
+        "model": _env("CCDB_MODEL", "CLAUDE_MODEL", "sonnet"),
+        "permission_mode": _env("CCDB_PERMISSION_MODE", "CLAUDE_PERMISSION_MODE", "acceptEdits"),
+        "working_dir": _env("CCDB_WORKING_DIR", "CLAUDE_WORKING_DIR", ""),
+        "dangerously_skip_permissions": _env(
+            "CCDB_DANGEROUSLY_SKIP_PERMISSIONS", "CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS", ""
+        ),
+        "allowed_tools": _env("CCDB_ALLOWED_TOOLS", "CLAUDE_ALLOWED_TOOLS", ""),
+        "effort": _env("CCDB_EFFORT", "CLAUDE_EFFORT", ""),
+        "append_system_prompt": os.getenv("APPEND_SYSTEM_PROMPT", ""),
         "max_concurrent": os.getenv("MAX_CONCURRENT_SESSIONS", "3"),
         "timeout": os.getenv("SESSION_TIMEOUT_SECONDS", "300"),
         "owner_id": os.getenv("DISCORD_OWNER_ID", ""),
-        "dangerously_skip_permissions": os.getenv("CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS", ""),
-        # Additional config for custom cogs and multi-channel
-        "claude_channel_ids": os.getenv("CLAUDE_CHANNEL_IDS", ""),
+        "channel_ids": _env("CCDB_CHANNEL_IDS", "CLAUDE_CHANNEL_IDS", ""),
+        "monitor_all_channels": _env(
+            "CCDB_MONITOR_ALL_CHANNELS", "CLAUDE_MONITOR_ALL_CHANNELS", "false"
+        ),
         "api_host": os.getenv("API_HOST", "127.0.0.1"),
         "api_port": os.getenv("API_PORT", ""),
-        "allowed_tools": os.getenv("CLAUDE_ALLOWED_TOOLS", ""),
         "custom_cogs_dir": os.getenv("CUSTOM_COGS_DIR", ""),
         "cli_sessions_path": os.getenv("CLI_SESSIONS_PATH", ""),
         "thread_inbox_enabled": os.getenv("THREAD_INBOX_ENABLED", "false"),
-        "monitor_all_channels": os.getenv("CLAUDE_MONITOR_ALL_CHANNELS", "false"),
-        "append_system_prompt": os.getenv("APPEND_SYSTEM_PROMPT", ""),
-        "claude_effort": os.getenv("CLAUDE_EFFORT", ""),
-        "backend": os.getenv("CCDB_BACKEND", "claude"),
     }
 
 
@@ -75,9 +82,9 @@ async def main() -> None:
 
     # Parse optional multi-channel IDs
     claude_channel_ids: set[int] | None = None
-    if config["claude_channel_ids"]:
+    if config["channel_ids"]:
         claude_channel_ids = {
-            int(x.strip()) for x in config["claude_channel_ids"].split(",") if x.strip().isdigit()
+            int(x.strip()) for x in config["channel_ids"].split(",") if x.strip().isdigit()
         } or None
 
     # Parse allowed tools
@@ -90,16 +97,16 @@ async def main() -> None:
     default_command = "codex" if backend_name == "codex" else "claude"
     runner = create_backend(
         backend=backend_name,
-        command=config["claude_command"] or default_command,
-        model=config["claude_model"],
-        permission_mode=config["claude_permission_mode"],
-        working_dir=config["claude_working_dir"] or None,
+        command=config["command"] or default_command,
+        model=config["model"],
+        permission_mode=config["permission_mode"],
+        working_dir=config["working_dir"] or None,
         timeout_seconds=int(config["timeout"]),
         dangerously_skip_permissions=config["dangerously_skip_permissions"].lower()
         in ("true", "1", "yes"),
         allowed_tools=allowed_tools,
         append_system_prompt=config["append_system_prompt"] or None,
-        effort=config["claude_effort"] or None,
+        effort=config["effort"] or None,
     )
 
     owner_id = int(config["owner_id"]) if config["owner_id"] else None

--- a/claude_discord/main.py
+++ b/claude_discord/main.py
@@ -16,8 +16,9 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
+from claude_code_core.backend import create_backend
+
 from .bot import ClaudeDiscordBot
-from .claude.runner import ClaudeRunner
 from .cog_loader import load_custom_cogs
 from .setup import setup_bridge
 from .utils.logger import setup_logging
@@ -61,6 +62,7 @@ def load_config() -> dict[str, str]:
         "monitor_all_channels": os.getenv("CLAUDE_MONITOR_ALL_CHANNELS", "false"),
         "append_system_prompt": os.getenv("APPEND_SYSTEM_PROMPT", ""),
         "claude_effort": os.getenv("CLAUDE_EFFORT", ""),
+        "backend": os.getenv("CCDB_BACKEND", "claude"),
     }
 
 
@@ -83,9 +85,12 @@ async def main() -> None:
     if config["allowed_tools"]:
         allowed_tools = [t.strip() for t in config["allowed_tools"].split(",") if t.strip()] or None
 
-    # Create runner
-    runner = ClaudeRunner(
-        command=config["claude_command"],
+    # Create runner via backend factory (CCDB_BACKEND=claude|codex)
+    backend_name = config["backend"]
+    default_command = "codex" if backend_name == "codex" else "claude"
+    runner = create_backend(
+        backend=backend_name,
+        command=config["claude_command"] or default_command,
         model=config["claude_model"],
         permission_mode=config["claude_permission_mode"],
         working_dir=config["claude_working_dir"] or None,

--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -14,7 +14,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from discord.ext.commands import Bot
 
-    from .claude.runner import ClaudeRunner
+    from claude_code_core.backend import SessionBackend
+
     from .database.lounge_repo import LoungeRepository
     from .database.repository import SessionRepository
     from .database.resume_repo import PendingResumeRepository
@@ -64,7 +65,7 @@ class BridgeComponents:
 
 async def setup_bridge(
     bot: Bot,
-    runner: ClaudeRunner,
+    runner: SessionBackend,
     *,
     api_server: ApiServer | None = None,
     session_db_path: str = "data/sessions.db",
@@ -98,7 +99,7 @@ async def setup_bridge(
 
     Args:
         bot: Discord bot instance.
-        runner: ClaudeRunner for Claude CLI invocation.
+        runner: SessionBackend (ClaudeRunner, CodexRunner, etc.).
         api_server: Optional ApiServer to auto-wire repos into.  Also sets
                     runner.api_port so CCDB_API_URL is available to Claude.
         session_db_path: Path for session SQLite DB.

--- a/scripts/pre-start.sh
+++ b/scripts/pre-start.sh
@@ -71,8 +71,10 @@ echo "[pre-start] Code at: ${COMMIT}" >&2
 for SITE_PKG in "$CCDB_HOME"/.venv/lib/python*/site-packages; do
     # Install the import hook module
     cat > "$SITE_PKG/_ccdb_dev_hook.py" << 'HOOK_EOF'
-"""Dev worktree import hook — redirects claude_discord to ~/.ccdb-dev-worktree."""
+"""Dev worktree import hook — redirects claude_discord & claude_code_core to ~/.ccdb-dev-worktree."""
 import sys, os, importlib.util
+
+_TARGETS = ("claude_discord", "claude_code_core")
 
 def _install():
     dev_file = os.path.expanduser("~/.ccdb-dev-worktree")
@@ -80,11 +82,12 @@ def _install():
         return
     with open(dev_file) as f:
         worktree = f.read().strip()
-    if not os.path.isdir(os.path.join(worktree, "claude_discord")):
+    if not any(os.path.isdir(os.path.join(worktree, t)) for t in _TARGETS):
         return
     class _Finder:
         def find_spec(self, fullname, path, target=None):
-            if not (fullname == "claude_discord" or fullname.startswith("claude_discord.")):
+            root = fullname.split(".", 1)[0]
+            if root not in _TARGETS:
                 return None
             parts = fullname.split(".")
             pkg = os.path.join(worktree, *parts)

--- a/tests/test_backend_protocol.py
+++ b/tests/test_backend_protocol.py
@@ -1,0 +1,83 @@
+"""Tests for the SessionBackend protocol and backend factory."""
+
+from __future__ import annotations
+
+import pytest
+
+from claude_code_core.backend import SessionBackend, create_backend
+from claude_code_core.runner import ClaudeRunner
+
+
+class TestSessionBackendProtocol:
+    """Verify that ClaudeRunner satisfies the SessionBackend protocol."""
+
+    def test_claude_runner_is_session_backend(self) -> None:
+        runner = ClaudeRunner(command="claude", model="sonnet")
+        assert isinstance(runner, SessionBackend)
+
+    def test_protocol_has_run_method(self) -> None:
+        assert hasattr(SessionBackend, "run")
+
+    def test_protocol_has_clone_method(self) -> None:
+        assert hasattr(SessionBackend, "clone")
+
+    def test_protocol_has_interrupt_method(self) -> None:
+        assert hasattr(SessionBackend, "interrupt")
+
+    def test_protocol_has_kill_method(self) -> None:
+        assert hasattr(SessionBackend, "kill")
+
+    def test_protocol_has_inject_tool_result_method(self) -> None:
+        assert hasattr(SessionBackend, "inject_tool_result")
+
+    def test_protocol_has_required_properties(self) -> None:
+        runner = ClaudeRunner(command="claude", model="sonnet")
+        assert hasattr(runner, "model")
+        assert hasattr(runner, "working_dir")
+        assert hasattr(runner, "permission_mode")
+        assert hasattr(runner, "images")
+
+
+class TestCreateBackend:
+    """Tests for the backend factory function."""
+
+    def test_default_creates_claude_runner(self) -> None:
+        backend = create_backend(model="sonnet")
+        assert isinstance(backend, ClaudeRunner)
+
+    def test_claude_backend_explicit(self) -> None:
+        backend = create_backend(backend="claude", model="sonnet")
+        assert isinstance(backend, ClaudeRunner)
+
+    def test_codex_backend(self) -> None:
+        from claude_code_core.codex_runner import CodexRunner
+
+        backend = create_backend(backend="codex", model="o4-mini")
+        assert isinstance(backend, CodexRunner)
+
+    def test_unknown_backend_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown backend"):
+            create_backend(backend="unknown", model="sonnet")
+
+    def test_factory_passes_common_params(self) -> None:
+        backend = create_backend(
+            backend="claude",
+            model="opus",
+            working_dir="/tmp/test",
+            timeout_seconds=600,
+        )
+        assert backend.model == "opus"
+        assert backend.working_dir == "/tmp/test"
+        assert backend.timeout_seconds == 600
+
+    def test_codex_factory_params(self) -> None:
+        from claude_code_core.codex_runner import CodexRunner
+
+        backend = create_backend(
+            backend="codex",
+            model="o4-mini",
+            working_dir="/tmp/test",
+        )
+        assert isinstance(backend, CodexRunner)
+        assert backend.model == "o4-mini"
+        assert backend.working_dir == "/tmp/test"

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -1500,3 +1500,139 @@ class TestCompactCommand:
         call_kwargs = cog._run_claude.call_args.kwargs
         assert call_kwargs["prompt"] == "/compact"
         assert call_kwargs["session_id"] == "abc-123"
+
+
+class TestGoalCommand:
+    """Tests for /goal slash command."""
+
+    @pytest.mark.asyncio
+    async def test_goal_outside_thread_sends_ephemeral(self) -> None:
+        cog = _make_cog()
+        interaction = _make_channel_interaction()
+
+        await cog.goal_session.callback(cog, interaction, condition=None)
+
+        interaction.response.send_message.assert_called_once()
+        call_kwargs = interaction.response.send_message.call_args.kwargs
+        assert call_kwargs.get("ephemeral") is True
+
+    @pytest.mark.asyncio
+    async def test_goal_no_session_sends_ephemeral(self) -> None:
+        cog = _make_cog()
+        interaction = _make_thread_interaction(thread_id=12345)
+        cog.repo.get = AsyncMock(return_value=None)
+
+        await cog.goal_session.callback(cog, interaction, condition="all tests pass")
+
+        interaction.response.send_message.assert_called_once()
+        call_kwargs = interaction.response.send_message.call_args.kwargs
+        assert call_kwargs.get("ephemeral") is True
+
+    @pytest.mark.asyncio
+    async def test_goal_while_running_sends_ephemeral(self) -> None:
+        cog = _make_cog()
+        thread_id = 12345
+        interaction = _make_thread_interaction(thread_id=thread_id)
+        record = MagicMock()
+        record.session_id = "abc-123"
+        record.working_dir = None
+        cog.repo.get = AsyncMock(return_value=record)
+        cog._active_runners[thread_id] = MagicMock()
+
+        await cog.goal_session.callback(cog, interaction, condition="all tests pass")
+
+        interaction.response.send_message.assert_called_once()
+        call_kwargs = interaction.response.send_message.call_args.kwargs
+        assert call_kwargs.get("ephemeral") is True
+        assert "running" in interaction.response.send_message.call_args.args[0].lower()
+
+    @pytest.mark.asyncio
+    async def test_goal_with_condition_sends_goal_prompt(self) -> None:
+        cog = _make_cog()
+        thread_id = 12345
+        interaction = _make_thread_interaction(thread_id=thread_id)
+        record = MagicMock()
+        record.session_id = "abc-123"
+        record.working_dir = "/tmp/test"
+        cog.repo.get = AsyncMock(return_value=record)
+
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+
+        cog._run_claude = AsyncMock()
+
+        await cog.goal_session.callback(cog, interaction, condition="all tests pass")
+
+        interaction.response.defer.assert_called_once()
+        cog._run_claude.assert_called_once()
+        call_kwargs = cog._run_claude.call_args.kwargs
+        assert call_kwargs["prompt"] == "/goal all tests pass"
+        assert call_kwargs["session_id"] == "abc-123"
+        assert call_kwargs["working_dir_override"] == "/tmp/test"
+
+    @pytest.mark.asyncio
+    async def test_goal_no_condition_sends_status_check(self) -> None:
+        cog = _make_cog()
+        thread_id = 12345
+        interaction = _make_thread_interaction(thread_id=thread_id)
+        record = MagicMock()
+        record.session_id = "abc-123"
+        record.working_dir = None
+        cog.repo.get = AsyncMock(return_value=record)
+
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+
+        cog._run_claude = AsyncMock()
+
+        await cog.goal_session.callback(cog, interaction, condition=None)
+
+        cog._run_claude.assert_called_once()
+        call_kwargs = cog._run_claude.call_args.kwargs
+        assert call_kwargs["prompt"] == "/goal"
+
+    @pytest.mark.asyncio
+    async def test_goal_clear_sends_clear_prompt(self) -> None:
+        cog = _make_cog()
+        thread_id = 12345
+        interaction = _make_thread_interaction(thread_id=thread_id)
+        record = MagicMock()
+        record.session_id = "abc-123"
+        record.working_dir = None
+        cog.repo.get = AsyncMock(return_value=record)
+
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+
+        cog._run_claude = AsyncMock()
+
+        await cog.goal_session.callback(cog, interaction, condition="clear")
+
+        cog._run_claude.assert_called_once()
+        call_kwargs = cog._run_claude.call_args.kwargs
+        assert call_kwargs["prompt"] == "/goal clear"
+
+    @pytest.mark.asyncio
+    async def test_goal_seed_message_emoji(self) -> None:
+        cog = _make_cog()
+        thread_id = 12345
+        interaction = _make_thread_interaction(thread_id=thread_id)
+        record = MagicMock()
+        record.session_id = "abc-123"
+        record.working_dir = None
+        cog.repo.get = AsyncMock(return_value=record)
+
+        interaction.response.defer = AsyncMock()
+        seed = MagicMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock(return_value=seed)
+
+        cog._run_claude = AsyncMock()
+
+        await cog.goal_session.callback(cog, interaction, condition="all tests pass")
+
+        send_args = interaction.followup.send.call_args
+        assert "◎" in send_args.args[0] or "goal" in send_args.args[0].lower()

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -1,0 +1,206 @@
+"""Tests for CodexRunner — OpenAI Codex CLI backend."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from claude_code_core.backend import SessionBackend
+from claude_code_core.codex_runner import CodexRunner, parse_codex_line
+from claude_code_core.types import MessageType
+
+
+class TestCodexRunnerIsBackend:
+    """CodexRunner must satisfy the SessionBackend protocol."""
+
+    def test_is_session_backend(self) -> None:
+        runner = CodexRunner(command="codex", model="o4-mini")
+        assert isinstance(runner, SessionBackend)
+
+
+class TestCodexRunnerBuildArgs:
+    """Tests for _build_args() — Codex CLI flag assembly."""
+
+    def test_basic_args(self) -> None:
+        runner = CodexRunner(command="codex", model="o4-mini")
+        args = runner._build_args("hello", session_id=None)
+        assert args[0] == "codex"
+        assert "exec" in args
+        assert "--json" in args
+        assert "--model" in args or "-m" in args
+        assert "o4-mini" in args
+
+    def test_resume_session(self) -> None:
+        runner = CodexRunner(command="codex", model="o4-mini")
+        args = runner._build_args("hello", session_id="0199a213-81c0-7800-8aa1-bbab2a035a53")
+        assert "resume" in args
+        assert "0199a213-81c0-7800-8aa1-bbab2a035a53" in args
+
+    def test_approval_mode_mapping(self) -> None:
+        runner = CodexRunner(command="codex", model="o4-mini", permission_mode="acceptEdits")
+        args = runner._build_args("hello", session_id=None)
+        assert any(a in args for a in ["--ask-for-approval", "-a"])
+
+    def test_dangerously_skip_permissions(self) -> None:
+        runner = CodexRunner(command="codex", model="o4-mini", dangerously_skip_permissions=True)
+        args = runner._build_args("hello", session_id=None)
+        assert "--yolo" in args or "--dangerously-bypass-approvals-and-sandbox" in args
+
+    def test_working_dir_flag(self) -> None:
+        runner = CodexRunner(command="codex", model="o4-mini", working_dir="/tmp/work")
+        args = runner._build_args("hello", session_id=None)
+        assert "--cd" in args or "-C" in args
+        assert "/tmp/work" in args
+
+    def test_prompt_is_last_arg(self) -> None:
+        runner = CodexRunner(command="codex", model="o4-mini")
+        args = runner._build_args("hello world", session_id=None)
+        assert args[-1] == "hello world"
+
+    def test_session_id_validation(self) -> None:
+        runner = CodexRunner(command="codex", model="o4-mini")
+        with pytest.raises(ValueError, match="Invalid session_id"):
+            runner._build_args("hello", session_id="'; DROP TABLE --")
+
+
+class TestCodexRunnerClone:
+    """Tests for clone() — creating a new runner with overrides."""
+
+    def test_clone_preserves_config(self) -> None:
+        runner = CodexRunner(command="codex", model="o4-mini", working_dir="/tmp")
+        cloned = runner.clone()
+        assert isinstance(cloned, CodexRunner)
+        assert cloned.model == "o4-mini"
+        assert cloned.working_dir == "/tmp"
+
+    def test_clone_overrides_model(self) -> None:
+        runner = CodexRunner(command="codex", model="o4-mini")
+        cloned = runner.clone(model="gpt-5.4")
+        assert cloned.model == "gpt-5.4"
+
+    def test_clone_overrides_working_dir(self) -> None:
+        runner = CodexRunner(command="codex", model="o4-mini", working_dir="/old")
+        cloned = runner.clone(working_dir="/new")
+        assert cloned.working_dir == "/new"
+
+    def test_clone_returns_codex_runner_not_claude(self) -> None:
+        runner = CodexRunner(command="codex", model="o4-mini")
+        cloned = runner.clone(model="gpt-5.4")
+        assert type(cloned) is CodexRunner
+
+
+class TestParseCodexLine:
+    """Tests for parse_codex_line() — Codex JSONL → StreamEvent."""
+
+    def test_thread_started(self) -> None:
+        line = json.dumps({"type": "thread.started", "thread_id": "abc-123"})
+        event = parse_codex_line(line)
+        assert event is not None
+        assert event.message_type == MessageType.SYSTEM
+        assert event.session_id == "abc-123"
+
+    def test_item_completed_agent_message(self) -> None:
+        line = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_1",
+                    "type": "agent_message",
+                    "text": "Hello, world!",
+                },
+            }
+        )
+        event = parse_codex_line(line)
+        assert event is not None
+        assert event.message_type == MessageType.ASSISTANT
+        assert event.text == "Hello, world!"
+
+    def test_item_started_command_execution(self) -> None:
+        line = json.dumps(
+            {
+                "type": "item.started",
+                "item": {
+                    "id": "item_2",
+                    "type": "command_execution",
+                    "command": "ls -la",
+                    "status": "in_progress",
+                },
+            }
+        )
+        event = parse_codex_line(line)
+        assert event is not None
+        assert event.tool_use is not None
+        assert event.tool_use.tool_name == "Bash"
+        assert event.tool_use.tool_input.get("command") == "ls -la"
+
+    def test_turn_completed_with_usage(self) -> None:
+        line = json.dumps(
+            {
+                "type": "turn.completed",
+                "usage": {
+                    "input_tokens": 1000,
+                    "output_tokens": 200,
+                    "cached_input_tokens": 500,
+                    "reasoning_output_tokens": 50,
+                },
+            }
+        )
+        event = parse_codex_line(line)
+        assert event is not None
+        assert event.input_tokens == 1000
+        assert event.output_tokens == 200
+        assert event.cache_read_tokens == 500
+
+    def test_item_completed_command_execution(self) -> None:
+        line = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_2",
+                    "type": "command_execution",
+                    "command": "ls -la",
+                    "output": "total 42\ndrwxr-xr-x ...",
+                },
+            }
+        )
+        event = parse_codex_line(line)
+        assert event is not None
+        assert event.tool_result_content is not None
+
+    def test_invalid_json_returns_none(self) -> None:
+        event = parse_codex_line("not valid json")
+        assert event is None
+
+    def test_empty_line_returns_none(self) -> None:
+        event = parse_codex_line("")
+        assert event is None
+
+    def test_item_completed_file_changes(self) -> None:
+        line = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_3",
+                    "type": "file_changes",
+                    "text": "Modified src/main.py",
+                },
+            }
+        )
+        event = parse_codex_line(line)
+        assert event is not None
+        assert event.tool_use is not None
+        assert event.tool_use.tool_name == "Edit"
+
+    def test_turn_started(self) -> None:
+        line = json.dumps({"type": "turn.started"})
+        event = parse_codex_line(line)
+        assert event is not None
+        assert event.message_type == MessageType.SYSTEM
+
+    def test_error_event(self) -> None:
+        line = json.dumps({"type": "error", "message": "something broke"})
+        event = parse_codex_line(line)
+        assert event is not None
+        assert event.error is not None
+        assert event.is_complete is True

--- a/tests/test_main_backend.py
+++ b/tests/test_main_backend.py
@@ -1,0 +1,33 @@
+"""Tests for CCDB_BACKEND env var based backend selection in main.py."""
+
+from __future__ import annotations
+
+from claude_code_core.backend import create_backend
+from claude_code_core.codex_runner import CodexRunner
+from claude_code_core.runner import ClaudeRunner
+
+
+class TestCreateBackendFromEnv:
+    """Verify that create_backend() produces the right runner type."""
+
+    def test_default_is_claude(self) -> None:
+        backend = create_backend(model="sonnet")
+        assert isinstance(backend, ClaudeRunner)
+
+    def test_codex_backend(self) -> None:
+        backend = create_backend(backend="codex", model="o4-mini")
+        assert isinstance(backend, CodexRunner)
+
+    def test_claude_backend_explicit(self) -> None:
+        backend = create_backend(backend="claude", model="sonnet")
+        assert isinstance(backend, ClaudeRunner)
+
+    def test_codex_passes_working_dir(self) -> None:
+        backend = create_backend(backend="codex", model="o4-mini", working_dir="/tmp")
+        assert isinstance(backend, CodexRunner)
+        assert backend.working_dir == "/tmp"
+
+    def test_claude_passes_working_dir(self) -> None:
+        backend = create_backend(backend="claude", model="sonnet", working_dir="/tmp")
+        assert isinstance(backend, ClaudeRunner)
+        assert backend.working_dir == "/tmp"

--- a/tests/test_main_backend.py
+++ b/tests/test_main_backend.py
@@ -1,6 +1,8 @@
-"""Tests for CCDB_BACKEND env var based backend selection in main.py."""
+"""Tests for CCDB_BACKEND env var based backend selection and env var renaming."""
 
 from __future__ import annotations
+
+from unittest.mock import patch
 
 from claude_code_core.backend import create_backend
 from claude_code_core.codex_runner import CodexRunner
@@ -31,3 +33,52 @@ class TestCreateBackendFromEnv:
         backend = create_backend(backend="claude", model="sonnet", working_dir="/tmp")
         assert isinstance(backend, ClaudeRunner)
         assert backend.working_dir == "/tmp"
+
+
+class TestEnvVarRename:
+    """Verify CCDB_* env vars with CLAUDE_* fallbacks in load_config()."""
+
+    _REQUIRED = {"DISCORD_BOT_TOKEN": "fake-token", "DISCORD_CHANNEL_ID": "12345"}
+
+    def _load(self, env: dict[str, str]) -> dict[str, str]:
+        from claude_discord.main import load_config
+
+        merged = {**self._REQUIRED, **env}
+        with patch.dict("os.environ", merged, clear=True):
+            return load_config()
+
+    def test_ccdb_model_takes_precedence(self) -> None:
+        config = self._load({"CCDB_MODEL": "o4-mini", "CLAUDE_MODEL": "sonnet"})
+        assert config["model"] == "o4-mini"
+
+    def test_claude_model_fallback(self) -> None:
+        config = self._load({"CLAUDE_MODEL": "opus"})
+        assert config["model"] == "opus"
+
+    def test_model_default(self) -> None:
+        config = self._load({})
+        assert config["model"] == "sonnet"
+
+    def test_ccdb_command_takes_precedence(self) -> None:
+        config = self._load({"CCDB_COMMAND": "codex", "CLAUDE_COMMAND": "claude"})
+        assert config["command"] == "codex"
+
+    def test_claude_command_fallback(self) -> None:
+        config = self._load({"CLAUDE_COMMAND": "/usr/bin/claude"})
+        assert config["command"] == "/usr/bin/claude"
+
+    def test_ccdb_permission_mode_takes_precedence(self) -> None:
+        config = self._load({"CCDB_PERMISSION_MODE": "auto", "CLAUDE_PERMISSION_MODE": "plan"})
+        assert config["permission_mode"] == "auto"
+
+    def test_ccdb_working_dir(self) -> None:
+        config = self._load({"CCDB_WORKING_DIR": "/work"})
+        assert config["working_dir"] == "/work"
+
+    def test_claude_working_dir_fallback(self) -> None:
+        config = self._load({"CLAUDE_WORKING_DIR": "/old"})
+        assert config["working_dir"] == "/old"
+
+    def test_ccdb_backend_env(self) -> None:
+        config = self._load({"CCDB_BACKEND": "codex"})
+        assert config["backend"] == "codex"

--- a/tests/test_main_config.py
+++ b/tests/test_main_config.py
@@ -65,9 +65,11 @@ class TestLoadConfig:
 
         assert config["token"] == "fake-token"
         assert config["channel_id"] == "123456"
-        assert config["claude_command"] == "claude"
-        assert config["claude_model"] == "sonnet"
-        assert config["claude_permission_mode"] == "acceptEdits"
+        # "command" defaults to empty; backend-aware default is picked in main()
+        assert config["command"] == ""
+        assert config["model"] == "sonnet"
+        assert config["permission_mode"] == "acceptEdits"
+        assert config["backend"] == "claude"  # CCDB_BACKEND default
         assert config["max_concurrent"] == "3"
         assert config["timeout"] == "300"
         assert config["custom_cogs_dir"] == ""
@@ -103,12 +105,12 @@ class TestLoadConfig:
         ):
             config = load_config()
 
-        assert config["claude_command"] == "/usr/bin/claude"
-        assert config["claude_model"] == "opus"
-        assert config["claude_working_dir"] == "/home/test"
+        assert config["command"] == "/usr/bin/claude"
+        assert config["model"] == "opus"
+        assert config["working_dir"] == "/home/test"
         assert config["max_concurrent"] == "5"
         assert config["owner_id"] == "999"
-        assert config["claude_channel_ids"] == "111,222,333"
+        assert config["channel_ids"] == "111,222,333"
         assert config["api_host"] == "0.0.0.0"
         assert config["api_port"] == "9000"
         assert config["allowed_tools"] == "Read,Write"

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -368,3 +368,24 @@ async def test_setup_bridge_defaults_max_concurrent_to_3(tmp_path: object) -> No
         if isinstance(call.args[0], ClaudeChatCog)
     )
     assert chat_cog._max_concurrent == 3
+
+
+@pytest.mark.asyncio
+async def test_setup_bridge_accepts_codex_runner(tmp_path: object) -> None:
+    """setup_bridge should accept any SessionBackend, not just ClaudeRunner."""
+    from claude_code_core.codex_runner import CodexRunner
+
+    bot = _make_bot()
+    runner = CodexRunner(command="codex", model="o4-mini")
+
+    result = await setup_bridge(
+        bot,
+        runner,  # type: ignore[arg-type]  # CodexRunner satisfies SessionBackend
+        session_db_path=str(tmp_path / "sessions.db"),  # type: ignore[operator]
+        claude_channel_id=12345,
+        enable_scheduler=False,
+    )
+
+    cog_names = [call.args[0].__class__.__name__ for call in bot.add_cog.call_args_list]
+    assert "ClaudeChatCog" in cog_names
+    assert isinstance(result, BridgeComponents)

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "2.1.38"
+version = "2.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Adds dual-backend support so CCDB can drive either the **Claude** CLI or the **OpenAI Codex** CLI behind the same `SessionBackend` Protocol. Backend selection is controlled by the `CCDB_BACKEND=claude|codex` env var (default: `claude`). All other config env vars are renamed to a unified `CCDB_*` namespace with `CLAUDE_*` fallbacks for backward compatibility.

This PR bundles three commits that together complete the feature:

1. `0482164` — `/goal` slash command for autonomous goal-driven sessions
2. `882930f` — `SessionBackend` protocol + `CodexRunner` + `create_backend()` factory
3. `4822732` — `load_config()` refactor to `CCDB_*` namespace + dev hook extension for `claude_code_core` import redirection

## Why

- One Discord bot, two CLI backends — pick per deployment via env
- Existing `CLAUDE_*` env vars continue to work; users opt in to the new namespace at their own pace
- Dev workflow on this branch needs `claude_code_core/` to be served from the active worktree (because `backend.py` and `codex_runner.py` are new files only on this branch). Without the dev hook extension, `from claude_code_core.backend import create_backend` resolves to the older copy in main and fails.

## Test plan

- [x] `pytest tests/test_main_backend.py` — 14/14 pass (5 backend factory + 9 env var rename)
- [x] `discord-bot.service` restart on moviegen — starts cleanly, no `ImportError`, `ClaudeCode#5230` logs in, `/api/health` returns 200
- [x] codex CLI standalone (`codex exec`) — works with default model `gpt-5.4`, returns expected reply
- [x] Bot chain `create_backend(backend=\"codex\") → CodexRunner → codex CLI` — 4-event stream, completes with input/output token counts, EXIT 0
- [ ] (post-merge) Bump version, release pipeline
- [ ] (manual) Set `CCDB_BACKEND=codex` in `.env` and verify a real Discord conversation flows through the Codex path

🤖 Generated with [Claude Code](https://claude.com/claude-code)