### PR TITLE
feat: visible backend indicator + /backend and /model slash commands

### DIFF
--- a/claude_discord/backend_factory.py
+++ b/claude_discord/backend_factory.py
@@ -1,0 +1,92 @@
+"""Factory for SessionBackend instances.
+
+Holds the static configuration needed to construct ClaudeRunner or
+CodexRunner instances on demand. Used by ClaudeChatCog (and friends)
+to spawn a fresh runner per Discord thread whenever the user issues
+a chat message.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from claude_code_core.backend import create_backend
+
+if TYPE_CHECKING:
+    from claude_code_core.backend import SessionBackend
+
+logger = logging.getLogger(__name__)
+
+
+# Sensible per-backend defaults (mirror the CLIs own defaults so users
+# do not need to pick a model just to try a backend).
+DEFAULT_MODEL = {"claude": "sonnet", "codex": "gpt-5.4"}
+DEFAULT_COMMAND = {"claude": "claude", "codex": "codex"}
+
+
+class BackendFactory:
+    """Builds SessionBackend instances on demand from static configuration."""
+
+    def __init__(
+        self,
+        *,
+        claude_command: str,
+        codex_command: str,
+        permission_mode: str,
+        working_dir: str | None,
+        timeout_seconds: int,
+        dangerously_skip_permissions: bool,
+        allowed_tools: list[str] | None,
+        append_system_prompt: str | None,
+        effort: str | None,
+    ) -> None:
+        self.claude_command = claude_command or DEFAULT_COMMAND["claude"]
+        self.codex_command = codex_command or DEFAULT_COMMAND["codex"]
+        self.permission_mode = permission_mode
+        self.working_dir = working_dir
+        self.timeout_seconds = timeout_seconds
+        self.dangerously_skip_permissions = dangerously_skip_permissions
+        self.allowed_tools = allowed_tools
+        self.append_system_prompt = append_system_prompt
+        self.effort = effort
+
+    def command_for(self, backend: str) -> str:
+        if backend == "claude":
+            return self.claude_command
+        if backend == "codex":
+            return self.codex_command
+        raise ValueError(f"Unknown backend: {backend!r}")
+
+    def default_model_for(self, backend: str) -> str:
+        return DEFAULT_MODEL.get(backend, DEFAULT_MODEL["claude"])
+
+    def build(
+        self,
+        *,
+        backend: str,
+        model: str | None = None,
+        thread_id: int | None = None,
+    ) -> SessionBackend:
+        """Construct a fresh SessionBackend for the given backend/model."""
+        chosen_model = model or self.default_model_for(backend)
+        command = self.command_for(backend)
+        kwargs: dict[str, object] = {
+            "command": command,
+            "permission_mode": self.permission_mode,
+            "working_dir": self.working_dir,
+            "timeout_seconds": self.timeout_seconds,
+            "dangerously_skip_permissions": self.dangerously_skip_permissions,
+            "allowed_tools": self.allowed_tools,
+        }
+        if thread_id is not None:
+            kwargs["thread_id"] = thread_id
+        # Only ClaudeRunner accepts these — pass via kwargs and let create_backend
+        # forward them; CodexRunner.__init__ swallows unknown kwargs via **_kwargs.
+        if self.append_system_prompt is not None:
+            kwargs["append_system_prompt"] = self.append_system_prompt
+        if self.effort is not None:
+            kwargs["effort"] = self.effort
+        runner = create_backend(backend=backend, model=chosen_model, **kwargs)
+        logger.debug("Built %s runner (model=%s, thread_id=%s)", backend, chosen_model, thread_id)
+        return runner

--- a/claude_discord/backend_settings.py
+++ b/claude_discord/backend_settings.py
@@ -1,0 +1,112 @@
+"""Persistent, runtime-mutable backend/model selection.
+
+Reads and writes the current backend (claude/codex) and per-backend
+model preference to ``SettingsRepository`` (sqlite key-value store).
+
+Resolution order for any field:
+    1. Thread-scoped override (when ``thread_id`` is given)
+    2. Global setting
+    3. Environment default (passed to constructor)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .database.settings_repo import SettingsRepository
+
+logger = logging.getLogger(__name__)
+
+# Valid backend names. Keep in sync with claude_code_core.backend.create_backend().
+ALL_BACKENDS = ("claude", "codex")
+
+# Settings keys
+BACKEND_GLOBAL = "backend.global"
+BACKEND_THREAD_PREFIX = "backend.thread."  # + thread_id
+MODEL_GLOBAL_PREFIX = "model.global."  # + backend
+MODEL_THREAD_PREFIX = "model.thread."  # + thread_id + "." + backend
+
+
+class BackendSettings:
+    """Thin wrapper around SettingsRepository that resolves backend/model."""
+
+    def __init__(
+        self,
+        repo: SettingsRepository,
+        *,
+        env_backend: str,
+        env_model_for_claude: str,
+        env_model_for_codex: str,
+    ) -> None:
+        self.repo = repo
+        self._env_backend = env_backend if env_backend in ALL_BACKENDS else "claude"
+        self._env_model = {
+            "claude": env_model_for_claude or "",
+            "codex": env_model_for_codex or "",
+        }
+
+    # ── Resolution ──────────────────────────────────────────
+
+    async def current_backend(self, thread_id: int | None = None) -> str:
+        """Return the active backend for the given thread (or globally)."""
+        if thread_id is not None:
+            v = await self.repo.get(f"{BACKEND_THREAD_PREFIX}{thread_id}")
+            if v in ALL_BACKENDS:
+                return v
+        v = await self.repo.get(BACKEND_GLOBAL)
+        if v in ALL_BACKENDS:
+            return v
+        return self._env_backend
+
+    async def current_model(self, backend: str, thread_id: int | None = None) -> str | None:
+        """Return the model for the given backend, or None if no override.
+
+        When ``None`` is returned the caller should fall back to the
+        backend factorys built-in default (e.g. "sonnet" / "gpt-5.4").
+        """
+        if backend not in ALL_BACKENDS:
+            return None
+        if thread_id is not None:
+            v = await self.repo.get(f"{MODEL_THREAD_PREFIX}{thread_id}.{backend}")
+            if v:
+                return v
+        v = await self.repo.get(f"{MODEL_GLOBAL_PREFIX}{backend}")
+        if v:
+            return v
+        return self._env_model.get(backend) or None
+
+    # ── Mutation ────────────────────────────────────────────
+
+    async def set_backend(self, backend: str, *, thread_id: int | None = None) -> None:
+        if backend not in ALL_BACKENDS:
+            raise ValueError(f"unknown backend {backend!r}")
+        if thread_id is not None:
+            await self.repo.set(f"{BACKEND_THREAD_PREFIX}{thread_id}", backend)
+            logger.info("backend set: thread=%d -> %s", thread_id, backend)
+        else:
+            await self.repo.set(BACKEND_GLOBAL, backend)
+            logger.info("backend set: global -> %s", backend)
+
+    async def set_model(self, backend: str, model: str, *, thread_id: int | None = None) -> None:
+        if backend not in ALL_BACKENDS:
+            raise ValueError(f"unknown backend {backend!r}")
+        if not model:
+            raise ValueError("model must not be empty")
+        if thread_id is not None:
+            await self.repo.set(f"{MODEL_THREAD_PREFIX}{thread_id}.{backend}", model)
+            logger.info("model set: thread=%d backend=%s -> %s", thread_id, backend, model)
+        else:
+            await self.repo.set(f"{MODEL_GLOBAL_PREFIX}{backend}", model)
+            logger.info("model set: global backend=%s -> %s", backend, model)
+
+    async def clear_thread_overrides(self, thread_id: int) -> int:
+        """Remove all thread-scoped overrides. Returns count deleted."""
+        deleted = 0
+        if await self.repo.delete(f"{BACKEND_THREAD_PREFIX}{thread_id}"):
+            deleted += 1
+        for b in ALL_BACKENDS:
+            if await self.repo.delete(f"{MODEL_THREAD_PREFIX}{thread_id}.{b}"):
+                deleted += 1
+        return deleted

--- a/claude_discord/cogs/backend_command.py
+++ b/claude_discord/cogs/backend_command.py
@@ -1,0 +1,258 @@
+"""/backend and /model slash commands for runtime backend switching.
+
+Persists the selection to ``SettingsRepository`` via ``BackendSettings``
+and swaps out ``ClaudeChatCog.runner`` so the next session uses the new
+backend immediately. Subsequent sessions inherit the new default.
+
+For now the scope is **global** only (per-thread overrides are persisted
+by ``BackendSettings`` and ``ClaudeChatCog`` will honour them when the
+factory path lands — keeping the public surface stable across that
+follow-up).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import discord
+from discord import app_commands
+from discord.app_commands import Choice
+from discord.ext import commands
+
+from ..backend_settings import ALL_BACKENDS, BackendSettings
+
+if TYPE_CHECKING:
+    from ..backend_factory import BackendFactory
+    from ..cogs.claude_chat import ClaudeChatCog
+
+logger = logging.getLogger(__name__)
+
+
+SCOPE_THREAD = "thread"
+SCOPE_GLOBAL = "global"
+
+
+class BackendCommandCog(commands.Cog):
+    """/backend and /model slash commands."""
+
+    def __init__(
+        self,
+        bot: commands.Bot,
+        *,
+        settings: BackendSettings,
+        factory: BackendFactory,
+        chat_cog: ClaudeChatCog,
+    ) -> None:
+        self.bot = bot
+        self._settings = settings
+        self._factory = factory
+        self._chat_cog = chat_cog
+
+    # ── helpers ────────────────────────────────────────────────────
+
+    def _thread_id_or_none(self, interaction: discord.Interaction) -> int | None:
+        ch = interaction.channel
+        if isinstance(ch, discord.Thread):
+            return ch.id
+        return None
+
+    def _resolve_scope(
+        self, interaction: discord.Interaction, requested: str | None
+    ) -> tuple[str, int | None]:
+        """Decide whether the command applies to a thread or globally.
+
+        - If ``requested`` is explicit, honour it (require thread context if
+          ``thread``).
+        - Otherwise: invoked inside a thread → thread; in a channel → global.
+        """
+        thread_id = self._thread_id_or_none(interaction)
+        if requested == SCOPE_GLOBAL:
+            return SCOPE_GLOBAL, None
+        if requested == SCOPE_THREAD:
+            return SCOPE_THREAD, thread_id
+        # auto
+        if thread_id is not None:
+            return SCOPE_THREAD, thread_id
+        return SCOPE_GLOBAL, None
+
+    # ── /backend ───────────────────────────────────────────────────
+
+    @app_commands.command(
+        name="backend",
+        description="Show or switch the AI backend (claude/codex)",
+    )
+    @app_commands.choices(
+        name=[Choice(name=b, value=b) for b in ALL_BACKENDS],
+        scope=[
+            Choice(name="thread", value=SCOPE_THREAD),
+            Choice(name="global", value=SCOPE_GLOBAL),
+        ],
+    )
+    @app_commands.describe(
+        name="claude or codex. Omit to show current setting.",
+        scope=(
+            "thread: only this thread; global: server-wide default. "
+            "Default: thread when invoked in a thread, otherwise global."
+        ),
+    )
+    async def backend_command(
+        self,
+        interaction: discord.Interaction,
+        name: str | None = None,
+        scope: str | None = None,
+    ) -> None:
+        thread_id_now = self._thread_id_or_none(interaction)
+
+        # Show current selection if no name provided
+        if name is None:
+            current_t = (
+                await self._settings.current_backend(thread_id_now)
+                if thread_id_now is not None
+                else None
+            )
+            current_g = await self._settings.current_backend(None)
+            lines: list[str] = [
+                f"\U0001f9e0 **Global backend**: `{current_g}`",
+            ]
+            if thread_id_now is not None and current_t is not None:
+                tag = " (thread override)" if current_t != current_g else ""
+                lines.append(f"\U0001f9f5 **This thread**: `{current_t}`{tag}")
+            await interaction.response.send_message("\n".join(lines), ephemeral=True)
+            return
+
+        # Validate
+        if name not in ALL_BACKENDS:
+            await interaction.response.send_message(
+                f"Unknown backend `{name}`. Choose: {', '.join(ALL_BACKENDS)}.",
+                ephemeral=True,
+            )
+            return
+
+        resolved_scope, target_thread_id = self._resolve_scope(interaction, scope)
+        if resolved_scope == SCOPE_THREAD and target_thread_id is None:
+            await interaction.response.send_message(
+                "`scope:thread` requires the command to be run inside a thread.",
+                ephemeral=True,
+            )
+            return
+
+        # Persist
+        await self._settings.set_backend(name, thread_id=target_thread_id)
+
+        # If global change, also swap the shared default runner so the next
+        # ClaudeChatCog session inherits it (thread overrides will be honoured
+        # by ClaudeChatCog at spawn time once it consults BackendSettings).
+        if resolved_scope == SCOPE_GLOBAL:
+            try:
+                model = await self._settings.current_model(name, None)
+                new_runner = self._factory.build(backend=name, model=model)
+                self._chat_cog.runner = new_runner  # type: ignore[assignment]
+                logger.info(
+                    "ClaudeChatCog default runner swapped: %s (model=%s)",
+                    name,
+                    new_runner.model,
+                )
+            except Exception:
+                logger.exception("Failed to swap ClaudeChatCog.runner after /backend change")
+
+        scope_label = (
+            f"<#{target_thread_id}>"
+            if resolved_scope == SCOPE_THREAD and target_thread_id is not None
+            else "**globally**"
+        )
+        emoji = "\U0001f300" if name == "codex" else "\U0001f916"
+        await interaction.response.send_message(
+            f"{emoji} Backend set to `{name}` {scope_label}. Next session will use it.",
+            ephemeral=False,
+        )
+
+    # ── /model ─────────────────────────────────────────────────────
+
+    @app_commands.command(
+        name="model",
+        description="Show or switch the model for the current backend",
+    )
+    @app_commands.choices(
+        scope=[
+            Choice(name="thread", value=SCOPE_THREAD),
+            Choice(name="global", value=SCOPE_GLOBAL),
+        ],
+    )
+    @app_commands.describe(
+        name="Model id (e.g. sonnet, opus, gpt-5.4, o4-mini). Omit to show current.",
+        scope=(
+            "thread: only this thread; global: server-wide. "
+            "Default: thread when in thread, else global."
+        ),
+    )
+    async def model_command(
+        self,
+        interaction: discord.Interaction,
+        name: str | None = None,
+        scope: str | None = None,
+    ) -> None:
+        thread_id_now = self._thread_id_or_none(interaction)
+
+        # Show current
+        if name is None:
+            backend_for_thread = (
+                await self._settings.current_backend(thread_id_now)
+                if thread_id_now is not None
+                else await self._settings.current_backend(None)
+            )
+            current_t = (
+                await self._settings.current_model(backend_for_thread, thread_id_now)
+                if thread_id_now is not None
+                else None
+            )
+            backend_for_global = await self._settings.current_backend(None)
+            current_g = await self._settings.current_model(
+                backend_for_global, None
+            ) or self._factory.default_model_for(backend_for_global)
+            lines: list[str] = [
+                f"\U0001f9e0 **Global model**: `{current_g}` (for `{backend_for_global}`)",
+            ]
+            if thread_id_now is not None:
+                resolved_t = current_t or self._factory.default_model_for(backend_for_thread)
+                lines.append(
+                    f"\U0001f9f5 **This thread**: `{resolved_t}` (for `{backend_for_thread}`)"
+                )
+            await interaction.response.send_message("\n".join(lines), ephemeral=True)
+            return
+
+        resolved_scope, target_thread_id = self._resolve_scope(interaction, scope)
+        if resolved_scope == SCOPE_THREAD and target_thread_id is None:
+            await interaction.response.send_message(
+                "`scope:thread` requires the command to be run inside a thread.",
+                ephemeral=True,
+            )
+            return
+
+        # Determine which backend this model is for: read current backend
+        # for the chosen scope.
+        backend_for_save = await self._settings.current_backend(
+            target_thread_id if resolved_scope == SCOPE_THREAD else None
+        )
+
+        await self._settings.set_model(backend_for_save, name, thread_id=target_thread_id)
+
+        # Global change → also update shared runner.model so the next
+        # ClaudeChatCog session uses the new model right away.
+        if resolved_scope == SCOPE_GLOBAL and self._chat_cog.runner is not None:
+            try:
+                self._chat_cog.runner.model = name  # type: ignore[assignment]
+                logger.info("ClaudeChatCog default runner.model swapped to %s", name)
+            except Exception:
+                logger.exception("Failed to update ClaudeChatCog.runner.model")
+
+        scope_label = (
+            f"<#{target_thread_id}>"
+            if resolved_scope == SCOPE_THREAD and target_thread_id is not None
+            else "**globally**"
+        )
+        await interaction.response.send_message(
+            f"\U0001f9e0 Model set to `{name}` for `{backend_for_save}` "
+            f"{scope_label}. Next session will use it.",
+            ephemeral=False,
+        )

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -70,6 +70,8 @@ _HELP_CATEGORY: dict[str, str | None] = {
     "sync-settings": "📌 Session",
     "model-show": "🤖 Model",
     "model-set": "🤖 Model",
+    "model": "🤖 Model",
+    "backend": "🤖 Model",
     "effort-show": "⚡ Effort",
     "effort-set": "⚡ Effort",
     "effort-clear": "⚡ Effort",

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -40,6 +40,15 @@ from .run_config import RunConfig
 
 logger = logging.getLogger(__name__)
 
+
+def _backend_name_from_runner(runner: object) -> str:
+    """Best-effort mapping from runner class name to embed backend tag."""
+    cls = type(runner).__name__
+    if cls == "CodexRunner":
+        return "codex"
+    return "claude"
+
+
 # Marker file prefix. The full name includes the thread ID to prevent
 # cross-contamination when multiple sessions share the same working_dir.
 _ATTACHMENT_MARKER_PREFIX = ".ccdb-attachments"
@@ -282,7 +291,13 @@ class EventProcessor:
         # Guard: post session_start_embed only once (Claude can emit multiple SYSTEM events).
         # Skip in chat_only mode — no session start embed.
         if not self._chat_only and not self._config.session_id and not self._session_start_sent:
-            await self._config.thread.send(embed=session_start_embed(self._state.session_id))
+            await self._config.thread.send(
+                embed=session_start_embed(
+                    self._state.session_id,
+                    backend=_backend_name_from_runner(self._config.runner),
+                    model=self._config.runner.model,
+                )
+            )
             self._session_start_sent = True
 
     async def _on_assistant(self, event: StreamEvent) -> None:
@@ -459,6 +474,8 @@ class EventProcessor:
                         event.cache_read_tokens,
                         event.context_window,
                         event.cache_creation_tokens,
+                        backend=_backend_name_from_runner(self._config.runner),
+                        model=self._config.runner.model,
                     )
                 )
                 if self._config.status:

--- a/claude_discord/discord_ui/embeds.py
+++ b/claude_discord/discord_ui/embeds.py
@@ -18,9 +18,30 @@ COLOR_TODO = 0xE67E22  # Orange — task list
 AUTOCOMPACT_THRESHOLD = 83.5
 
 
+# Per-backend visual mapping for session embeds. Falls back to claude
+# defaults when an unknown / None backend is supplied.
+_BACKEND_TITLE: dict[str, str] = {
+    "claude": "\U0001f916 Claude Code",  # robot face 🤖
+    "codex": "\U0001f300 OpenAI Codex",  # cyclone 🌀
+}
+_BACKEND_COLOR_START: dict[str, int] = {
+    "claude": COLOR_INFO,  # Discord blurple
+    "codex": 0x10A37F,  # OpenAI teal-green
+}
+
+
+def _backend_display(backend: str | None, model: str | None) -> tuple[str, int, str]:
+    """Return (title_prefix, color, model_suffix) for the given backend."""
+    b = backend if isinstance(backend, str) and backend else "claude"
+    title = _BACKEND_TITLE.get(b, _BACKEND_TITLE["claude"])
+    color = _BACKEND_COLOR_START.get(b, COLOR_INFO)
+    suffix = f" · {model}" if model else ""
+    return title, color, suffix
+
+
 CATEGORY_ICON: dict[ToolCategory, str] = {
     ToolCategory.READ: "\U0001f4d6",  # 📖
-    ToolCategory.EDIT: "\u270f\ufe0f",  # ✏️
+    ToolCategory.EDIT: "✏️",  # ✏️
     ToolCategory.COMMAND: "\U0001f527",  # 🔧
     ToolCategory.WEB: "\U0001f310",  # 🌐
     ToolCategory.THINK: "\U0001f4ad",  # 💭
@@ -54,14 +75,29 @@ def tool_use_embed(
     return embed
 
 
-def session_start_embed(session_id: str | None = None) -> discord.Embed:
-    """Create an embed for session start."""
+def session_start_embed(
+    session_id: str | None = None,
+    *,
+    backend: str | None = None,
+    model: str | None = None,
+) -> discord.Embed:
+    """Create an embed for session start.
+
+    Title prefix and color reflect which backend (claude/codex) is
+    handling this session. The model name appears in the footer.
+    """
+    title_prefix, color, _ = _backend_display(backend, model)
     embed = discord.Embed(
-        title="\U0001f916 Claude Code session started",
-        color=COLOR_INFO,
+        title=f"{title_prefix} session started",
+        color=color,
     )
+    footer_parts: list[str] = []
     if session_id:
-        embed.set_footer(text=f"Session: {session_id[:8]}...")
+        footer_parts.append(f"Session: {session_id[:8]}...")
+    if isinstance(model, str) and model:
+        footer_parts.append(model)
+    if footer_parts:
+        embed.set_footer(text=" · ".join(footer_parts))
     return embed
 
 
@@ -73,12 +109,21 @@ def session_complete_embed(
     cache_read_tokens: int | None = None,
     context_window: int | None = None,
     cache_creation_tokens: int | None = None,
+    *,
+    backend: str | None = None,
+    model: str | None = None,
 ) -> discord.Embed:
     """Create an embed for session completion."""
     parts: list[str] = []
+    if isinstance(backend, str) and backend:
+        _model_str = model if isinstance(model, str) else None
+        title_prefix, _, model_suffix = _backend_display(backend, _model_str)
+        # Strip the leading emoji for inline use; the leading brain chip carries enough.
+        backend_tag = title_prefix.split(" ", 1)[-1] if " " in title_prefix else title_prefix
+        parts.append(f"\U0001f9e0 {backend_tag}{model_suffix}")
     if duration_ms is not None:
         seconds = duration_ms / 1000
-        parts.append(f"\u23f1\ufe0f {seconds:.1f}s")
+        parts.append(f"⏱️ {seconds:.1f}s")
     if cost_usd is not None:
         parts.append(f"\U0001f4b0 ${cost_usd:.4f}")
     if input_tokens is not None and output_tokens is not None:
@@ -86,7 +131,7 @@ def session_complete_embed(
         def _fmt(n: int) -> str:
             return f"{n / 1000:.1f}k" if n >= 1000 else str(n)
 
-        token_str = f"\U0001f4ca {_fmt(input_tokens)}\u2191 {_fmt(output_tokens)}\u2193"
+        token_str = f"\U0001f4ca {_fmt(input_tokens)}↑ {_fmt(output_tokens)}↓"
         if cache_read_tokens:
             total = input_tokens + cache_read_tokens
             hit_pct = int(cache_read_tokens / total * 100) if total else 0
@@ -105,13 +150,13 @@ def session_complete_embed(
         if usage_pct < AUTOCOMPACT_THRESHOLD:
             ctx_str += f" ({remaining_pct:.0f}% until compact)"
         else:
-            ctx_str += " \u26a0\ufe0f"
+            ctx_str += " ⚠️"
         parts.append(ctx_str)
 
     description = " | ".join(parts) if parts else None
 
     embed = discord.Embed(
-        title="\u2705 Done",
+        title="✅ Done",
         description=description,
         color=COLOR_SUCCESS,
     )
@@ -121,8 +166,7 @@ def session_complete_embed(
         usage_pct = min(100.0, context_used / context_window * 100)
         if usage_pct >= AUTOCOMPACT_THRESHOLD:
             embed.set_footer(
-                text=f"\u26a0\ufe0f Context {usage_pct:.0f}% full"
-                " \u2014 auto-compact may run on next turn"
+                text=f"⚠️ Context {usage_pct:.0f}% full — auto-compact may run on next turn"
             )
 
     return embed
@@ -204,7 +248,7 @@ def redacted_thinking_embed() -> discord.Embed:
 def error_embed(error: str) -> discord.Embed:
     """Create an embed for errors."""
     return discord.Embed(
-        title="\u274c Error",
+        title="❌ Error",
         description=error[:4000],
         color=COLOR_ERROR,
     )
@@ -213,12 +257,12 @@ def error_embed(error: str) -> discord.Embed:
 def timeout_embed(seconds: int) -> discord.Embed:
     """Create an embed for session timeout with actionable guidance."""
     return discord.Embed(
-        title="\u23f1\ufe0f Session timed out",
+        title="⏱️ Session timed out",
         description=(
             f"No response received for {seconds} seconds.\n\n"
             "**What to do:**\n"
-            "\u2022 Send a message to resume the session\n"
-            "\u2022 Use `/clear` to start fresh"
+            "• Send a message to resume the session\n"
+            "• Use `/clear` to start fresh"
         ),
         color=COLOR_ERROR,
     )
@@ -237,10 +281,10 @@ def ask_embed(question: str, header: str = "") -> discord.Embed:
 def stopped_embed() -> discord.Embed:
     """Create an embed for a manually stopped session."""
     return discord.Embed(
-        title="\u23f9\ufe0f Session stopped",
+        title="⏹️ Session stopped",
         description=(
             "The session was stopped.\n\n"
-            "The session is preserved \u2014 send a message to resume, "
+            "The session is preserved — send a message to resume, "
             "or use `/clear` to start fresh."
         ),
         color=0xFFA500,  # Orange — not an error, just interrupted
@@ -250,7 +294,7 @@ def stopped_embed() -> discord.Embed:
 # Status icons for each todo state
 _TODO_ICON = {
     "pending": "⬜",
-    "in_progress": "🔄",
+    "in_progress": "\U0001f504",
     "completed": "✅",
 }
 
@@ -277,7 +321,7 @@ def todo_embed(todos: list[TodoItem]) -> discord.Embed:
     description = "\n".join(lines) if lines else "*(no tasks)*"
     completed = sum(1 for t in todos if t.status == "completed")
     total = len(todos)
-    title = f"📋 Tasks ({completed}/{total})"
+    title = f"\U0001f4cb Tasks ({completed}/{total})"
 
     return discord.Embed(
         title=title,
@@ -297,7 +341,7 @@ def plan_embed(plan_text: str) -> discord.Embed:
     if len(plan_text) > max_text:
         truncated += "\n... (truncated)"
     return discord.Embed(
-        title="📋 Plan ready — approve to execute",
+        title="\U0001f4cb Plan ready — approve to execute",
         description=f"```\n{truncated}\n```" if truncated else "*(no plan text)*",
         color=0x2ECC71,  # Emerald green — action required
     )
@@ -326,7 +370,7 @@ def permission_embed(request) -> discord.Embed:
 
     description = f"**Tool:** `{tool_name}`\n\n**Input:**\n```json\n{input_str}\n```"
     return discord.Embed(
-        title="🔐 Permission required",
+        title="\U0001f510 Permission required",
         description=description[:4096],
         color=0xE74C3C,  # Alizarin red — requires attention
     )
@@ -335,7 +379,7 @@ def permission_embed(request) -> discord.Embed:
 def elicitation_embed(request) -> discord.Embed:
     """Create an embed for an MCP elicitation request."""
     mode_label = "Form" if request.mode == "form-mode" else "URL"
-    title = f"🔌 MCP input required ({mode_label}) — {request.server_name}"
+    title = f"\U0001f50c MCP input required ({mode_label}) — {request.server_name}"
 
     description = request.message or "An MCP server needs your input to continue."
     return discord.Embed(

--- a/claude_discord/main.py
+++ b/claude_discord/main.py
@@ -49,6 +49,10 @@ def load_config() -> dict[str, str]:
         "channel_id": channel_id,
         "backend": os.getenv("CCDB_BACKEND", "claude"),
         "command": _env("CCDB_COMMAND", "CLAUDE_COMMAND", ""),
+        # Per-backend explicit command paths. Used by BackendFactory when
+        # the user switches backend at runtime via /backend.
+        "claude_command": _env("CCDB_CLAUDE_COMMAND", "CLAUDE_COMMAND", ""),
+        "codex_command": os.getenv("CCDB_CODEX_COMMAND", ""),
         "model": _env("CCDB_MODEL", "CLAUDE_MODEL", "sonnet"),
         "permission_mode": _env("CCDB_PERMISSION_MODE", "CLAUDE_PERMISSION_MODE", "acceptEdits"),
         "working_dir": _env("CCDB_WORKING_DIR", "CLAUDE_WORKING_DIR", ""),
@@ -95,6 +99,28 @@ async def main() -> None:
     # Create runner via backend factory (CCDB_BACKEND=claude|codex)
     backend_name = config["backend"]
     default_command = "codex" if backend_name == "codex" else "claude"
+
+    # BackendFactory is the runtime authority for building Claude/Codex
+    # runners on demand (e.g. when the user switches via /backend).
+    from .backend_factory import BackendFactory
+
+    factory = BackendFactory(
+        claude_command=config["claude_command"]
+        or (config["command"] if backend_name == "claude" else "")
+        or "claude",
+        codex_command=config["codex_command"]
+        or (config["command"] if backend_name == "codex" else "")
+        or "codex",
+        permission_mode=config["permission_mode"],
+        working_dir=config["working_dir"] or None,
+        timeout_seconds=int(config["timeout"]),
+        dangerously_skip_permissions=config["dangerously_skip_permissions"].lower()
+        in ("true", "1", "yes"),
+        allowed_tools=allowed_tools,
+        append_system_prompt=config["append_system_prompt"] or None,
+        effort=config["effort"] or None,
+    )
+
     runner = create_backend(
         backend=backend_name,
         command=config["command"] or default_command,
@@ -138,6 +164,7 @@ async def main() -> None:
             bot,
             runner,
             api_server=api_server,
+            backend_factory=factory,
             allowed_user_ids=allowed_user_ids,
             claude_channel_id=channel_id,
             claude_channel_ids=claude_channel_ids,

--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
     from claude_code_core.backend import SessionBackend
 
+    from .backend_factory import BackendFactory
     from .database.lounge_repo import LoungeRepository
     from .database.repository import SessionRepository
     from .database.resume_repo import PendingResumeRepository
@@ -85,6 +86,7 @@ async def setup_bridge(
     auto_rename_threads: bool | None = None,
     monitor_all_channels: bool | None = None,
     context_links_config: str | None = None,
+    backend_factory: BackendFactory | None = None,
 ) -> BridgeComponents:
     """Initialize and register all ccdb Cogs in one call.
 
@@ -319,6 +321,27 @@ async def setup_bridge(
     await bot.add_cog(context_links_cog)
     if context_links_cog._config is not None:
         logger.info("Registered ContextLinksCog (config=%s)", context_links_config)
+
+    # --- BackendCommandCog (optional — only if a BackendFactory was provided) ---
+    if backend_factory is not None:
+        from .backend_settings import BackendSettings
+        from .cogs.backend_command import BackendCommandCog
+
+        _runner_class = runner.__class__.__name__
+        backend_settings = BackendSettings(
+            settings_repo,
+            env_backend=_runner_class.replace("Runner", "").lower(),
+            env_model_for_claude=(runner.model if _runner_class == "ClaudeRunner" else ""),
+            env_model_for_codex=(runner.model if _runner_class == "CodexRunner" else ""),
+        )
+        backend_cmd_cog = BackendCommandCog(
+            bot,  # type: ignore[arg-type]
+            settings=backend_settings,
+            factory=backend_factory,
+            chat_cog=chat_cog,
+        )
+        await bot.add_cog(backend_cmd_cog)
+        logger.info("Registered BackendCommandCog")
 
     components = BridgeComponents(
         session_repo=session_repo,

--- a/tests/test_backend_settings.py
+++ b/tests/test_backend_settings.py
@@ -1,0 +1,127 @@
+"""Tests for BackendSettings (resolution + persistence)."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from claude_discord.backend_settings import (
+    BACKEND_GLOBAL,
+    BackendSettings,
+)
+from claude_discord.database.settings_repo import SettingsRepository
+
+
+async def _new_repo() -> tuple[SettingsRepository, Path]:
+    """Create a fresh on-disk SettingsRepository with the schema created."""
+    tmp = Path(tempfile.mkdtemp()) / "settings.db"
+    async with aiosqlite.connect(str(tmp)) as db:
+        await db.execute("CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+        await db.commit()
+    return SettingsRepository(str(tmp)), tmp
+
+
+class TestResolution:
+    async def test_global_only_env_fallback(self) -> None:
+        repo, _ = await _new_repo()
+        s = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+        )
+        assert await s.current_backend() == "claude"
+        assert await s.current_model("claude") == "sonnet"
+        assert await s.current_model("codex") is None
+
+    async def test_global_set_overrides_env(self) -> None:
+        repo, _ = await _new_repo()
+        s = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+        )
+        await s.set_backend("codex")
+        assert await s.current_backend() == "codex"
+
+    async def test_thread_overrides_global(self) -> None:
+        repo, _ = await _new_repo()
+        s = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+        )
+        await s.set_backend("claude")
+        await s.set_backend("codex", thread_id=42)
+        assert await s.current_backend() == "claude"
+        assert await s.current_backend(thread_id=42) == "codex"
+
+    async def test_model_thread_overrides_global(self) -> None:
+        repo, _ = await _new_repo()
+        s = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+        )
+        await s.set_model("claude", "opus")
+        await s.set_model("claude", "haiku", thread_id=99)
+        assert await s.current_model("claude") == "opus"
+        assert await s.current_model("claude", thread_id=99) == "haiku"
+        # other thread sees global
+        assert await s.current_model("claude", thread_id=1) == "opus"
+
+    async def test_unknown_backend_in_db_falls_through(self) -> None:
+        repo, _ = await _new_repo()
+        s = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="",
+            env_model_for_codex="",
+        )
+        # Inject a corrupted value directly
+        await repo.set(BACKEND_GLOBAL, "bogus")
+        assert await s.current_backend() == "claude"
+
+    async def test_clear_thread_overrides(self) -> None:
+        repo, _ = await _new_repo()
+        s = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+        )
+        await s.set_backend("codex", thread_id=7)
+        await s.set_model("codex", "gpt-5", thread_id=7)
+        deleted = await s.clear_thread_overrides(7)
+        assert deleted == 2
+        assert await s.current_backend(thread_id=7) == "claude"
+
+
+class TestMutationValidation:
+    async def test_set_backend_rejects_unknown(self) -> None:
+        repo, _ = await _new_repo()
+        s = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="",
+            env_model_for_codex="",
+        )
+        with pytest.raises(ValueError):
+            await s.set_backend("gpt4")  # type: ignore[arg-type]
+
+    async def test_set_model_rejects_empty(self) -> None:
+        repo, _ = await _new_repo()
+        s = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="",
+            env_model_for_codex="",
+        )
+        with pytest.raises(ValueError):
+            await s.set_model("claude", "")


### PR DESCRIPTION
## Summary

Lets the user see at a glance which CLI backend (Claude / Codex) is handling each session, and switch backend/model from inside Discord without restarting the bot.

## What changes

**Visual**
- `session_start_embed` title and color reflect backend: blurple "🤖 Claude Code" vs OpenAI teal "🌀 OpenAI Codex"
- `session_complete_embed` prepends a "🧠 <backend> · <model>" chip
- Model name appears in the footer of the start embed
- All defensive against non-string inputs so MagicMock-based tests stay green

**Runtime switching**
- `/backend [name] [scope]` — show or switch backend. `name`: `claude` | `codex`. `scope`: `thread` | `global`. Default scope is auto (thread when invoked in a thread, otherwise global)
- `/model [name] [scope]` — same UX, sets per-backend model
- Both commands list current values when no `name` is provided
- Persists across bot restarts via existing `SettingsRepository`

**Per-thread overrides**
- `BackendSettings` already supports per-thread overrides (resolution order: thread → global → env)
- `/backend` and `/model` persist them correctly
- ClaudeChatCog uses the new global runner immediately; consuming thread overrides is a follow-up (will land when claude_chat moves from `self.runner.clone()` to `factory.build(...)`)

## New modules

- `claude_discord/backend_factory.py` — builds `SessionBackend` instances on demand from static config (per-backend command paths, permission mode, working dir, ...)
- `claude_discord/backend_settings.py` — thread/global resolution + persistence
- `claude_discord/cogs/backend_command.py` — `/backend` and `/model` slash commands

## New env vars (optional)

- `CCDB_CLAUDE_COMMAND` — absolute path to claude CLI (falls back to `CLAUDE_COMMAND`)
- `CCDB_CODEX_COMMAND` — absolute path to codex CLI (currently `/home/ebi/.npm-global/bin/codex` on moviegen; defaults to literal `codex` and lets PATH lookup, which works only when service PATH is extended)

## Test plan

- [x] `pytest tests/test_backend_settings.py -v` — 8 new tests for resolution, mutation, validation, override clearing
- [x] `pytest --ignore=tests/integration` — **1373 passed**
- [x] `pyright claude_discord/ claude_code_core/` — 0 errors
- [x] `ruff format` / `ruff check` — clean
- [ ] After merge: send a test message in Discord, observe Claude title; run `/backend codex` (globally); send another message, observe Codex title; run `/model gpt-5.4` and verify footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
