### PR TITLE
[docs-sync] Add SessionBackend/CodexRunner, CCDB_* env vars, /goal command (English + Japanese)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,8 @@ uv run ruff format claude_discord/
 
 ## Project Structure
 
-- `claude_discord/claude/` — Claude Code CLI interaction (runner, parser, types)
+- `claude_code_core/` — Backend-agnostic core library: `SessionBackend` protocol, `ClaudeRunner`, `CodexRunner`, `create_backend()` factory, parser, types, SQLite models
+- `claude_discord/claude/` — Re-exports from `claude_code_core` for backward compatibility
 - `claude_discord/cogs/` — Discord.py Cogs (chat, skill command, webhook trigger, auto-upgrade)
 - `claude_discord/database/` — SQLite session and notification persistence
 - `claude_discord/discord_ui/` — Discord UI components (status, chunker, embeds)

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ If the bot restarts mid-session, interrupted Claude sessions are automatically r
 #### 🔗 Session Basics
 - **Chat-only mode** — When `CHAT_ONLY_CHANNEL_IDS` includes a channel, only Claude's text responses are shown; tool embeds, thinking blocks, session start/complete embeds, and todo lists are hidden. Permission requests and `AskUserQuestion` are always shown. Ideal for public channels where non-technical users are watching.
 - **Thread = Session** — 1:1 mapping between Discord thread and Claude Code session
+- **Goal tracking** — `/goal <condition>` sets a completion condition; Claude keeps working until the condition is met. Omit the condition to check status; pass `clear` to cancel
 - **Session persistence** — Resume conversations across messages via `--resume`
 - **Concurrent sessions** — Multiple parallel sessions with configurable limit
 - **Stop without clearing** — `/stop` halts a session while preserving it for resume
@@ -520,11 +521,19 @@ In chat-only mode, permission requests and `AskUserQuestion` prompts are **alway
 |----------|-------------|---------|
 | `DISCORD_BOT_TOKEN` | Your Discord bot token | (required) |
 | `DISCORD_CHANNEL_ID` | Channel ID for Claude chat | (required) |
-| `CLAUDE_COMMAND` | Path or name of the Claude CLI binary. Use to pin a specific version (e.g. `CLAUDE_COMMAND=/usr/local/lib/node_modules/@anthropic-ai/claude-code@2.1.77/cli.js`) — useful to avoid regressions in newer CLI releases. | `claude` |
-| `CLAUDE_MODEL` | Model to use | `sonnet` |
-| `CLAUDE_PERMISSION_MODE` | Permission mode for CLI | `acceptEdits` |
-| `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | Skip all permission checks (use with caution) | `false` |
-| `CLAUDE_WORKING_DIR` | Working directory for Claude | current dir |
+| `CCDB_BACKEND` | CLI backend to use: `claude` (Claude Code CLI) or `codex` (OpenAI Codex CLI) | `claude` |
+| `CCDB_COMMAND` | Path or name of the CLI binary (overrides `CLAUDE_COMMAND`). Useful to pin a specific version. | _(auto: `claude` or `codex`)_ |
+| `CCDB_MODEL` | Model to use (overrides `CLAUDE_MODEL`) | `sonnet` |
+| `CCDB_PERMISSION_MODE` | Permission mode for CLI (overrides `CLAUDE_PERMISSION_MODE`) | `acceptEdits` |
+| `CCDB_DANGEROUSLY_SKIP_PERMISSIONS` | Skip all permission checks — overrides `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | `false` |
+| `CCDB_WORKING_DIR` | Working directory for CLI (overrides `CLAUDE_WORKING_DIR`) | current dir |
+| `CCDB_ALLOWED_TOOLS` | Comma-separated list of allowed tools (overrides `CLAUDE_ALLOWED_TOOLS`) | (optional) |
+| `CCDB_CHANNEL_IDS` | Additional channel IDs, comma-separated (overrides `CLAUDE_CHANNEL_IDS`) | (optional) |
+| `CLAUDE_COMMAND` | Path or name of the Claude CLI binary (legacy name — prefer `CCDB_COMMAND`). Use to pin a specific version (e.g. `CLAUDE_COMMAND=/usr/local/lib/node_modules/@anthropic-ai/claude-code@2.1.77/cli.js`) — useful to avoid regressions in newer CLI releases. | `claude` |
+| `CLAUDE_MODEL` | Model to use (legacy — prefer `CCDB_MODEL`) | `sonnet` |
+| `CLAUDE_PERMISSION_MODE` | Permission mode for CLI (legacy — prefer `CCDB_PERMISSION_MODE`) | `acceptEdits` |
+| `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | Skip all permission checks (legacy — prefer `CCDB_DANGEROUSLY_SKIP_PERMISSIONS`) | `false` |
+| `CLAUDE_WORKING_DIR` | Working directory for Claude (legacy — prefer `CCDB_WORKING_DIR`) | current dir |
 | `MAX_CONCURRENT_SESSIONS` | Max parallel Claude CLI sessions across all code paths (chat, skills, scheduler, webhooks) | `3` |
 | `SESSION_TIMEOUT_SECONDS` | Session inactivity timeout | `300` |
 | `DISCORD_OWNER_ID` | User ID to @-mention when Claude needs input | (optional) |
@@ -535,8 +544,8 @@ In chat-only mode, permission requests and `AskUserQuestion` prompts are **alway
 | `WORKTREE_BASE_DIR` | Base directory to scan for session worktrees (enables automatic cleanup) | (optional) |
 | `CLI_SESSIONS_PATH` | Path to `~/.claude/projects` for CLI session discovery (enables `/sync-sessions`) | (optional) |
 | `CUSTOM_COGS_DIR` | Directory containing custom Cog files to load at startup (see [Custom Cogs](#custom-cogs-extend-without-forking)) | (optional) |
-| `CLAUDE_ALLOWED_TOOLS` | Comma-separated list of allowed tools for Claude CLI | (optional) |
-| `CLAUDE_CHANNEL_IDS` | Additional channel IDs (comma-separated) for multi-channel setup | (optional) |
+| `CLAUDE_ALLOWED_TOOLS` | Comma-separated list of allowed tools for Claude CLI (legacy — prefer `CCDB_ALLOWED_TOOLS`) | (optional) |
+| `CLAUDE_CHANNEL_IDS` | Additional channel IDs (comma-separated) for multi-channel setup (legacy — prefer `CCDB_CHANNEL_IDS`) | (optional) |
 | `THREAD_INBOX_ENABLED` | Enable the persistent thread inbox (classifies sessions as `waiting`/`done`/`ambiguous` via `claude -p`; shown in thread dashboard) | `false` |
 | `THREAD_AUTO_RENAME` | Auto-rename new thread titles using Claude AI — generates a short, descriptive title from the first user message via a background `claude -p` call (never delays session start) | `false` |
 | `CCDB_CLI_ENV_FILE` | Path to a `KEY=VALUE` file whose variables are merged into the CLI subprocess environment on every invocation. Changes take effect immediately without restarting the bot. Useful for temporary API routing (e.g., Azure Foundry) | (optional) |
@@ -812,6 +821,16 @@ curl -X POST http://localhost:8080/api/tasks \
 ## Architecture
 
 ```
+claude_code_core/          # Shared core library (backend-agnostic)
+  backend.py               # SessionBackend protocol + create_backend() factory
+  codex_runner.py          # OpenAI Codex CLI backend
+  runner.py                # Claude CLI subprocess manager
+  parser.py                # stream-json event parser
+  types.py                 # Type definitions for SDK messages
+  models.py                # SQLite schema
+  session_repo.py          # Session CRUD
+  lounge_repo.py           # AI Lounge message CRUD
+  rewind.py                # Session rewind helpers
 claude_discord/
   main.py                  # Standalone entry point (setup_bridge + custom cog loader)
   cli.py                   # CLI entry point (ccdb setup/start commands)
@@ -836,9 +855,9 @@ claude_discord/
     run_config.py          # RunConfig dataclass — bundles all CLI execution params
     _run_helper.py         # Thin orchestration layer (run_claude_with_config + shim)
   claude/
-    runner.py              # Claude CLI subprocess manager
-    parser.py              # stream-json event parser
-    types.py               # Type definitions for SDK messages
+    runner.py              # Re-exports ClaudeRunner from claude_code_core
+    parser.py              # Re-exports parse_line from claude_code_core
+    types.py               # Re-exports type definitions from claude_code_core
   database/
     models.py              # SQLite schema
     repository.py          # Session CRUD
@@ -896,7 +915,7 @@ examples/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-1300+ tests covering parser, chunker, repository, runner, streaming, webhook triggers, auto-upgrade (including `/upgrade` slash command, thread-invocation, and approval button), REST API, AskUserQuestion UI, thread dashboard, scheduled tasks, session sync, AI Lounge, startup resume, model switching, compact detection, TodoWrite progress embeds, custom Cog loader, permission/elicitation/plan-mode event parsing, thread inbox classification, and per-thread lock behavior.
+1365+ tests covering parser, chunker, repository, runner, streaming, webhook triggers, auto-upgrade (including `/upgrade` slash command, thread-invocation, and approval button), REST API, AskUserQuestion UI, thread dashboard, scheduled tasks, session sync, AI Lounge, startup resume, model switching, compact detection, TodoWrite progress embeds, custom Cog loader, permission/elicitation/plan-mode event parsing, thread inbox classification, per-thread lock behavior, SessionBackend protocol, CodexRunner, and backend factory.
 
 ---
 

--- a/docs/ja/CONTRIBUTING.md
+++ b/docs/ja/CONTRIBUTING.md
@@ -73,7 +73,8 @@ uv run ruff format claude_discord/
 
 ## プロジェクト構造
 
-- `claude_discord/claude/` — Claude Code CLI との連携（runner、parser、types）
+- `claude_code_core/` — バックエンド非依存コアライブラリ: `SessionBackend` プロトコル、`ClaudeRunner`、`CodexRunner`、`create_backend()` ファクトリー、パーサー、型定義、SQLite モデル
+- `claude_discord/claude/` — `claude_code_core` からの後方互換性のための再エクスポート
 - `claude_discord/cogs/` — Discord.py の Cog（chat、skill コマンド、webhook トリガー、自動アップグレード）
 - `claude_discord/database/` — SQLite セッションおよび通知の永続化
 - `claude_discord/discord_ui/` — Discord UI コンポーネント（status、chunker、embeds）

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -146,6 +146,7 @@ Bot の再起動中にセッションが中断された場合、Bot が再起動
 #### 🔗 セッションの基本
 - **チャットのみモード** — `CHAT_ONLY_CHANNEL_IDS` にチャンネルを設定すると、Claude のテキスト応答のみを表示。ツール embed、思考ブロック、セッション開始/完了 embed、Todo リストはすべて非表示。許可リクエストと `AskUserQuestion` は常に表示。技術的な詳細を見せたくないパブリックチャンネルに最適。
 - **Thread = Session** — Discord スレッドと Claude Code セッションの 1:1 マッピング
+- **ゴール追跡** — `/goal <条件>` で完了条件を設定。Claude は条件を満たすまで継続して作業します。条件を省略するとステータス確認、`clear` を渡すとキャンセル
 - **セッション永続化** — `--resume` で複数メッセージをまたいだ会話を継続
 - **並行セッション** — 設定可能な上限での複数並行セッション
 - **削除せず停止** — `/stop` でセッションを保持したまま停止し、リジューム可能
@@ -521,11 +522,19 @@ CHAT_ONLY_CHANNEL_IDS=444,555
 |--------|------|-----------|
 | `DISCORD_BOT_TOKEN` | Discord Bot トークン | （必須） |
 | `DISCORD_CHANNEL_ID` | Claude チャット用チャンネル ID | （必須） |
-| `CLAUDE_COMMAND` | Claude CLI バイナリのパスまたは名前。特定バージョンを固定する場合に使用（例: `CLAUDE_COMMAND=/usr/local/lib/node_modules/@anthropic-ai/claude-code@2.1.77/cli.js`）— 新バージョンのリグレッション回避に便利。 | `claude` |
-| `CLAUDE_MODEL` | 使用するモデル | `sonnet` |
-| `CLAUDE_PERMISSION_MODE` | CLI のパーミッションモード | `auto` |
-| `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | 全パーミッションチェックをスキップ（注意して使用） | `false` |
-| `CLAUDE_WORKING_DIR` | Claude の作業ディレクトリ | カレントディレクトリ |
+| `CCDB_BACKEND` | 使用する CLI バックエンド: `claude`（Claude Code CLI）または `codex`（OpenAI Codex CLI） | `claude` |
+| `CCDB_COMMAND` | CLI バイナリのパスまたは名前（`CLAUDE_COMMAND` より優先）。特定バージョンを固定する場合に使用。 | _（自動: `claude` or `codex`）_ |
+| `CCDB_MODEL` | 使用するモデル（`CLAUDE_MODEL` より優先） | `sonnet` |
+| `CCDB_PERMISSION_MODE` | CLI のパーミッションモード（`CLAUDE_PERMISSION_MODE` より優先） | `acceptEdits` |
+| `CCDB_DANGEROUSLY_SKIP_PERMISSIONS` | 全パーミッションチェックをスキップ（`CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` より優先） | `false` |
+| `CCDB_WORKING_DIR` | CLI の作業ディレクトリ（`CLAUDE_WORKING_DIR` より優先） | カレントディレクトリ |
+| `CCDB_ALLOWED_TOOLS` | 許可するツールのカンマ区切りリスト（`CLAUDE_ALLOWED_TOOLS` より優先） | （オプション） |
+| `CCDB_CHANNEL_IDS` | マルチチャンネル設定用の追加チャンネル ID（`CLAUDE_CHANNEL_IDS` より優先） | （オプション） |
+| `CLAUDE_COMMAND` | Claude CLI バイナリのパスまたは名前（旧名 — `CCDB_COMMAND` を推奨）。特定バージョンを固定する場合に使用（例: `CLAUDE_COMMAND=/usr/local/lib/node_modules/@anthropic-ai/claude-code@2.1.77/cli.js`）— 新バージョンのリグレッション回避に便利。 | `claude` |
+| `CLAUDE_MODEL` | 使用するモデル（旧名 — `CCDB_MODEL` を推奨） | `sonnet` |
+| `CLAUDE_PERMISSION_MODE` | CLI のパーミッションモード（旧名 — `CCDB_PERMISSION_MODE` を推奨） | `auto` |
+| `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | 全パーミッションチェックをスキップ（旧名 — `CCDB_DANGEROUSLY_SKIP_PERMISSIONS` を推奨） | `false` |
+| `CLAUDE_WORKING_DIR` | Claude の作業ディレクトリ（旧名 — `CCDB_WORKING_DIR` を推奨） | カレントディレクトリ |
 | `MAX_CONCURRENT_SESSIONS` | 最大並行 Claude CLI セッション数（チャット・スキル・スケジューラ・Webhook の全パスに適用） | `3` |
 | `SESSION_TIMEOUT_SECONDS` | セッション非アクティブタイムアウト | `300` |
 | `DISCORD_OWNER_ID` | Claude が入力待ちのとき @mention する Discord ユーザー ID | （オプション） |
@@ -536,8 +545,8 @@ CHAT_ONLY_CHANNEL_IDS=444,555
 | `WORKTREE_BASE_DIR` | セッション Worktree のスキャン対象ディレクトリ（自動クリーンアップを有効化） | （オプション） |
 | `CLI_SESSIONS_PATH` | CLI セッション検出用のパス（`~/.claude/projects`）。`/sync-sessions` の有効化に必要 | （オプション） |
 | `CUSTOM_COGS_DIR` | 起動時に読み込むカスタム Cog ファイルを含むディレクトリ（[カスタム Cog](#カスタム-cogフォーク不要で機能拡張) 参照） | （オプション） |
-| `CLAUDE_ALLOWED_TOOLS` | Claude CLI に許可するツールのカンマ区切りリスト | （オプション） |
-| `CLAUDE_CHANNEL_IDS` | マルチチャンネル設定用の追加チャンネル ID（カンマ区切り） | （オプション） |
+| `CLAUDE_ALLOWED_TOOLS` | Claude CLI に許可するツールのカンマ区切りリスト（旧名 — `CCDB_ALLOWED_TOOLS` を推奨） | （オプション） |
+| `CLAUDE_CHANNEL_IDS` | マルチチャンネル設定用の追加チャンネル ID（旧名 — `CCDB_CHANNEL_IDS` を推奨） | （オプション） |
 | `THREAD_INBOX_ENABLED` | 永続スレッドインボックスを有効化（`claude -p` でセッションを `waiting`/`done`/`ambiguous` に分類し、スレッドダッシュボードに表示） | `false` |
 | `THREAD_AUTO_RENAME` | 新しいスレッドのタイトルを Claude AI で自動リネーム — 最初のユーザーメッセージをもとにバックグラウンドの `claude -p` 呼び出しで短く分かりやすいタイトルを生成（セッション開始を遅延させない） | `false` |
 | `CCDB_CLI_ENV_FILE` | CLI サブプロセス起動時に毎回環境変数へマージする `KEY=VALUE` ファイルのパス。Bot を再起動せずに即座に反映される。一時的な API ルーティング（Azure Foundry への切り替えなど）に便利 | （オプション） |
@@ -813,6 +822,16 @@ curl -X POST http://localhost:8080/api/tasks \
 ## アーキテクチャ
 
 ```
+claude_code_core/          # バックエンド非依存のコアライブラリ
+  backend.py               # SessionBackend プロトコル + create_backend() ファクトリー
+  codex_runner.py          # OpenAI Codex CLI バックエンド
+  runner.py                # Claude CLI subprocess マネージャー
+  parser.py                # stream-json イベントパーサー
+  types.py                 # SDK メッセージの型定義
+  models.py                # SQLite スキーマ
+  session_repo.py          # セッション CRUD
+  lounge_repo.py           # AI Lounge メッセージ CRUD
+  rewind.py                # セッションリワインドヘルパー
 claude_discord/
   main.py                  # スタンドアロンエントリーポイント（setup_bridge + カスタム Cog ローダー）
   cli.py                   # CLI エントリーポイント（ccdb setup/start コマンド）
@@ -837,9 +856,9 @@ claude_discord/
     run_config.py          # RunConfig データクラス — CLI 実行パラメーターをまとめる
     _run_helper.py         # 薄いオーケストレーション層（run_claude_with_config + shim）
   claude/
-    runner.py              # Claude CLI subprocess マネージャー
-    parser.py              # stream-json イベントパーサー
-    types.py               # SDK メッセージの型定義
+    runner.py              # claude_code_core からの ClaudeRunner 再エクスポート
+    parser.py              # claude_code_core からの parse_line 再エクスポート
+    types.py               # claude_code_core からの型定義再エクスポート
   database/
     models.py              # SQLite スキーマ
     repository.py          # セッション CRUD
@@ -897,7 +916,7 @@ examples/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-1300 件以上のテストがパーサー、チャンカー、リポジトリ、ランナー、ストリーミング、Webhook トリガー、自動アップグレード（`/upgrade` スラッシュコマンド、スレッド内実行、承認ボタン含む）、REST API、AskUserQuestion UI、スレッドダッシュボード、スケジュールタスク、セッション同期、AI Lounge、スタートアップリジューム、モデル切り替え、コンパクト検出、TodoWrite 進捗 embed、カスタム Cog ローダー、許可／Elicitation／Plan Mode イベントパース、スレッドインボックス分類、スレッドごとのロック動作をカバーしています。
+1365 件以上のテストがパーサー、チャンカー、リポジトリ、ランナー、ストリーミング、Webhook トリガー、自動アップグレード（`/upgrade` スラッシュコマンド、スレッド内実行、承認ボタン含む）、REST API、AskUserQuestion UI、スレッドダッシュボード、スケジュールタスク、セッション同期、AI Lounge、スタートアップリジューム、モデル切り替え、コンパクト検出、TodoWrite 進捗 embed、カスタム Cog ローダー、許可／Elicitation／Plan Mode イベントパース、スレッドインボックス分類、スレッドごとのロック動作、SessionBackend プロトコル、CodexRunner、バックエンドファクトリーをカバーしています。
 
 ---
 


### PR DESCRIPTION
## Summary

- **SessionBackend protocol + CodexRunner**: Added `claude_code_core/backend.py` (SessionBackend Protocol + `create_backend()` factory) and `claude_code_core/codex_runner.py` (OpenAI Codex CLI backend). Architecture section updated to show the new `claude_code_core/` package.
- **CCDB_* env vars**: New `CCDB_BACKEND`, `CCDB_MODEL`, `CCDB_COMMAND`, `CCDB_PERMISSION_MODE`, `CCDB_WORKING_DIR`, `CCDB_ALLOWED_TOOLS`, `CCDB_CHANNEL_IDS` env vars added to the configuration table with their `CLAUDE_*` fallback counterparts marked as legacy.
- **`/goal` slash command**: New command added under the Session Basics feature list (English + Japanese).
- **Test count**: Updated from 1300+ to 1365+; coverage description now includes SessionBackend, CodexRunner, and backend factory tests.

## Test plan

- [ ] Verify configuration table is accurate against `claude_discord/main.py:load_config()`
- [ ] Verify architecture diagram matches `ls claude_code_core/` and `ls claude_discord/claude/`
- [ ] Verify `/goal` description matches `claude_discord/cogs/claude_chat.py:goal_session()`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
