### PR TITLE
[docs-sync] Update all translations for v3.0.0 — Claude & Codex Discord Bridge

### DIFF
--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -3,43 +3,48 @@
 > **Nota:** Esta es una versión autotraducida de la documentación original en inglés.
 > En caso de discrepancias, la [versión en inglés](../../README.md) prevalece.
 
-# claude-code-discord-bridge
+# Claude & Codex Discord Bridge
+
+*Nombre del paquete: `claude-code-discord-bridge` (kebab-case)*
 
 [![CI](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**Ejecuta múltiples sesiones de Claude Code en paralelo — de forma segura — a través de Discord.**
+**Usa Claude Code _o_ OpenAI Codex desde tu teléfono. Múltiples hilos. Todo a la vez. Desarrollo real incluido.**
 
-Cada hilo de Discord se convierte en una sesión aislada de Claude Code. Inicia tantas como necesites: trabaja en una funcionalidad en un hilo, revisa un PR en otro, ejecuta una tarea programada en un tercero. El bridge gestiona la coordinación automáticamente para que las sesiones concurrentes no interfieran entre sí.
+Abre Claude Code o OpenAI Codex desde la aplicación Discord de tu smartphone, inicia múltiples hilos y ejecuta sesiones de desarrollo en paralelo — todo sin tocar un teclado. Cada hilo de Discord se convierte en una sesión de IA completamente aislada. Trabaja en una función en un hilo, revisa un PR en otro y ejecuta una tarea en segundo plano en un tercero — simultáneamente, incluso mezclando backends por hilo. El bridge gestiona toda la coordinación para que las sesiones nunca se interfieran entre sí.
+
+**Usa tus suscripciones existentes. Sin configuración de API key.** ccdb funciona sobre las CLIs oficiales — Claude Code (incluida en tu [suscripción Claude Pro/Max](https://claude.ai/pricing)) y OpenAI Codex (incluida en [ChatGPT Plus/Pro/Business](https://chatgpt.com)). Cambia de backend con `/backend` o configura por hilo — tu equipo accede a ambas IAs a través de Discord a un costo predecible.
 
 **[English](../../README.md)** | **[日本語](../ja/README.md)** | **[简体中文](../zh-CN/README.md)** | **[한국어](../ko/README.md)** | **[Português](../pt-BR/README.md)** | **[Français](../fr/README.md)**
 
-> **Aviso legal:** Este proyecto no está afiliado, respaldado ni conectado oficialmente con Anthropic. "Claude" y "Claude Code" son marcas registradas de Anthropic, PBC. Esta es una herramienta de código abierto independiente que interactúa con Claude Code CLI.
+> **Descargo de responsabilidad:** Este proyecto no está afiliado, respaldado ni tiene relación oficial con Anthropic u OpenAI. "Claude" y "Claude Code" son marcas comerciales de Anthropic, PBC; "OpenAI", "Codex" y "ChatGPT" son marcas comerciales de OpenAI. Esta es una herramienta de código abierto independiente que interactúa con Claude Code CLI y OpenAI Codex CLI.
 
-> **Construido completamente por Claude Code.** Todo este código base — arquitectura, implementación, pruebas, documentación — fue escrito por Claude Code. El autor humano proporcionó requisitos y dirección en lenguaje natural, pero no leyó ni editó manualmente el código fuente. Ver [Cómo se construyó este proyecto](#cómo-se-construyó-este-proyecto).
+> **Construido enteramente por Claude Code.** Todo este codebase — arquitectura, implementación, pruebas, documentación — fue escrito por Claude Code. El autor humano proporcionó requisitos y dirección. Ver [Cómo se construyó este proyecto](#cómo-se-construyó-este-proyecto).
 
 ---
 
 ## La Gran Idea: Sesiones Paralelas Sin Miedo
 
-Cuando envías tareas a Claude Code en hilos separados de Discord, el bridge hace tres cosas automáticamente:
+Cuando envías tareas a Claude Code en hilos de Discord separados, el bridge hace cuatro cosas automáticamente:
 
-1. **Inyección de aviso de concurrencia** — El prompt de sistema de cada sesión incluye instrucciones obligatorias: crea un git worktree, trabaja solo dentro de él, nunca toques el directorio de trabajo principal directamente.
+1. **Inyección de aviso de concurrencia** — El prompt del sistema de cada sesión incluye instrucciones obligatorias: crear un git worktree, trabajar solo dentro de él, nunca tocar el directorio de trabajo principal directamente.
 
-2. **Registro de sesiones activas** — Cada sesión en ejecución conoce las demás. Si dos sesiones están a punto de modificar el mismo repositorio, pueden coordinarse en lugar de entrar en conflicto.
+2. **Registro de sesiones activas** — Cada sesión en ejecución sabe de las demás. Si dos sesiones van a tocar el mismo repositorio, pueden coordinarse en lugar de entrar en conflicto.
 
-3. **AI Lounge** — Un canal de «sala de espera» compartida inyectado en el prompt de cada sesión. Antes de comenzar, cada sesión lee los mensajes recientes del Lounge para conocer el estado de las otras. Antes de operaciones destructivas (force push, reinicio del bot, etc.), las sesiones verifican el Lounge primero.
+3. **AI Lounge** — Un "sala de descanso" inyectada en cada prompt. Antes de empezar, cada sesión lee los mensajes recientes del lounge para ver qué están haciendo las otras. Antes de operaciones destructivas (force push, reinicio del bot, eliminación de DB), las sesiones verifican el lounge primero.
 
 ```
-Hilo A (funcionalidad) ──→  Claude Code (worktree-A)  ─┐
-Hilo B (revisión PR)   ──→  Claude Code (worktree-B)   ├─→  #ai-lounge
-Hilo C (docs)          ──→  Claude Code (worktree-C)  ─┘    "A: refactor auth en progreso"
-                                                             "B: revisión PR #42 completa"
-                                                             "C: actualizando README"
+Hilo A (función)   ──→  Claude Code (worktree-A)  ─┐
+Hilo B (PR review) ──→  Claude Code (worktree-B)   ├─→  #ai-lounge
+Hilo C (docs)      ──→  Claude Code (worktree-C)  ─┘    "A: refactor auth en progreso"
+                                                         "B: revisión PR #42 lista"
+                                                         "C: actualizando README"
 ```
 
-Sin condiciones de carrera. Sin trabajo perdido. Sin sorpresas al hacer merge.
+Sin condiciones de carrera. Sin trabajo perdido. Sin sorpresas en los merges.
 
 ---
 
@@ -47,63 +52,39 @@ Sin condiciones de carrera. Sin trabajo perdido. Sin sorpresas al hacer merge.
 
 ### Chat Interactivo (Móvil / Escritorio)
 
-Usa Claude Code desde cualquier lugar donde funcione Discord — teléfono, tablet o escritorio. Cada mensaje crea o continúa un hilo, mapeado 1:1 a una sesión persistente de Claude Code.
+Usa Claude Code desde cualquier lugar donde Discord funcione — teléfono, tablet o escritorio. Cada mensaje crea o continúa un hilo, mapeando 1:1 a una sesión persistente de Claude Code.
 
 ### Desarrollo Paralelo
 
 Abre múltiples hilos simultáneamente. Cada uno es una sesión independiente de Claude Code con su propio contexto, directorio de trabajo y git worktree. Patrones útiles:
 
-- **Funcionalidad + revisión en paralelo**: Inicia una funcionalidad en un hilo mientras Claude revisa un PR en otro.
-- **Múltiples colaboradores**: Diferentes miembros del equipo tienen su propio hilo; las sesiones se mantienen al tanto entre sí a través del AI Lounge.
-- **Experimenta con seguridad**: Prueba un enfoque en el hilo A mientras el hilo B se mantiene en código estable.
+- **Función + revisión en paralelo**: Inicia una función en un hilo mientras Claude revisa un PR en otro.
+- **Múltiples contribuidores**: Diferentes miembros del equipo tienen sus propios hilos; las sesiones se coordinan a través del AI Lounge.
+- **Experimenta con seguridad**: Prueba un enfoque en el hilo A mientras mantienes el hilo B en código estable.
 
 ### Tareas Programadas (SchedulerCog)
 
-Registra tareas periódicas de Claude Code desde una conversación de Discord o vía REST API — sin cambios de código, sin redeploys. Las tareas se almacenan en SQLite y se ejecutan según un horario configurable. Claude puede auto-registrar tareas durante una sesión usando `POST /api/tasks`.
+Registra tareas periódicas de Claude Code desde una conversación de Discord o mediante REST API — sin cambios de código, sin redeployments. Las tareas se almacenan en SQLite y se ejecutan en un horario configurable.
 
 ```
-/skill name:goodmorning         → se ejecuta inmediatamente
-Claude llama POST /api/tasks   → registra tarea periódica
-SchedulerCog (bucle cada 30s)  → ejecuta tareas cuando toca
+/skill name:goodmorning         → ejecutar inmediatamente
+Claude llama POST /api/tasks    → registrar tarea periódica
+SchedulerCog (ciclo 30s)        → dispara tareas vencidas automáticamente
 ```
 
 ### Automatización CI/CD
 
-Activa tareas de Claude Code desde GitHub Actions vía webhooks de Discord. Claude se ejecuta de forma autónoma — lee código, actualiza docs, crea PRs, activa auto-merge.
+Dispara tareas de Claude Code desde GitHub Actions a través de webhooks de Discord. Claude se ejecuta de forma autónoma — lee código, actualiza documentación, crea PRs, habilita auto-merge.
 
-```
-GitHub Actions → Discord Webhook → Bridge → Claude Code CLI
-                                                  ↓
-GitHub PR ←── git push ←── Claude Code ──────────┘
-```
-
-**Ejemplo real:** En cada push a `main`, Claude analiza el diff, actualiza documentación en inglés + japonés, crea un PR con resumen bilingüe y activa auto-merge. Cero interacción humana.
+**Ejemplo real:** En cada push a `main`, Claude analiza el diff, actualiza la documentación en inglés + japonés, crea un PR bilingüe y habilita auto-merge. Cero interacción humana.
 
 ### Sincronización de Sesiones
 
-¿Ya usas Claude Code CLI directamente? Sincroniza tus sesiones de terminal existentes en hilos de Discord con `/sync-sessions`. Rellena mensajes de conversación recientes para que puedas continuar una sesión CLI desde tu teléfono sin perder contexto.
+¿Ya usas Claude Code CLI directamente? Sincroniza tus sesiones de terminal existentes en hilos de Discord con `/sync-sessions`. Rellena los mensajes de conversación recientes para que puedas continuar una sesión CLI desde tu teléfono sin perder el contexto.
 
-### Creación Programática de Sesiones
+### AI Lounge
 
-Crea nuevas sesiones de Claude Code desde scripts, GitHub Actions u otras sesiones de Claude — sin interacción con mensajes de Discord.
-
-```bash
-# Desde otra sesión de Claude o un script CI:
-curl -X POST "$CCDB_API_URL/api/spawn" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "Ejecutar análisis de seguridad en el repositorio", "thread_name": "Análisis de Seguridad"}'
-# Devuelve inmediatamente con el ID del hilo; Claude corre en segundo plano
-```
-
-Los subprocesos de Claude reciben `DISCORD_THREAD_ID` como variable de entorno, por lo que una sesión en ejecución puede crear sesiones hijas para paralelizar el trabajo.
-
-### Reanudación al Inicio
-
-Si el bot se reinicia a mitad de sesión, las sesiones de Claude interrumpidas se reanudan automáticamente cuando el bot vuelve a estar en línea. Las sesiones se marcan para reanudar de tres formas:
-
-- **Automático (reinicio por actualización)** — `AutoUpgradeCog` toma una instantánea de todas las sesiones activas justo antes de un reinicio por actualización de paquete y las marca automáticamente.
-- **Automático (cualquier apagado)** — `ClaudeChatCog.cog_unload()` marca todas las sesiones en ejecución cuando el bot se apaga por cualquier mecanismo (`systemctl stop`, `bot.close()`, SIGTERM, etc.).
-- **Manual** — Cualquier sesión puede llamar a `POST /api/mark-resume` directamente.
+Un canal compartido "sala de descanso" donde todas las sesiones concurrentes se anuncian, leen las actualizaciones de las demás y se coordinan antes de operaciones destructivas.
 
 ---
 
@@ -111,172 +92,191 @@ Si el bot se reinicia a mitad de sesión, las sesiones de Claude interrumpidas s
 
 ### Chat Interactivo
 
-#### 🔗 Sesión Básica
-- **Thread = Session** — Mapeo 1:1 entre hilo de Discord y sesión de Claude Code
-- **Persistencia de sesión** — Reanuda conversaciones entre mensajes via `--resume`
-- **Sesiones concurrentes** — Múltiples sesiones en paralelo con límite configurable
-- **Parar sin borrar** — `/stop` detiene una sesión preservándola para reanudar
-- **Interrupción de sesión** — Enviar un nuevo mensaje a un hilo activo envía SIGINT a la sesión en ejecución y comienza de nuevo con la nueva instrucción; no se necesita `/stop` manual
-- **Renombrado automático de hilos** — Cuando `THREAD_AUTO_RENAME=true`, cada nuevo hilo se renombra automáticamente con un título generado por Claude basado en el primer mensaje (tarea en segundo plano, nunca retrasa el inicio de la sesión)
+#### 🔗 Conceptos Básicos de Sesión
+- **Modo solo chat** — `CHAT_ONLY_CHANNEL_IDS` muestra solo respuestas de texto de Claude; se ocultan embeds de herramientas, bloques de pensamiento, embeds de sesión y listas de tareas
+- **Hilo = Sesión** — Mapeo 1:1 entre hilo de Discord y sesión de Claude Code
+- **Seguimiento de objetivos** — `/goal <condición>` establece condición de finalización; Claude sigue trabajando hasta cumplirla
+- **Persistencia de sesión** — Continúa conversaciones entre mensajes mediante `--resume`
+- **Sesiones concurrentes** — Múltiples sesiones paralelas con límite configurable
+- **Detener sin borrar** — `/stop` detiene una sesión preservándola para reanudar
+- **Interrupción de sesión** — Enviar mensaje nuevo a hilo activo envía SIGINT y comienza con nueva instrucción
+- **Auto-renombramiento de hilos** — Con `THREAD_AUTO_RENAME=true`, cada nuevo hilo se renombra automáticamente
 
 #### 📡 Retroalimentación en Tiempo Real
 - **Estado en tiempo real** — Reacciones emoji: 🧠 pensando, 🛠️ leyendo archivos, 💻 editando, 🌐 búsqueda web
 - **Texto en streaming** — El texto intermedio aparece mientras Claude trabaja
-- **Embeds de resultados de herramientas** — Resultados en vivo con tiempo transcurrido que aumenta cada 10s; resultados de una línea se muestran directamente, resultados de múltiples líneas se colapsan tras un botón de expansión
-- **Pensamiento extendido** — Razonamiento mostrado como embeds con spoiler (clic para revelar)
-- **Panel de hilos** — Embed fijo en vivo mostrando qué hilos están activos vs. en espera; el propietario es @mencionado cuando se necesita entrada
+- **Embeds de resultados de herramientas** — Resultados de llamadas de herramientas en vivo con tiempo transcurrido
+- **Pensamiento extendido** — Razonamiento mostrado como embeds con etiqueta spoiler
+- **Panel de hilos** — Embed fijado en vivo mostrando qué hilos están activos vs. esperando
 
-#### 🤝 Colaboración Humano-IA
-- **Preguntas interactivas** — `AskUserQuestion` se renderiza como Botones de Discord o Menú de Selección; la sesión se reanuda con tu respuesta; los botones sobreviven reinicios del bot
-- **Plan Mode** — Cuando Claude llama a `ExitPlanMode`, se muestra un embed de Discord con el plan completo y botones Aprobar/Cancelar; Claude solo continúa tras la aprobación; cancelación automática tras 5 minutos
-- **Solicitudes de permiso de herramientas** — Cuando Claude necesita permiso para ejecutar una herramienta, Discord muestra botones Permitir/Denegar con el nombre y la entrada de la herramienta; denegación automática tras 2 minutos
-- **MCP Elicitation** — Los servidores MCP pueden solicitar entrada del usuario via Discord (modo formulario: hasta 5 campos Modal del esquema JSON; modo URL: botón URL + confirmación); 5 minutos de tiempo de espera
-- **Progreso en vivo de TodoWrite** — Cuando Claude llama a `TodoWrite`, se publica un único embed de Discord que se edita in situ en cada actualización; muestra ✅ completado, 🔄 activo (con etiqueta `activeForm`), ⬜ pendiente
+#### 🤝 Human-in-the-Loop
+- **Preguntas interactivas** — `AskUserQuestion` se renderiza como botones o menú de selección de Discord
+- **Modo Plan** — `ExitPlanMode` muestra embed de Discord con botones Aprobar/Cancelar; 5 minutos de timeout
+- **Solicitudes de permisos de herramientas** — Botones Permitir/Denegar; auto-rechazo después de 2 minutos
+- **MCP Elicitation** — Los servidores MCP pueden solicitar entrada del usuario a través de Discord; 5 minutos de timeout
+- **Progreso TodoWrite en vivo** — Embed único de Discord actualizado en su lugar
 
 #### 📊 Observabilidad
-- **Uso de tokens** — Tasa de aciertos de caché y recuento de tokens mostrados en el embed de sesión completada
-- **Uso de contexto** — Porcentaje de la ventana de contexto (tokens de entrada + caché, excluyendo salida) y capacidad restante hasta el auto-compactado mostrados en el embed de sesión completada; ⚠️ advertencia cuando supera el 83,5%
-- **Detección de compactado** — Notifica en el hilo cuando ocurre la compactación de contexto (tipo de desencadenante + recuento de tokens antes del compactado)
-- **Notificación de estancamiento** — Mensaje en el hilo cuando no hay actividad (pensamiento extendido o compresión de contexto); se reinicia automáticamente cuando Claude reanuda. Los umbrales se adaptan al modelo: 30 s para modelos estándar, 120 s para Opus (pausas de reflexión más largas)
-- **Notificaciones de timeout** — Embed con tiempo transcurrido y guía de reanudación al agotar tiempo
-- **Bandeja de entrada de hilos** — Cuando `THREAD_INBOX_ENABLED=true`, el panel muestra una sección 📬 persistente; al finalizar cada sesión, Claude clasifica el último mensaje (`waiting`/`done`/`ambiguous`) mediante una llamada ligera a `claude -p`; los hilos que esperan respuesta sobreviven reinicios del bot y se muestran hasta que respondes
+- **Uso de tokens** — Tasa de aciertos en caché y conteo de tokens en embed de sesión completa
+- **Uso de contexto** — Porcentaje de ventana de contexto; advertencia ⚠️ por encima del 83.5%
+- **Detección de compresión** — Notificación en hilo cuando ocurre compresión de contexto
+- **Notificación de bloqueo prolongado** — Mensaje en hilo tras inactividad (30s estándar, 120s para Opus)
+- **Notificaciones de timeout** — Embed con tiempo transcurrido y guía de reanudación
+- **Visualización de StatusLine** — Muestra la línea de estado de Claude después de cada sesión
+- **Bandeja de entrada de hilos** — Con `THREAD_INBOX_ENABLED=true`, sección 📬 en el panel
 
-#### 🔌 Entrada y Skills
-- **Soporte de adjuntos** — Archivos de texto añadidos automáticamente al prompt (hasta 5 × 50 KB); imágenes descargadas y pasadas via `--image` (hasta 4 × 5 MB)
-- **Ejecución de skills** — Comando `/skill` con autocompletado, argumentos opcionales, reanudación en hilo
-- **Hot reload** — Los nuevos skills añadidos a `~/.claude/skills/` se detectan automáticamente (refresco cada 60s, sin reinicio)
+#### 🔌 Entrada y Habilidades
+- **Soporte de archivos adjuntos** — Archivos de texto añadidos automáticamente (hasta 5 archivos, 200 KB c/u); imágenes como URLs de CDN (hasta 4 × 5 MB)
+- **Entrega de archivos bajo demanda** — Claude escribe ruta en `.ccdb-attachments`; el bot la envía como adjunto
+- **Ejecución de habilidades** — Comando `/skill` con autocompletado; habilidades de plugins instalados también descubiertas
+- **Recarga en caliente** — Nuevas habilidades en `~/.claude/skills/` detectadas automáticamente (60s de actualización)
 
 ### Concurrencia y Coordinación
-- **Instrucciones de worktree auto-inyectadas** — Cada sesión recibe instrucciones para usar `git worktree` antes de tocar cualquier archivo
-- **Limpieza automática de worktrees** — Los worktrees de sesión (`wt-{thread_id}`) se eliminan automáticamente al terminar la sesión y al iniciar el bot; los worktrees con cambios nunca se eliminan automáticamente (invariante de seguridad)
+- **Instrucciones de Worktree auto-inyectadas** — Cada sesión instada a usar `git worktree`
+- **Limpieza automática de worktree** — Worktrees de sesión eliminados automáticamente; los sucios nunca se eliminan automáticamente
 - **Registro de sesiones activas** — Registro en memoria; cada sesión ve lo que hacen las demás
-- **AI Lounge** — Canal «sala de descanso» compartida; contexto inyectado via `--append-system-prompt` (efímero, nunca se acumula en el historial) para que las sesiones largas no alcancen «Prompt is too long»; las sesiones publican intenciones, leen el estado de las demás y comprueban antes de operaciones disruptivas; los humanos lo ven como un feed de actividad en tiempo real
-- **Canal de coordinación** — La variable de entorno `COORDINATION_CHANNEL_ID` se usa como fallback predeterminado para el canal AI Lounge (las notificaciones automáticas del ciclo de vida del bot han sido eliminadas)
+- **AI Lounge** — Canal compartido; contexto inyectado mediante `--append-system-prompt` (no acumula en historial)
+- **Canal de coordinación** — `COORDINATION_CHANNEL_ID` como fallback predeterminado para AI Lounge
 
 ### Tareas Programadas
-- **SchedulerCog** — Ejecutor de tareas periódicas respaldado por SQLite con un bucle maestro de 30 segundos
-- **Auto-registro** — Claude registra tareas via `POST /api/tasks` durante una sesión de chat
+- **SchedulerCog** — Ejecutor de tareas periódicas respaldado por SQLite, ciclo maestro de 30 segundos
+- **Auto-registro** — Claude registra tareas a través de `POST /api/tasks`
 - **Sin cambios de código** — Añade, elimina o modifica tareas en tiempo de ejecución
 - **Activar/desactivar** — Pausa tareas sin eliminarlas (`PATCH /api/tasks/{id}`)
 
 ### Automatización CI/CD
-- **Disparadores webhook** — Activa tareas de Claude Code desde GitHub Actions o cualquier sistema CI/CD
-- **Auto-actualización** — Actualiza automáticamente el bot cuando se publican paquetes upstream
-- **Reinicio con drenaje** — Espera a que las sesiones activas terminen antes de reiniciar
-- **Marcado automático de reanudación** — Las sesiones activas se marcan automáticamente para reanudar en cualquier apagado (reinicio por actualización via `AutoUpgradeCog`, o cualquier otro apagado via `ClaudeChatCog.cog_unload()`); se reanudan donde las dejaron tras el reinicio del bot
-- **Aprobación de reinicio** — Compuerta opcional para confirmar actualizaciones antes de aplicarlas
+- **Disparadores de Webhook** — Dispara tareas desde GitHub Actions o cualquier sistema CI/CD
+- **Auto-actualización** — Actualiza el bot automáticamente cuando se publican paquetes upstream
+- **Reinicio DrainAware** — Espera a que las sesiones activas terminen antes de reiniciar
+- **Marcado automático de reanudación** — Las sesiones activas se marcan automáticamente en cualquier apagado
+- **Disparador manual de actualización** — Comando `/upgrade` (opt-in mediante `slash_command_enabled=True`)
 
 ### Gestión de Sesiones
-- **Sincronización de sesiones** — Importa sesiones CLI como hilos de Discord (`/sync-sessions`); `/sync-settings` para ver o cambiar preferencias de sincronización (estilo de hilo, ventana de tiempo, resultados mínimos)
-- **Lista de sesiones** — `/sessions` con filtrado por origen (Discord / CLI / todas) y ventana de tiempo
-- **Reanudación de sesión** — `/resume` muestra un menú de selección con sesiones recientes (hasta 25) y reanuda la seleccionada en un nuevo hilo; parámetro opcional `query` para búsqueda por palabras clave (coincide con resumen y directorio de trabajo), `filter=orphaned` para mostrar solo sesiones de hilos eliminados; funciona desde cualquier canal o hilo — siempre crea un nuevo hilo en el canal principal configurado
-- **Información de reanudación** — `/resume-info` muestra el comando CLI para continuar la sesión actual en un terminal (solo en hilos)
-- **Limpiar sesión** — `/clear` reinicia la sesión de Claude Code para el hilo actual, empezando de cero sin crear un nuevo hilo
-- **Reanudación al inicio** — Las sesiones interrumpidas se reinician automáticamente tras cualquier reinicio del bot; `AutoUpgradeCog` (reinicios por actualización) y `ClaudeChatCog.cog_unload()` (todos los demás apagados) las marcan automáticamente, o usa `POST /api/mark-resume` manualmente
-- **Creación programática** — `POST /api/spawn` crea un nuevo hilo de Discord + sesión de Claude desde cualquier script o subproceso de Claude; devuelve un 201 no bloqueante inmediatamente tras la creación del hilo
-- **Inyección de ID de hilo** — La variable de entorno `DISCORD_THREAD_ID` se pasa a cada subproceso de Claude, permitiendo que las sesiones creen sesiones hijas via `$CCDB_API_URL/api/spawn`
-- **Visualización de StatusLine** — Si `settings.json` de Claude Code tiene `statusLine` configurado, su salida se muestra en Discord después de cada respuesta de sesión
-- **Gestión de worktrees** — `/worktree-list` muestra todos los worktrees de sesión activos con estado limpio/sucio; `/worktree-cleanup` elimina worktrees limpios huérfanos (admite vista previa con `dry_run`)
-- **Rebobinar conversación** — `/rewind` restablece el historial de conversación manteniendo los archivos de trabajo que Claude creó; el mensaje de confirmación muestra el % de uso del contexto en el momento del reinicio
-- **Bifurcar conversación** — `/fork` usa `--fork-session` para crear un nuevo hilo desde el mismo estado de sesión, permitiéndote explorar una dirección diferente sin afectar el hilo original
-- **Visibilidad del contexto** — `/context` muestra el % de uso de la ventana de contexto con una barra de progreso visual; muestra advertencia ⚠️ de autocompactación al acercarse al umbral del 83.5%
-- **Monitoreo de límites de tasa** — `/usage` muestra la utilización del límite de tasa de la API de Claude con barra de porcentaje y cuenta regresiva hasta el reinicio por cada tipo de límite
-- **Ayuda integrada** — `/help` muestra todos los comandos slash disponibles y uso básico (efímero, solo visible para quien lo ejecuta)
-- **Cambio de modelo en tiempo de ejecución** — `/model-show` muestra el modelo global actual y el modelo de sesión por hilo; `/model-set` cambia el modelo para todas las nuevas sesiones sin reiniciar
-- **Permisos de herramientas en tiempo de ejecución** — `/tools-show` muestra las herramientas permitidas actualmente; `/tools-set` abre un menú de selección para activar/desactivar herramientas; `/tools-reset` revierte al valor por defecto de `.env` — todo sin reiniciar
+- **Ayuda integrada** — `/help` muestra todos los comandos slash disponibles (efímero)
+- **Sincronización de sesiones** — Importa sesiones CLI como hilos de Discord (`/sync-sessions`)
+- **Lista de sesiones** — `/sessions` con filtrado por origen y ventana de tiempo
+- **Reanudar sesión** — `/resume` muestra menú de selección y reanuda en nuevo hilo
+- **Borrar sesión** — `/clear` reinicia la sesión de Claude Code del hilo actual
+- **Reanudación al inicio** — Las sesiones interrumpidas se reanudan automáticamente tras cualquier reinicio del bot
+- **Generación programática** — `POST /api/spawn` crea nuevo hilo + sesión desde cualquier script
+- **Gestión de Worktree** — `/worktree-list` y `/worktree-cleanup`
+- **Cambio de modelo en tiempo de ejecución** — `/model-show` y `/model-set`, sin reiniciar
+- **Rebobinado de conversación** — `/rewind` trunca la sesión al turno seleccionado
+- **Bifurcación de conversación** — `/fork` crea copia independiente de sesión en nuevo hilo
 
 ### Seguridad
 - **Sin inyección de shell** — Solo `asyncio.create_subprocess_exec`, nunca `shell=True`
-- **Validación de ID de sesión** — Regex estricto antes de pasar a `--resume`
+- **Validación de ID de sesión** — Regex estricta antes de pasar a `--resume`
 - **Prevención de inyección de flags** — Separador `--` antes de todos los prompts
-- **Aislamiento de secretos** — El token del bot se elimina del entorno del subproceso
-- **Autorización de usuario** — `allowed_user_ids` restringe quién puede invocar a Claude
-- **Prevención de inyección en logs** — Los valores de API suministrados por el usuario se sanean (se eliminan saltos de línea y secuencias de escape ANSI) antes de escribirlos en los logs
+- **Aislamiento de secretos** — Token del bot eliminado del entorno del subproceso
+- **Autorización de usuarios** — `allowed_user_ids` restringe quién puede invocar a Claude
+- **Prevención de inyección en logs** — Valores de API proporcionados por usuarios saneados antes de escribir en logs
 
 ---
 
-## Inicio Rápido
+## Inicio Rápido — Claude en Discord en 5 Minutos
 
-### Requisitos
+**Prerrequisitos:** Python 3.10+, [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) instalado y autenticado.
 
-- Python 3.10+
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) instalado y autenticado
-- Token de bot Discord con Message Content intent habilitado
-- [uv](https://docs.astral.sh/uv/) (recomendado) o pip
+**Soporte de plataformas:** Principalmente desarrollado y probado en **Linux**. macOS y Windows son soportados y pasan CI, pero reciben menos pruebas en el mundo real.
 
-### Ejecución autónoma
+### Paso 1 — Crear un Bot de Discord (una vez, ~2 minutos)
+
+1. Ve a [discord.com/developers/applications](https://discord.com/developers/applications) → **New Application**
+2. Navega a **Bot** → habilita **Message Content Intent** en Privileged Gateway Intents
+3. Copia el **Token** del bot
+4. Ve a **OAuth2 → URL Generator**: Scopes `bot` + `applications.commands`, Permisos: Send Messages, Create Public Threads, Send Messages in Threads, Add Reactions, Manage Messages, Read Message History
+5. Abre la URL generada → invita el bot a tu servidor
+
+### Paso 2 — Ejecutar el Asistente de Configuración
+
+Sin necesidad de clonar ni editar `.env` — el asistente lo hace todo:
 
 ```bash
+# Con uvx (sin necesidad de instalación):
+uvx --from "git+https://github.com/ebibibi/claude-code-discord-bridge.git" ccdb setup
+
+# O después de clonar:
 git clone https://github.com/ebibibi/claude-code-discord-bridge.git
 cd claude-code-discord-bridge
-
-cp .env.example .env
-# Edita .env con tu token de bot y ID de canal
-
-uv run python -m claude_discord.main
+uv run ccdb setup
 ```
 
-### Ejecutar como servicio systemd (producción)
-
-Para entornos de producción, ejecutar bajo systemd permite el inicio automático al arranque y reinicio ante fallos.
-
-El repositorio incluye plantillas: `discord-bot.service` y `scripts/pre-start.sh`. Copia y personaliza las rutas y el usuario:
+### Iniciar / Detener
 
 ```bash
-# 1. Edita el archivo de servicio — reemplaza /home/ebi y User=ebi con tu ruta/usuario
+ccdb start    # iniciar el bot (lee .env en el directorio actual)
+ccdb start --env /path/to/.env   # ubicación personalizada de .env
+```
+
+Envía un mensaje en el canal configurado — Claude responderá en un nuevo hilo.
+
+### Ejecutar como Servicio systemd (Producción)
+
+```bash
 sudo cp discord-bot.service /etc/systemd/system/mybot.service
 sudo nano /etc/systemd/system/mybot.service
-
-# 2. Habilitar e iniciar
 sudo systemctl daemon-reload
 sudo systemctl enable mybot.service
 sudo systemctl start mybot.service
-
-# 3. Verificar estado
-sudo systemctl status mybot.service
 journalctl -u mybot.service -f
 ```
 
-**Qué hace `scripts/pre-start.sh`** (se ejecuta como `ExecStartPre` antes del proceso del bot):
+### Cogs Personalizados (Extiende Sin Hacer Fork)
 
-1. **`git pull --ff-only`** — obtiene el código más reciente de `origin main`
-2. **`uv sync`** — sincroniza dependencias según `uv.lock`
-3. **Validación de importación** — verifica que `claude_discord.main` se importe correctamente
-4. **Reversión automática** — si la importación falla, revierte al commit anterior y reintenta; envía notificación vía Discord webhook
-5. **Limpieza de worktrees** — elimina git worktrees huérfanos de sesiones que fallaron
+Añade tus propias características dejando archivos Python en un directorio — sin fork, sin subclase, sin paquete:
 
-El script detecta dinámicamente la raíz del repositorio mediante `readlink -f $0`, por lo que no es necesario editar rutas en el script independientemente de dónde se haya clonado. El binario `uv` también se detecta automáticamente desde `PATH`; usa la variable `CCDB_UV_BIN` para especificar una ruta personalizada.
+```bash
+ccdb start --cogs-dir ./my-cogs/
+# O: CUSTOM_COGS_DIR=./my-cogs ccdb start
+```
 
-Configura `DISCORD_WEBHOOK_URL` en `.env` para recibir notificaciones de fallo (opcional).
+Cada archivo `.py` debe exponer `async def setup(bot, runner, components)`.
 
-### Instalar como paquete
+---
 
-Si ya tienes un bot discord.py en ejecución (Discord solo permite una conexión Gateway por token):
+### Bot Mínimo (Instalar como Paquete)
 
 ```bash
 uv add git+https://github.com/ebibibi/claude-code-discord-bridge.git
 ```
 
+Crea `bot.py`:
+
 ```python
+import asyncio
+import os
+from dotenv import load_dotenv
+import discord
 from discord.ext import commands
 from claude_discord import ClaudeRunner, setup_bridge
 
-bot = commands.Bot(...)
-runner = ClaudeRunner(command="claude", model="sonnet")
+load_dotenv()
+
+intents = discord.Intents.default()
+intents.message_content = True
+
+bot = commands.Bot(command_prefix="!", intents=intents)
+runner = ClaudeRunner(
+    command="claude",
+    model="sonnet",
+    working_dir="/path/to/your/project",
+)
 
 @bot.event
 async def on_ready():
+    print(f"Logged in as {bot.user}")
     await setup_bridge(
         bot,
         runner,
-        claude_channel_id=YOUR_CHANNEL_ID,
-        allowed_user_ids={YOUR_USER_ID},
+        claude_channel_id=int(os.environ["DISCORD_CHANNEL_ID"]),
+        allowed_user_ids={int(os.environ["DISCORD_OWNER_ID"])},
     )
+
+asyncio.run(bot.start(os.environ["DISCORD_BOT_TOKEN"]))
 ```
 
-`setup_bridge()` conecta todos los Cogs automáticamente. Los nuevos Cogs añadidos a ccdb se incluyen sin cambios en el código del consumidor.
-
-Actualizar a la última versión:
+`setup_bridge()` conecta todos los Cogs automáticamente. Actualizar a la última versión:
 
 ```bash
 uv lock --upgrade-package claude-code-discord-bridge && uv sync
@@ -288,212 +288,36 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 
 | Variable | Descripción | Por defecto |
 |----------|-------------|-------------|
-| `DISCORD_BOT_TOKEN` | Tu token de bot Discord | (requerido) |
-| `DISCORD_CHANNEL_ID` | ID del canal para el chat de Claude | (requerido) |
-| `CLAUDE_COMMAND` | Ruta al Claude Code CLI | `claude` |
-| `CLAUDE_MODEL` | Modelo a usar | `sonnet` |
-| `CLAUDE_PERMISSION_MODE` | Modo de permisos del CLI | `acceptEdits` |
-| `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | Omitir todas las comprobaciones de permisos (usar con precaución) | `false` |
-| `CLAUDE_WORKING_DIR` | Directorio de trabajo para Claude | directorio actual |
-| `MAX_CONCURRENT_SESSIONS` | Máximo de sesiones Claude CLI en paralelo (se aplica a todas las rutas: chat, skills, scheduler, webhooks) | `3` |
+| `DISCORD_BOT_TOKEN` | Token del bot de Discord | (requerido) |
+| `DISCORD_CHANNEL_ID` | ID de canal para chat de Claude | (requerido) |
+| `CCDB_BACKEND` | Backend CLI a usar: `claude` o `codex` | `claude` |
+| `CCDB_COMMAND` | Ruta o nombre del binario CLI (reemplaza `CLAUDE_COMMAND`) | _(auto)_ |
+| `CCDB_MODEL` | Modelo a usar (reemplaza `CLAUDE_MODEL`) | `sonnet` |
+| `CCDB_PERMISSION_MODE` | Modo de permisos CLI (reemplaza `CLAUDE_PERMISSION_MODE`) | `acceptEdits` |
+| `CCDB_DANGEROUSLY_SKIP_PERMISSIONS` | Omitir todas las verificaciones de permisos | `false` |
+| `CCDB_WORKING_DIR` | Directorio de trabajo CLI | directorio actual |
+| `CCDB_ALLOWED_TOOLS` | Lista separada por comas de herramientas permitidas | (opcional) |
+| `CCDB_CHANNEL_IDS` | IDs de canal adicionales para configuración multi-canal | (opcional) |
+| `CLAUDE_COMMAND` | Ruta del CLI de Claude (nombre heredado — preferir `CCDB_COMMAND`) | `claude` |
+| `CLAUDE_MODEL` | Modelo (nombre heredado — preferir `CCDB_MODEL`) | `sonnet` |
+| `CLAUDE_PERMISSION_MODE` | Modo de permisos (nombre heredado — preferir `CCDB_PERMISSION_MODE`) | `acceptEdits` |
+| `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | Omitir permisos (nombre heredado) | `false` |
+| `CLAUDE_WORKING_DIR` | Directorio de trabajo (nombre heredado) | directorio actual |
+| `MAX_CONCURRENT_SESSIONS` | Máximo de sesiones CLI paralelas | `3` |
 | `SESSION_TIMEOUT_SECONDS` | Timeout de inactividad de sesión | `300` |
-| `DISCORD_OWNER_ID` | ID de usuario para @mencionar cuando Claude necesita entrada | (opcional) |
-| `COORDINATION_CHANNEL_ID` | ID del canal utilizado como fallback predeterminado para el canal AI Lounge | (opcional) |
-| `WORKTREE_BASE_DIR` | Directorio base para escanear worktrees de sesión (activa limpieza automática) | (opcional) |
-| `CLI_SESSIONS_PATH` | Ruta a `~/.claude/projects` para descubrimiento de sesiones CLI (habilita `/sync-sessions`) | (opcional) |
-| `MENTION_ONLY_CHANNEL_IDS` | IDs de canal separadas por coma donde el bot solo responde cuando se le @menciona | (opcional) |
-| `INLINE_REPLY_CHANNEL_IDS` | IDs de canal separadas por coma donde el bot responde en línea (sin crear hilo) | (opcional) |
-| `CHAT_ONLY_CHANNEL_IDS` | IDs de canal separadas por coma donde solo se muestran las respuestas de texto de Claude (embeds de herramientas/thinking/Todo ocultos) | (opcional) |
-| `THREAD_INBOX_ENABLED` | Habilita la bandeja de entrada persistente de hilos (clasifica sesiones como `waiting`/`done`/`ambiguous` via `claude -p`; mostrado en el panel de hilos) | `false` |
-| `THREAD_AUTO_RENAME` | Renombra automáticamente los títulos de nuevos hilos con Claude AI — genera un título corto y descriptivo del primer mensaje del usuario mediante una llamada a `claude -p` en segundo plano (sin retrasar el inicio de la sesión) | `false` |
-| `CCDB_CLI_ENV_FILE` | Ruta a un archivo `KEY=VALUE` cuyas variables se mezclan en el entorno del subproceso CLI en cada invocación. Los cambios surten efecto de inmediato sin reiniciar el bot. Útil para enrutamiento de API temporal (p. ej., Azure Foundry) | (opcional) |
-
-### Modos de Permiso — Qué Funciona en el Modo `-p`
-
-Claude Code CLI se ejecuta en **modo `-p` (no interactivo)** cuando se usa a través de ccdb. En este modo, el CLI **no puede solicitar permisos** — las herramientas que requieren aprobación son rechazadas de inmediato. Esta es una [restricción de diseño del CLI](https://code.claude.com/docs/en/headless), no una limitación de ccdb.
-
-| Modo | Comportamiento en modo `-p` | Recomendación |
-|------|----------------------|----------------|
-| `default` | ❌ **Todas las herramientas rechazadas** — inutilizable | No usar |
-| `acceptEdits` | ⚠️ Edit/Write aprobados automáticamente, Bash rechazado (Claude usa Write para operaciones de archivo) | Opción mínima viable |
-| `bypassPermissions` | ✅ Todas las herramientas aprobadas | Funciona, pero preferir la opción abajo |
-| **`CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`** | ✅ **Todas las herramientas aprobadas** | **Recomendado** — ccdb ya restringe el acceso con `allowed_user_ids` |
-
-**Nuestra recomendación:** Configura `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`. Como ccdb controla quién puede interactuar con Claude mediante `allowed_user_ids`, las verificaciones de permisos a nivel del CLI añaden fricción sin beneficio de seguridad real. El «dangerously» en el nombre refleja la advertencia general del CLI; en el contexto de ccdb donde el acceso ya está restringido, es la elección práctica.
-
-**Para control granular**, usa `CLAUDE_ALLOWED_TOOLS` para permitir herramientas específicas sin bypassear completamente los permisos:
-
-```env
-# Ejemplo: permitir operaciones de archivo y ejecución de código, pero no acceso web
-CLAUDE_ALLOWED_TOOLS=Bash,Read,Write,Edit,Glob,Grep
-
-# Ejemplo: modo solo lectura — Claude puede explorar pero no modificar
-CLAUDE_ALLOWED_TOOLS=Read,Glob,Grep
-```
-
-Nombres de herramientas comunes: `Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`, `WebFetch`, `WebSearch`, `NotebookEdit`. Configura `CLAUDE_PERMISSION_MODE=default` cuando uses esto (otros modos pueden sobreescribirlo).
-
-> **¿Por qué no aparecen botones de permisos en Discord?** El modo `-p` del CLI nunca emite eventos `permission_request`, por lo que no hay nada que ccdb pueda mostrar. Los botones `AskUserQuestion` que ves (prompts de selección de Claude) son un mecanismo diferente que funciona correctamente. Consulta [#210](https://github.com/ebibibi/claude-code-discord-bridge/issues/210) para la investigación completa.
-
----
-
-## Configuración del Bot de Discord
-
-1. Crea una nueva aplicación en el [Portal de Desarrolladores de Discord](https://discord.com/developers/applications)
-2. Crea un bot y copia el token
-3. Activa **Message Content Intent** en Privileged Gateway Intents
-4. Invita al bot con estos permisos:
-   - Send Messages
-   - Create Public Threads
-   - Send Messages in Threads
-   - Add Reactions
-   - Manage Messages (para limpiar reacciones)
-   - Read Message History
-
----
-
-## GitHub + Automatización con Claude Code
-
-### Ejemplo: Sincronización Automática de Documentación
-
-En cada push a `main`, Claude Code:
-1. Obtiene los últimos cambios y analiza el diff
-2. Actualiza la documentación en inglés
-3. Traduce al japonés (o cualquier idioma objetivo)
-4. Crea un PR con resumen bilingüe
-5. Activa auto-merge — se fusiona automáticamente cuando CI pasa
-
-**GitHub Actions:**
-
-```yaml
-# .github/workflows/docs-sync.yml
-name: Documentation Sync
-on:
-  push:
-    branches: [main]
-jobs:
-  trigger:
-    if: "!contains(github.event.head_commit.message, '[docs-sync]')"
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          curl -X POST "${{ secrets.DISCORD_WEBHOOK_URL }}" \
-            -H "Content-Type: application/json" \
-            -d '{"content": "🔄 docs-sync"}'
-```
-
-**Configuración del bot:**
-
-```python
-from claude_discord import WebhookTriggerCog, WebhookTrigger, ClaudeRunner
-
-runner = ClaudeRunner(command="claude", model="sonnet")
-
-triggers = {
-    "🔄 docs-sync": WebhookTrigger(
-        prompt="Analiza cambios, actualiza docs, crea un PR con resumen bilingüe, activa auto-merge.",
-        working_dir="/home/user/my-project",
-        timeout=600,
-    ),
-}
-
-await bot.add_cog(WebhookTriggerCog(
-    bot=bot,
-    runner=runner,
-    triggers=triggers,
-    channel_ids={YOUR_CHANNEL_ID},
-))
-```
-
-**Seguridad:** Los prompts se definen en el lado del servidor. Los webhooks solo seleccionan qué disparador activar — sin inyección arbitraria de prompts.
-
-### Ejemplo: Auto-aprobación de PRs del propietario
-
-```yaml
-# .github/workflows/auto-approve.yml
-name: Auto Approve Owner PRs
-on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-jobs:
-  auto-approve:
-    if: github.event.pull_request.user.login == 'your-username'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
-    steps:
-      - env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --approve
-          gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --squash
-```
-
----
-
-## Tareas Programadas
-
-Registra tareas periódicas de Claude Code en tiempo de ejecución — sin cambios de código, sin redeploys.
-
-Desde una sesión de Discord, Claude puede registrar una tarea:
-
-```bash
-# Claude llama esto dentro de una sesión:
-curl -X POST "$CCDB_API_URL/api/tasks" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "Verificar dependencias desactualizadas y abrir un issue si se encuentran", "interval_seconds": 604800}'
-```
-
-O registra desde tus propios scripts:
-
-```bash
-curl -X POST http://localhost:8080/api/tasks \
-  -H "Authorization: Bearer your-secret" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "Análisis de seguridad semanal", "interval_seconds": 604800}'
-```
-
-El bucle maestro de 30 segundos detecta las tareas pendientes y crea sesiones de Claude Code automáticamente.
-
----
-
-## Auto-actualización
-
-Actualiza automáticamente el bot cuando se publica una nueva versión:
-
-```python
-from claude_discord import AutoUpgradeCog, UpgradeConfig
-
-config = UpgradeConfig(
-    package_name="claude-code-discord-bridge",
-    trigger_prefix="🔄 bot-upgrade",
-    working_dir="/home/user/my-bot",
-    restart_command=["sudo", "systemctl", "restart", "my-bot.service"],
-    restart_approval=True,  # Reacciona con ✅ para confirmar el reinicio
-)
-
-await bot.add_cog(AutoUpgradeCog(bot, config))
-```
-
-Antes de reiniciar, `AutoUpgradeCog`:
-
-1. **Toma instantánea de sesiones activas** — Recopila todos los hilos con sesiones de Claude en ejecución (duck typing: cualquier Cog con dict `_active_runners` se descubre automáticamente).
-2. **Drena** — Espera a que las sesiones activas terminen naturalmente.
-3. **Marca para reanudar** — Guarda los IDs de hilos activos en la tabla de reanudaciones pendientes. En el próximo inicio, esas sesiones se reanudan automáticamente con un prompt "bot reiniciado, por favor continúa".
-4. **Reinicia** — Ejecuta el comando de reinicio configurado.
-
-Cualquier Cog con una propiedad `active_count` se descubre automáticamente y se drena:
-
-```python
-class MyCog(commands.Cog):
-    @property
-    def active_count(self) -> int:
-        return len(self._running_tasks)
-```
-
-> **Cobertura:** `AutoUpgradeCog` cubre los reinicios por actualización. Para *todos los demás* apagados (`systemctl stop`, `bot.close()`, SIGTERM), `ClaudeChatCog.cog_unload()` proporciona una segunda red de seguridad automática.
+| `DISCORD_OWNER_ID` | ID de usuario a @mencionar cuando Claude necesita input | (opcional) |
+| `COORDINATION_CHANNEL_ID` | ID de canal como fallback predeterminado para AI Lounge | (opcional) |
+| `MENTION_ONLY_CHANNEL_IDS` | IDs de canal donde el bot solo responde cuando se @menciona (separados por coma) | (opcional) |
+| `INLINE_REPLY_CHANNEL_IDS` | IDs de canal para respuesta inline (separados por coma, sin crear hilo) | (opcional) |
+| `CHAT_ONLY_CHANNEL_IDS` | IDs de canal en modo solo chat (separados por coma) | (opcional) |
+| `WORKTREE_BASE_DIR` | Directorio base para escanear worktrees de sesión | (opcional) |
+| `CLI_SESSIONS_PATH` | Ruta para descubrimiento de sesiones CLI (`~/.claude/projects`) | (opcional) |
+| `CUSTOM_COGS_DIR` | Directorio con archivos Cog personalizados | (opcional) |
+| `THREAD_INBOX_ENABLED` | Habilitar bandeja de entrada persistente de hilos | `false` |
+| `THREAD_AUTO_RENAME` | Auto-renombrar hilos con título generado por Claude | `false` |
+| `CCDB_CLI_ENV_FILE` | Ruta a archivo `KEY=VALUE` fusionado en entorno del subproceso CLI | (opcional) |
+| `API_HOST` | Dirección de enlace de REST API | `127.0.0.1` |
+| `API_PORT` | Puerto de REST API (habilita REST API cuando se configura) | (opcional) |
 
 ---
 
@@ -509,102 +333,56 @@ uv add "claude-code-discord-bridge[api]"
 
 | Método | Ruta | Descripción |
 |--------|------|-------------|
-| GET | `/api/health` | Comprobación de estado |
+| GET | `/api/health` | Verificación de salud |
 | POST | `/api/notify` | Enviar notificación inmediata |
-| POST | `/api/schedule` | Programar una notificación |
+| POST | `/api/schedule` | Programar notificación |
 | GET | `/api/scheduled` | Listar notificaciones pendientes |
-| DELETE | `/api/scheduled/{id}` | Cancelar una notificación |
-| POST | `/api/tasks` | Registrar una tarea de Claude Code programada |
+| DELETE | `/api/scheduled/{id}` | Cancelar notificación |
+| POST | `/api/tasks` | Registrar tarea periódica de Claude Code |
 | GET | `/api/tasks` | Listar tareas registradas |
-| DELETE | `/api/tasks/{id}` | Eliminar una tarea |
-| PATCH | `/api/tasks/{id}` | Actualizar una tarea (activar/desactivar, cambiar horario) |
-| POST | `/api/spawn` | Crear un nuevo hilo de Discord e iniciar una sesión de Claude Code (no bloqueante) |
-| POST | `/api/mark-resume` | Marcar un hilo para reanudación automática en el próximo inicio del bot |
-
-```bash
-# Enviar notificación
-curl -X POST http://localhost:8080/api/notify \
-  -H "Authorization: Bearer your-secret" \
-  -H "Content-Type: application/json" \
-  -d '{"message": "¡Build exitoso!", "title": "CI/CD"}'
-
-# Registrar tarea recurrente
-curl -X POST http://localhost:8080/api/tasks \
-  -H "Authorization: Bearer your-secret" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "Resumen diario de standup", "interval_seconds": 86400}'
-```
+| DELETE | `/api/tasks/{id}` | Eliminar tarea |
+| PATCH | `/api/tasks/{id}` | Actualizar tarea |
+| POST | `/api/spawn` | Crear nuevo hilo de Discord e iniciar sesión de Claude Code (no bloqueante) |
+| POST | `/api/mark-resume` | Marcar hilo para reanudación automática en próximo inicio del bot |
+| GET | `/api/lounge` | Leer mensajes recientes del AI Lounge |
+| POST | `/api/lounge` | Publicar mensaje en AI Lounge |
 
 ---
 
 ## Arquitectura
 
 ```
+claude_code_core/          # Biblioteca central compartida (independiente del backend)
+  backend.py               # Protocolo SessionBackend + fábrica create_backend()
+  codex_runner.py          # Backend OpenAI Codex CLI
+  runner.py                # Gestor de subproceso Claude CLI
+  parser.py                # Analizador de eventos stream-json
+  types.py                 # Definiciones de tipos para mensajes SDK
 claude_discord/
-  main.py                  # Punto de entrada autónomo (setup_bridge + cargador de Cogs personalizados)
+  main.py                  # Punto de entrada independiente
   cli.py                   # Punto de entrada CLI (comandos ccdb setup/start)
-  setup.py                 # setup_bridge() — conexión de Cogs con una sola llamada
-  cog_loader.py            # Cargador dinámico de Cogs personalizados (CUSTOM_COGS_DIR)
-  bot.py                   # Clase Discord Bot
-  protocols.py             # Protocolos compartidos (DrainAware)
-  concurrency.py           # Instrucciones de worktree + registro de sesiones activas
-  lounge.py                # Constructor de prompts para AI Lounge
-  session_sync.py          # Descubrimiento e importación de sesiones CLI
-  worktree.py              # WorktreeManager — ciclo de vida seguro de git worktree
+  setup.py                 # setup_bridge() — configuración de Cogs en una llamada
   cogs/
-    claude_chat.py         # Chat interactivo (creación de hilos, manejo de mensajes)
-    skill_command.py       # Comando slash /skill con autocompletado
-    session_manage.py      # /sessions, /sync-sessions, /resume, /resume-info, /sync-settings
-    session_sync.py        # Lógica de creación de hilos y publicación de mensajes para sync-sessions
-    prompt_builder.py      # build_prompt_and_images() — función pura, sin estado Cog/Bot
-    scheduler.py           # Ejecutor de tareas periódicas de Claude Code
-    webhook_trigger.py     # Webhook → tarea de Claude Code (CI/CD)
-    auto_upgrade.py        # Webhook → actualización de paquete + reinicio con drenaje
-    event_processor.py     # EventProcessor — máquina de estados para eventos stream-json
-    run_config.py          # RunConfig dataclass — agrupa todos los parámetros de ejecución CLI
-    _run_helper.py         # Capa de orquestación delgada
-  claude/
-    runner.py              # Gestor de subprocesos Claude CLI
-    parser.py              # Parser de eventos stream-json
-    types.py               # Definiciones de tipos para mensajes SDK
-  database/
-    models.py              # Esquema SQLite
-    repository.py          # CRUD de sesiones
-    task_repo.py           # CRUD de tareas programadas
-    ask_repo.py            # CRUD de AskUserQuestion pendientes
-    notification_repo.py   # CRUD de notificaciones programadas
-    lounge_repo.py         # CRUD de mensajes de AI Lounge
-    resume_repo.py         # CRUD de reanudación al inicio
-    settings_repo.py       # Configuración por servidor
-  discord_ui/
-    status.py              # Gestor de reacciones emoji (con debounce)
-    chunker.py             # División de mensajes con conocimiento de bloques y tablas
-    embeds.py              # Constructores de embeds de Discord
-    views.py               # Botón de parada y componentes UI compartidos
-    ask_bus.py             # Bus de eventos para comunicación AskUserQuestion
-    ask_view.py            # Botones/Menús de Selección para AskUserQuestion
-    ask_handler.py         # collect_ask_answers() — UI + ciclo de vida DB de AskUserQuestion
-    streaming_manager.py   # StreamingMessageManager — ediciones de mensaje en sitio con debounce
-    tool_timer.py          # LiveToolTimer — contador de tiempo transcurrido para herramientas largas
-    thread_dashboard.py    # Embed fijo en vivo mostrando estados de sesión
-    plan_view.py           # Botones Aprobar/Cancelar para Plan Mode (ExitPlanMode)
-    permission_view.py     # Botones Permitir/Denegar para solicitudes de permiso de herramientas
-    elicitation_view.py    # UI de Discord para MCP Elicitation (formulario Modal o botón URL)
-    file_sender.py         # Entrega de archivos via .ccdb-attachments
+    claude_chat.py         # Chat interactivo
+    skill_command.py       # Comando slash /skill
+    session_manage.py      # Gestión de sesiones
+    scheduler.py           # Ejecutor de tareas periódicas
+    webhook_trigger.py     # Webhook → ejecución de tareas Claude Code
+    auto_upgrade.py        # Auto-actualización + reinicio con drenaje
   ext/
-    api_server.py          # REST API (opcional, requiere aiohttp)
-  utils/
-    logger.py              # Configuración de logging
+    api_server.py          # REST API (opcional)
+examples/
+  ebibot/                  # Ejemplo del mundo real
 ```
 
 ### Filosofía de Diseño
 
-- **Invocación CLI, no API** — Invoca `claude -p --output-format stream-json`, dando características completas de Claude Code (CLAUDE.md, skills, herramientas, memoria) sin reimplementarlas
-- **Concurrencia primero** — Múltiples sesiones simultáneas son el caso esperado, no un caso límite; cada sesión recibe instrucciones de worktree, el registro y el AI Lounge manejan el resto
-- **Discord como pegamento** — Discord proporciona UI, hilos, reacciones, webhooks y notificaciones persistentes; sin frontend personalizado necesario
-- **Framework, no aplicación** — Instala como paquete, añade Cogs a tu bot existente, configura via código
-- **Extensibilidad sin código** — Añade tareas programadas y disparadores webhook sin tocar el código fuente
-- **Seguridad por simplicidad** — ~3000 líneas de Python auditables; solo subprocess exec, sin expansión de shell
+- **Spawn de CLI, no API** — Invoca `claude -p --output-format stream-json`, obteniendo todas las características de Claude Code sin reimplementarlas. Sin API key, sin facturación por token.
+- **Concurrencia primero** — Múltiples sesiones simultáneas son el caso esperado
+- **Discord como pegamento** — Discord proporciona UI, hilos, reacciones, webhooks y notificaciones persistentes
+- **Framework, no aplicación** — Instala como paquete, añade Cogs a tu bot existente
+- **Extensibilidad sin código** — Añade tareas programadas y disparadores de webhook sin tocar el código fuente
+- **Seguridad por simplicidad** — ~8000 líneas de Python auditable; solo subprocess exec, sin expansión de shell
 
 ---
 
@@ -614,37 +392,38 @@ claude_discord/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-1050+ pruebas cubriendo parser, chunker, repositorio, runner, streaming, disparadores webhook, auto-actualización (incluyendo el comando `/upgrade`, invocación desde hilo y botón de aprobación), REST API, UI de AskUserQuestion, panel de hilos, tareas programadas, sincronización de sesiones, AI Lounge, reanudación al inicio, cambio de modelo, detección de compactado, embeds de progreso de TodoWrite, y análisis de eventos de permiso/elicitation/plan-mode.
+Más de 1365 pruebas cubriendo analizador, chunker, repositorio, runner, streaming, disparadores de webhook, auto-actualización, REST API, AskUserQuestion UI, panel de hilos, tareas programadas, sincronización de sesiones, AI Lounge, reanudación al inicio, cambio de modelo, detección de compresión, embeds de progreso TodoWrite, cargador de Cogs personalizados, protocolo SessionBackend, CodexRunner y fábrica de backends.
 
 ---
 
-## Cómo Se Construyó Este Proyecto
+## Cómo se Construyó este Proyecto
 
-**Todo este código base fue escrito por [Claude Code](https://docs.anthropic.com/en/docs/claude-code)**, el agente de codificación con IA de Anthropic. El autor humano ([@ebibibi](https://github.com/ebibibi)) proporcionó requisitos y dirección en lenguaje natural, pero no leyó ni editó manualmente el código fuente.
-
-Esto significa:
-
-- **Todo el código fue generado por IA** — arquitectura, implementación, pruebas, documentación
-- **El autor humano no puede garantizar la corrección a nivel de código** — revisa el código fuente si necesitas certeza
-- **Los reportes de bugs y PRs son bienvenidos** — Claude Code será usado para abordarlos
-- **Este es un ejemplo real de software open source escrito por IA**
+**Este codebase es desarrollado por [Claude Code](https://docs.anthropic.com/en/docs/claude-code)**, el agente de codificación AI de Anthropic, bajo la dirección de [@ebibibi](https://github.com/ebibibi). El autor humano define requisitos, revisa pull requests y aprueba todos los cambios — Claude Code hace la implementación.
 
 El proyecto comenzó el 2026-02-18 y continúa evolucionando a través de conversaciones iterativas con Claude Code.
 
 ---
 
-## Ejemplo Real
+## Ejemplo del Mundo Real
 
-**[EbiBot](https://github.com/ebibibi/discord-bot)** — Un bot personal de Discord construido sobre este framework. Incluye sincronización automática de documentación (inglés + japonés), notificaciones push, watchdog de Todoist, comprobaciones de salud programadas y CI/CD con GitHub Actions. Úsalo como referencia para construir tu propio bot.
+**[`examples/ebibot/`](examples/ebibot/)** — Un bot personal de Discord construido sobre este framework, incluido directamente en este repositorio. Demuestra el cargador de Cogs personalizado con:
+
+- **ReminderCog** — Comando slash `/remind HH:MM "mensaje"` + bucle de envío de 30 segundos
+- **WatchdogCog** — Monitor de tareas vencidas de Todoist
+- **AutoUpgradeCog** — Auto-actualización mediante GitHub webhook + systemctl restart
+- **DocsSyncCog** — Auto-traducción de documentación en cada push
+- **AlertResponderCog** — Cog de monitoreo de alertas genérico
+
+Ejecutar con: `ccdb start --cogs-dir examples/ebibot/cogs/`
 
 ---
 
-## Inspirado en
+## Inspirado Por
 
-- [OpenClaw](https://github.com/openclaw/openclaw) — Reacciones emoji de estado, debounce de mensajes, división con conocimiento de bloques
-- [claude-code-discord-bot](https://github.com/timoconnellaus/claude-code-discord-bot) — Enfoque de invocación CLI + stream-json
+- [OpenClaw](https://github.com/openclaw/openclaw) — Reacciones emoji de estado, debouncing de mensajes, chunking consciente de fence
+- [claude-code-discord-bot](https://github.com/timoconnellaus/claude-code-discord-bot) — Enfoque CLI spawn + stream-json
 - [claude-code-discord](https://github.com/zebbern/claude-code-discord) — Patrones de control de permisos
-- [claude-sandbox-bot](https://github.com/RhysSullivan/claude-sandbox-bot) — Modelo de hilo por conversación
+- [claude-sandbox-bot](https://github.com/RhysSullivan/claude-sandbox-bot) — Modelo de conversación por hilo
 
 ---
 

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -3,43 +3,48 @@
 > **Remarque :** Ceci est une version traduite automatiquement de la documentation originale en anglais.
 > En cas de divergence, la [version anglaise](../../README.md) fait foi.
 
-# claude-code-discord-bridge
+# Claude & Codex Discord Bridge
+
+*Nom du package : `claude-code-discord-bridge` (kebab-case)*
 
 [![CI](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**Exécutez plusieurs sessions Claude Code en parallèle — en toute sécurité — via Discord.**
+**Utilisez Claude Code _ou_ OpenAI Codex depuis votre téléphone. Plusieurs fils. Tout en même temps. Développement réel inclus.**
 
-Chaque fil Discord devient une session Claude Code isolée. Lancez-en autant que nécessaire : travaillez sur une fonctionnalité dans un fil, révisez un PR dans un autre, exécutez une tâche planifiée dans un troisième. Le bridge gère automatiquement la coordination pour que les sessions simultanées ne se perturbent pas mutuellement.
+Ouvrez Claude Code ou OpenAI Codex depuis l'application Discord de votre smartphone, lancez plusieurs fils et exécutez des sessions de développement en parallèle — sans toucher un clavier. Chaque fil Discord devient une session IA complètement isolée. Travaillez sur une fonctionnalité dans un fil, révisez un PR dans un autre et exécutez une tâche en arrière-plan dans un troisième — simultanément, en mélangeant même les backends par fil. Le bridge gère toute la coordination pour que les sessions ne se chevauchent jamais.
+
+**Utilisez vos abonnements existants. Sans configuration de clé API.** ccdb fonctionne sur les CLIs officielles — Claude Code (inclus dans votre [abonnement Claude Pro/Max](https://claude.ai/pricing)) et OpenAI Codex (inclus dans [ChatGPT Plus/Pro/Business](https://chatgpt.com)). Changez de backend avec `/backend` ou configurez par fil — votre équipe accède aux deux IA via Discord à un coût prévisible.
 
 **[English](../../README.md)** | **[日本語](../ja/README.md)** | **[简体中文](../zh-CN/README.md)** | **[한국어](../ko/README.md)** | **[Español](../es/README.md)** | **[Português](../pt-BR/README.md)**
 
-> **Avertissement :** Ce projet n'est pas affilié, approuvé ou officiellement connecté à Anthropic. « Claude » et « Claude Code » sont des marques déposées d'Anthropic, PBC. Ceci est un outil open source indépendant qui s'interface avec Claude Code CLI.
+> **Avertissement :** Ce projet n'est pas affilié, approuvé ni officiellement connecté à Anthropic ou OpenAI. « Claude » et « Claude Code » sont des marques commerciales d'Anthropic, PBC ; « OpenAI », « Codex » et « ChatGPT » sont des marques commerciales d'OpenAI. Il s'agit d'un outil open source indépendant qui s'interface avec Claude Code CLI et OpenAI Codex CLI.
 
-> **Entièrement construit par Claude Code.** L'intégralité de ce code base — architecture, implémentation, tests, documentation — a été écrite par Claude Code lui-même. L'auteur humain a fourni les exigences et la direction en langage naturel, mais n'a pas lu ni édité manuellement le code source. Voir [Comment ce projet a été construit](#comment-ce-projet-a-été-construit).
+> **Entièrement construit par Claude Code.** L'ensemble de ce codebase — architecture, implémentation, tests, documentation — a été écrit par Claude Code lui-même. L'auteur humain a fourni les exigences et la direction. Voir [Comment ce projet a été construit](#comment-ce-projet-a-été-construit).
 
 ---
 
-## La Grande Idée : Des Sessions Parallèles Sans Crainte
+## La Grande Idée : Sessions Parallèles Sans Crainte
 
-Quand vous envoyez des tâches à Claude Code dans des fils Discord séparés, le bridge fait automatiquement trois choses :
+Lorsque vous envoyez des tâches à Claude Code dans des fils Discord séparés, le bridge fait automatiquement quatre choses :
 
-1. **Injection d'avis de concurrence** — Le prompt système de chaque session inclut des instructions obligatoires : créez un git worktree, travaillez uniquement à l'intérieur, ne touchez jamais directement au répertoire de travail principal.
+1. **Injection d'avis de concurrence** — Le system prompt de chaque session inclut des instructions obligatoires : créer un git worktree, travailler uniquement à l'intérieur, ne jamais toucher le répertoire de travail principal directement.
 
-2. **Registre des sessions actives** — Chaque session en cours d'exécution connaît les autres. Si deux sessions sont sur le point de toucher au même dépôt, elles peuvent se coordonner plutôt que d'entrer en conflit.
+2. **Registre de sessions actives** — Chaque session en cours d'exécution connaît les autres. Si deux sessions vont toucher le même dépôt, elles peuvent se coordonner plutôt que d'entrer en conflit.
 
-3. **AI Lounge** — Une « salle d'attente » partagée injectée dans le prompt de chaque session. Avant de commencer, chaque session lit les messages récents du Lounge pour connaître l'état des autres. Avant les opérations destructives (force push, redémarrage du bot, etc.), les sessions vérifient le Lounge en premier.
+3. **AI Lounge** — Un « salon de repos » injecté dans chaque prompt. Avant de commencer, chaque session lit les messages récents du lounge pour voir ce que font les autres. Avant les opérations destructives (force push, redémarrage du bot, suppression DB), les sessions vérifient d'abord le lounge.
 
 ```
-Fil A (fonctionnalité) ──→  Claude Code (worktree-A)  ─┐
-Fil B (révision PR)    ──→  Claude Code (worktree-B)   ├─→  #ai-lounge
-Fil C (docs)           ──→  Claude Code (worktree-C)  ─┘    "A : refactor auth en cours"
-                                                             "B : révision PR #42 terminée"
-                                                             "C : mise à jour README"
+Fil A (fonctionnalité)  ──→  Claude Code (worktree-A)  ─┐
+Fil B (révision PR)     ──→  Claude Code (worktree-B)   ├─→  #ai-lounge
+Fil C (docs)            ──→  Claude Code (worktree-C)  ─┘    "A: refactor auth en cours"
+                                                              "B: révision PR #42 terminée"
+                                                              "C: mise à jour README"
 ```
 
-Sans race conditions. Sans travail perdu. Sans surprises au merge.
+Pas de conditions de course. Pas de travail perdu. Pas de surprises lors des merges.
 
 ---
 
@@ -51,59 +56,31 @@ Utilisez Claude Code depuis n'importe où où Discord fonctionne — téléphone
 
 ### Développement Parallèle
 
-Ouvrez plusieurs fils simultanément. Chacun est une session Claude Code indépendante avec son propre contexte, répertoire de travail et git worktree. Schémas utiles :
+Ouvrez plusieurs fils simultanément. Chacun est une session Claude Code indépendante avec son propre contexte, répertoire de travail et git worktree. Modèles utiles :
 
 - **Fonctionnalité + révision en parallèle** : Démarrez une fonctionnalité dans un fil pendant que Claude révise un PR dans un autre.
-- **Plusieurs contributeurs** : Différents membres de l'équipe ont chacun leur fil ; les sessions restent informées les unes des autres via le AI Lounge.
-- **Expérimentez en toute sécurité** : Essayez une approche dans le fil A tout en maintenant le fil B sur du code stable.
+- **Plusieurs contributeurs** : Différents membres de l'équipe ont leurs propres fils ; les sessions restent informées les unes des autres via l'AI Lounge.
+- **Expérimentez en sécurité** : Essayez une approche dans le fil A tout en maintenant le fil B sur du code stable.
 
 ### Tâches Planifiées (SchedulerCog)
 
-Enregistrez des tâches Claude Code périodiques depuis une conversation Discord ou via l'API REST — sans changements de code, sans redéploiements. Les tâches sont stockées dans SQLite et s'exécutent selon un calendrier configurable. Claude peut auto-enregistrer des tâches pendant une session en utilisant `POST /api/tasks`.
+Enregistrez des tâches Claude Code périodiques depuis une conversation Discord ou via l'API REST — sans changements de code, sans redéploiements.
 
 ```
 /skill name:goodmorning         → s'exécute immédiatement
-Claude appelle POST /api/tasks → enregistre une tâche périodique
-SchedulerCog (boucle toutes 30s) → déclenche les tâches dues automatiquement
+Claude appelle POST /api/tasks  → enregistre une tâche périodique
+SchedulerCog (boucle 30s)       → déclenche automatiquement les tâches dues
 ```
 
 ### Automatisation CI/CD
 
 Déclenchez des tâches Claude Code depuis GitHub Actions via des webhooks Discord. Claude s'exécute de manière autonome — lit le code, met à jour la documentation, crée des PRs, active l'auto-merge.
 
-```
-GitHub Actions → Discord Webhook → Bridge → Claude Code CLI
-                                                  ↓
-GitHub PR ←── git push ←── Claude Code ──────────┘
-```
-
-**Exemple concret :** À chaque push sur `main`, Claude analyse le diff, met à jour la documentation en anglais + japonais, crée un PR avec un résumé bilingue et active l'auto-merge. Zéro interaction humaine.
+**Exemple réel :** À chaque push sur `main`, Claude analyse le diff, met à jour la documentation en anglais + japonais, crée un PR bilingue et active l'auto-merge. Zéro interaction humaine.
 
 ### Synchronisation de Sessions
 
-Vous utilisez déjà Claude Code CLI directement ? Synchronisez vos sessions terminal existantes en fils Discord avec `/sync-sessions`. Remplit les messages de conversation récents pour que vous puissiez continuer une session CLI depuis votre téléphone sans perdre le contexte.
-
-### Création Programmatique de Sessions
-
-Créez de nouvelles sessions Claude Code depuis des scripts, GitHub Actions ou d'autres sessions Claude — sans interaction avec des messages Discord.
-
-```bash
-# Depuis une autre session Claude ou un script CI :
-curl -X POST "$CCDB_API_URL/api/spawn" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "Exécuter un scan de sécurité sur le dépôt", "thread_name": "Scan de Sécurité"}'
-# Retourne immédiatement avec l'ID du fil ; Claude s'exécute en arrière-plan
-```
-
-Les sous-processus Claude reçoivent `DISCORD_THREAD_ID` comme variable d'environnement, donc une session en cours peut créer des sessions enfants pour paralléliser le travail.
-
-### Reprise au Démarrage
-
-Si le bot redémarre en cours de session, les sessions Claude interrompues reprennent automatiquement quand le bot revient en ligne. Les sessions sont marquées pour reprise de trois façons :
-
-- **Automatique (redémarrage par mise à jour)** — `AutoUpgradeCog` prend un snapshot de toutes les sessions actives juste avant un redémarrage par mise à jour de package et les marque automatiquement.
-- **Automatique (n'importe quel arrêt)** — `ClaudeChatCog.cog_unload()` marque toutes les sessions en cours quand le bot s'arrête par n'importe quel mécanisme (`systemctl stop`, `bot.close()`, SIGTERM, etc.).
-- **Manuel** — N'importe quelle session peut appeler `POST /api/mark-resume` directement.
+Vous utilisez déjà Claude Code CLI directement ? Synchronisez vos sessions de terminal existantes dans des fils Discord avec `/sync-sessions`. Remplit les messages de conversation récents pour que vous puissiez continuer une session CLI depuis votre téléphone sans perdre le contexte.
 
 ---
 
@@ -112,171 +89,190 @@ Si le bot redémarre en cours de session, les sessions Claude interrompues repre
 ### Chat Interactif
 
 #### 🔗 Bases de Session
-- **Thread = Session** — Mappage 1:1 entre fil Discord et session Claude Code
-- **Persistance de session** — Reprend les conversations entre messages via `--resume`
-- **Sessions simultanées** — Plusieurs sessions parallèles avec limite configurable
-- **Arrêt sans effacement** — `/stop` arrête une session en la préservant pour reprise
-- **Interruption de session** — Envoyer un nouveau message à un fil actif envoie SIGINT à la session en cours et recommence avec la nouvelle instruction ; pas de `/stop` manuel nécessaire
-- **Renommage automatique des fils** — Quand `THREAD_AUTO_RENAME=true`, chaque nouveau fil est automatiquement renommé avec un titre généré par Claude basé sur le premier message (tâche en arrière-plan, sans délai de démarrage de session)
+- **Mode chat uniquement** — `CHAT_ONLY_CHANNEL_IDS` n'affiche que les réponses textuelles de Claude ; les embeds d'outils, blocs de réflexion, embeds de session et listes de tâches sont masqués
+- **Fil = Session** — Mappage 1:1 entre fil Discord et session Claude Code
+- **Suivi d'objectif** — `/goal <condition>` définit une condition de fin ; Claude continue à travailler jusqu'à ce qu'elle soit remplie
+- **Persistance de session** — Continue les conversations entre les messages via `--resume`
+- **Sessions concurrentes** — Plusieurs sessions parallèles avec limite configurable
+- **Arrêter sans effacer** — `/stop` arrête une session en la préservant pour une reprise
+- **Interruption de session** — Envoyer un nouveau message à un fil actif envoie SIGINT et recommence avec la nouvelle instruction
+- **Renommage automatique des fils** — Avec `THREAD_AUTO_RENAME=true`, chaque nouveau fil est automatiquement renommé
 
 #### 📡 Retour en Temps Réel
 - **Statut en temps réel** — Réactions emoji : 🧠 réflexion, 🛠️ lecture de fichiers, 💻 édition, 🌐 recherche web
-- **Texte en streaming** — Le texte intermédiaire de l'assistant apparaît pendant que Claude travaille
-- **Embeds de résultats d'outils** — Résultats en direct avec temps écoulé augmentant toutes les 10s ; résultats d'une seule ligne affichés directement, résultats multi-lignes réduits derrière un bouton d'expansion
-- **Pensée étendue** — Raisonnement affiché sous forme d'embeds avec spoiler (cliquer pour révéler)
-- **Tableau de bord des fils** — Embed épinglé en direct montrant quels fils sont actifs vs. en attente ; le propriétaire est @mentionné quand une saisie est nécessaire
+- **Texte en streaming** — Le texte intermédiaire apparaît pendant que Claude travaille
+- **Embeds de résultat d'outil** — Résultats d'appels d'outils en direct avec temps écoulé
+- **Réflexion étendue** — Raisonnement affiché comme embeds avec balise spoiler (cliquer pour révéler)
+- **Tableau de bord des fils** — Embed épinglé en direct montrant les fils actifs vs. en attente
 
-#### 🤝 Collaboration Humain-IA
-- **Questions interactives** — `AskUserQuestion` s'affiche en Boutons Discord ou Menu de Sélection ; la session reprend avec votre réponse ; les boutons survivent aux redémarrages du bot
-- **Plan Mode** — Quand Claude appelle `ExitPlanMode`, un embed Discord affiche le plan complet avec des boutons Approuver/Annuler ; Claude continue seulement après approbation ; annulation automatique après 5 minutes
-- **Demandes de permission d'outil** — Quand Claude a besoin d'une permission pour exécuter un outil, Discord affiche des boutons Autoriser/Refuser avec le nom et l'entrée de l'outil ; refus automatique après 2 minutes
-- **MCP Elicitation** — Les serveurs MCP peuvent demander une saisie utilisateur via Discord (mode formulaire : jusqu'à 5 champs Modal du schéma JSON ; mode URL : bouton URL + confirmation) ; délai de 5 minutes
-- **Progression en direct de TodoWrite** — Quand Claude appelle `TodoWrite`, un seul embed Discord est publié et édité en place à chaque mise à jour ; affiche ✅ terminé, 🔄 actif (avec étiquette `activeForm`), ⬜ en attente
+#### 🤝 Human-in-the-Loop
+- **Questions interactives** — `AskUserQuestion` rendu comme boutons ou menu de sélection Discord
+- **Mode Plan** — `ExitPlanMode` affiche un embed Discord avec boutons Approuver/Annuler ; timeout 5 minutes
+- **Demandes de permission d'outil** — Boutons Autoriser/Refuser ; refus automatique après 2 minutes
+- **MCP Elicitation** — Les serveurs MCP peuvent demander des saisies utilisateur via Discord ; timeout 5 minutes
+- **Progression TodoWrite en direct** — Embed Discord unique édité sur place
 
 #### 📊 Observabilité
-- **Utilisation de tokens** — Taux de succès du cache et nombre de tokens affichés dans l'embed de session terminée
-- **Utilisation du contexte** — Pourcentage de la fenêtre de contexte (tokens d'entrée + cache, hors sortie) et capacité restante jusqu'à l'auto-compactage affichés dans l'embed de session terminée ; ⚠️ avertissement au-dessus de 83,5%
-- **Détection de compactage** — Notifie dans le fil quand la compaction du contexte se produit (type de déclencheur + nombre de tokens avant compactage)
-- **Notification de blocage** — Message dans le fil en l'absence d'activité (réflexion étendue ou compression de contexte) ; réinitialise automatiquement quand Claude reprend. Les seuils s'adaptent au modèle : 30 s pour les modèles standard, 120 s pour Opus (pauses de réflexion plus longues)
-- **Notifications de timeout** — Embed avec temps écoulé et guide de reprise en cas de timeout
-- **Boîte de réception des fils** — Quand `THREAD_INBOX_ENABLED=true`, le tableau de bord affiche une section 📬 persistante ; après chaque fin de session, Claude classe le dernier message (`waiting`/`done`/`ambiguous`) via un appel léger à `claude -p` ; les fils attendant une réponse survivent aux redémarrages du bot et sont affichés jusqu'à votre réponse
+- **Utilisation de tokens** — Taux de succès du cache et comptages de tokens dans l'embed de session terminée
+- **Utilisation du contexte** — Pourcentage de fenêtre de contexte ; avertissement ⚠️ au-dessus de 83,5%
+- **Détection de compaction** — Notifie dans le fil lorsque la compaction de contexte se produit
+- **Notification de blocage prolongé** — Message dans le fil après inactivité (30s standard, 120s pour Opus)
+- **Notifications de timeout** — Embed avec temps écoulé et guide de reprise
+- **Affichage StatusLine** — Affiche le statut de Claude après chaque session
+- **Boîte de réception des fils** — Avec `THREAD_INBOX_ENABLED=true`, section 📬 dans le tableau de bord
 
-#### 🔌 Entrée et Skills
-- **Support des pièces jointes** — Fichiers texte ajoutés automatiquement au prompt (jusqu'à 5 × 50 Ko) ; images téléchargées et transmises via `--image` (jusqu'à 4 × 5 Mo)
-- **Exécution de skills** — Commande `/skill` avec autocomplétion, arguments optionnels, reprise dans le fil
-- **Hot reload** — Les nouveaux skills ajoutés à `~/.claude/skills/` sont détectés automatiquement (actualisation toutes les 60s, sans redémarrage)
+#### 🔌 Entrée et Compétences
+- **Support des pièces jointes** — Fichiers texte ajoutés automatiquement (jusqu'à 5 fichiers, 200 Ko chacun) ; images comme URLs CDN (jusqu'à 4 × 5 Mo)
+- **Livraison de fichiers à la demande** — Claude écrit le chemin dans `.ccdb-attachments` ; envoyé comme pièce jointe Discord à la fin de la session
+- **Exécution de compétences** — Commande `/skill` avec autocomplétion ; compétences des plugins installés aussi découvertes
+- **Hot reload** — Les nouvelles compétences dans `~/.claude/skills/` détectées automatiquement (actualisation 60s)
 
 ### Concurrence et Coordination
-- **Instructions de worktree auto-injectées** — Chaque session est invitée à utiliser `git worktree` avant de toucher à un fichier
-- **Nettoyage automatique de worktree** — Les worktrees de session (`wt-{thread_id}`) sont supprimés automatiquement à la fin de session et au démarrage du bot ; les worktrees avec des modifications ne sont jamais supprimés automatiquement (invariant de sécurité)
-- **Registre des sessions actives** — Registre en mémoire ; chaque session voit ce que font les autres
-- **AI Lounge** — Canal «salle de repos» partagée ; contexte injecté via `--append-system-prompt` (éphémère, ne s'accumule jamais dans l'historique) pour que les longues sessions n'atteignent jamais «Prompt is too long» ; les sessions publient leurs intentions, lisent le statut des autres et vérifient avant les opérations destructives ; les humains le voient comme un fil d'activité en temps réel
-- **Canal de coordination** — La variable d'environnement `COORDINATION_CHANNEL_ID` est utilisée comme valeur de repli par défaut pour le canal AI Lounge (les notifications automatiques de cycle de vie du bot ont été supprimées)
+- **Instructions Worktree auto-injectées** — Chaque session incitée à utiliser `git worktree`
+- **Nettoyage automatique des worktrees** — Worktrees de session supprimés automatiquement ; les worktrees sales ne sont jamais supprimés automatiquement
+- **Registre de sessions actives** — Registre en mémoire ; chaque session voit ce que font les autres
+- **AI Lounge** — Canal partagé ; contexte injecté via `--append-system-prompt` (n'accumule pas dans l'historique)
+- **Canal de coordination** — `COORDINATION_CHANNEL_ID` comme fallback par défaut pour AI Lounge
 
 ### Tâches Planifiées
-- **SchedulerCog** — Exécuteur de tâches périodiques avec support SQLite et une boucle maître de 30 secondes
-- **Auto-enregistrement** — Claude enregistre des tâches via `POST /api/tasks` pendant une session de chat
-- **Sans changements de code** — Ajoute, supprime ou modifie des tâches à l'exécution
-- **Activer/désactiver** — Pause des tâches sans les supprimer (`PATCH /api/tasks/{id}`)
+- **SchedulerCog** — Exécuteur de tâches périodiques avec support SQLite, boucle maître 30 secondes
+- **Auto-enregistrement** — Claude enregistre des tâches via `POST /api/tasks`
+- **Sans changements de code** — Ajoutez, supprimez ou modifiez des tâches à l'exécution
+- **Activer/désactiver** — Mettez en pause les tâches sans les supprimer (`PATCH /api/tasks/{id}`)
 
 ### Automatisation CI/CD
-- **Déclencheurs webhook** — Déclenche des tâches Claude Code depuis GitHub Actions ou tout système CI/CD
-- **Mise à jour automatique** — Met à jour automatiquement le bot quand des packages upstream sont publiés
-- **Redémarrage avec drainage** — Attend que les sessions actives se terminent avant de redémarrer
-- **Marquage automatique de reprise** — Les sessions actives sont automatiquement marquées pour reprise lors de tout arrêt (redémarrage par mise à jour via `AutoUpgradeCog`, ou tout autre arrêt via `ClaudeChatCog.cog_unload()`) ; elles reprennent où elles s'étaient arrêtées après le redémarrage du bot
-- **Approbation de redémarrage** — Portail optionnel pour confirmer les mises à jour avant de les appliquer
+- **Déclencheurs Webhook** — Déclenchez des tâches depuis GitHub Actions ou tout système CI/CD
+- **Auto-mise à jour** — Met à jour le bot automatiquement lors de publications de packages en amont
+- **Redémarrage DrainAware** — Attend que les sessions actives se terminent avant de redémarrer
+- **Marquage automatique de reprise** — Les sessions actives sont automatiquement marquées lors de tout arrêt
+- **Déclencheur manuel de mise à jour** — Commande `/upgrade` (opt-in via `slash_command_enabled=True`)
 
-### Gestion des Sessions
-- **Synchronisation de sessions** — Importe les sessions CLI comme fils Discord (`/sync-sessions`) ; `/sync-settings` pour afficher ou modifier les préférences de synchronisation (style de fil, fenêtre temporelle, résultats minimum)
-- **Liste des sessions** — `/sessions` avec filtrage par origine (Discord / CLI / toutes) et fenêtre temporelle
-- **Reprise de session** — `/resume` affiche un menu de sélection des sessions récentes (jusqu'à 25) et reprend celle sélectionnée dans un nouveau fil ; paramètre optionnel `query` pour la recherche par mot-clé (correspond au résumé et au répertoire de travail), `filter=orphaned` pour afficher uniquement les sessions des fils supprimés ; fonctionne depuis n'importe quel canal ou fil — crée toujours un nouveau fil dans le canal principal configuré
-- **Informations de reprise** — `/resume-info` affiche la commande CLI pour continuer la session actuelle dans un terminal (fils uniquement)
-- **Effacer la session** — `/clear` réinitialise la session Claude Code pour le fil actuel, repartant de zéro sans créer un nouveau fil
-- **Reprise au démarrage** — Les sessions interrompues redémarrent automatiquement après tout redémarrage du bot ; `AutoUpgradeCog` (redémarrages par mise à jour) et `ClaudeChatCog.cog_unload()` (tous les autres arrêts) les marquent automatiquement, ou utilisez `POST /api/mark-resume` manuellement
-- **Création programmatique** — `POST /api/spawn` crée un nouveau fil Discord + session Claude depuis n'importe quel script ou sous-processus Claude ; retourne un 201 non bloquant immédiatement après la création du fil
-- **Injection d'ID de fil** — La variable d'environnement `DISCORD_THREAD_ID` est passée à chaque sous-processus Claude, permettant aux sessions de créer des sessions enfants via `$CCDB_API_URL/api/spawn`
-- **Affichage de StatusLine** — Si `settings.json` de Claude Code a `statusLine` configuré, sa sortie est affichée dans Discord après chaque réponse de session
-- **Gestion des worktrees** — `/worktree-list` affiche tous les worktrees de session actifs avec leur statut propre/sale ; `/worktree-cleanup` supprime les worktrees propres orphelins (supporte la prévisualisation avec `dry_run`)
-- **Rembobiner la conversation** — `/rewind` réinitialise l'historique des échanges tout en conservant les fichiers de travail créés par Claude ; le message de confirmation affiche le % d'utilisation du contexte au moment du rembobinage
-- **Bifurquer la conversation** — `/fork` utilise `--fork-session` pour créer un nouveau fil depuis le même état de session, vous permettant d'explorer une direction différente sans affecter le fil original
-- **Visibilité du contexte** — `/context` affiche le % d'utilisation de la fenêtre de contexte avec une barre de progression visuelle ; affiche un avertissement ⚠️ d'autocompactage en approchant du seuil de 83,5 %
-- **Surveillance des limites de débit** — `/usage` affiche l'utilisation des limites de débit de l'API Claude avec une barre de pourcentage et un compte à rebours jusqu'à la réinitialisation pour chaque type de limite
-- **Aide intégrée** — `/help` affiche toutes les commandes slash disponibles et l'utilisation basique (éphémère, visible uniquement pour l'appelant)
-- **Changement de modèle à l'exécution** — `/model-show` affiche le modèle global actuel et le modèle de session par fil ; `/model-set` change le modèle pour toutes les nouvelles sessions sans redémarrer
-- **Permissions d'outils à l'exécution** — `/tools-show` affiche les outils actuellement autorisés ; `/tools-set` ouvre un menu de sélection pour activer/désactiver les outils ; `/tools-reset` restaure la valeur par défaut de `.env` — le tout sans redémarrage
+### Gestion de Session
+- **Aide intégrée** — `/help` affiche toutes les commandes slash disponibles (éphémère)
+- **Synchronisation de session** — Importez des sessions CLI comme fils Discord (`/sync-sessions`)
+- **Liste de sessions** — `/sessions` avec filtrage par origine et fenêtre temporelle
+- **Reprendre une session** — `/resume` affiche un menu de sélection et reprend dans un nouveau fil
+- **Effacer une session** — `/clear` réinitialise la session Claude Code du fil actuel
+- **Reprise au démarrage** — Les sessions interrompues reprennent automatiquement après tout redémarrage du bot
+- **Spawn programmatique** — `POST /api/spawn` crée un nouveau fil + session depuis n'importe quel script
+- **Gestion des Worktrees** — `/worktree-list` et `/worktree-cleanup`
+- **Changement de modèle à l'exécution** — `/model-show` et `/model-set`, sans redémarrer
+- **Rembobinage de conversation** — `/rewind` tronque la session au tour sélectionné
+- **Bifurcation de conversation** — `/fork` crée une copie de session indépendante dans un nouveau fil
 
 ### Sécurité
-- **Pas d'injection shell** — Uniquement `asyncio.create_subprocess_exec`, jamais `shell=True`
-- **Validation des ID de session** — Regex strict avant de passer à `--resume`
+- **Pas d'injection de shell** — Seulement `asyncio.create_subprocess_exec`, jamais `shell=True`
+- **Validation de l'ID de session** — Regex stricte avant de passer à `--resume`
 - **Prévention d'injection de flags** — Séparateur `--` avant tous les prompts
-- **Isolation des secrets** — Le token du bot est supprimé de l'environnement du sous-processus
-- **Autorisation utilisateur** — `allowed_user_ids` restreint qui peut invoquer Claude
-- **Prévention d'injection dans les logs** — Les valeurs API fournies par l'utilisateur sont assainies (suppression des sauts de ligne et des séquences d'échappement ANSI) avant d'être écrites dans les logs
+- **Isolation des secrets** — Token du bot supprimé de l'environnement du sous-processus
+- **Autorisation des utilisateurs** — `allowed_user_ids` restreint qui peut invoquer Claude
+- **Prévention d'injection dans les logs** — Valeurs API fournies par l'utilisateur assainies avant écriture dans les logs
 
 ---
 
-## Démarrage Rapide
+## Démarrage Rapide — Claude dans Discord en 5 Minutes
 
-### Prérequis
+**Prérequis :** Python 3.10+, [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installé et authentifié.
 
-- Python 3.10+
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installé et authentifié
-- Token de bot Discord avec Message Content intent activé
-- [uv](https://docs.astral.sh/uv/) (recommandé) ou pip
+**Support des plateformes :** Principalement développé et testé sur **Linux**. macOS et Windows sont pris en charge et passent les CI, mais reçoivent moins de tests réels.
 
-### Exécution autonome
+### Étape 1 — Créer un Bot Discord (une fois, ~2 minutes)
+
+1. Allez sur [discord.com/developers/applications](https://discord.com/developers/applications) → **New Application**
+2. Naviguez vers **Bot** → activez **Message Content Intent** sous Privileged Gateway Intents
+3. Copiez le **Token** du bot
+4. Allez dans **OAuth2 → URL Generator** : Portées `bot` + `applications.commands`, Permissions : Send Messages, Create Public Threads, Send Messages in Threads, Add Reactions, Manage Messages, Read Message History
+5. Ouvrez l'URL générée → invitez le bot sur votre serveur
+
+### Étape 2 — Exécuter l'Assistant de Configuration
+
+Pas besoin de cloner ni d'éditer `.env` — l'assistant fait tout :
 
 ```bash
+# Avec uvx (pas d'installation requise) :
+uvx --from "git+https://github.com/ebibibi/claude-code-discord-bridge.git" ccdb setup
+
+# Ou après avoir cloné :
 git clone https://github.com/ebibibi/claude-code-discord-bridge.git
 cd claude-code-discord-bridge
-
-cp .env.example .env
-# Éditez .env avec votre token de bot et ID de canal
-
-uv run python -m claude_discord.main
+uv run ccdb setup
 ```
 
-### Exécuter comme service systemd (production)
-
-En production, gérer le bot via systemd permet le démarrage automatique au boot et le redémarrage automatique en cas de panne.
-
-Le dépôt fournit des modèles prêts à l'emploi : `discord-bot.service` et `scripts/pre-start.sh`. Copiez-les et adaptez les chemins et l'utilisateur :
+### Démarrer / Arrêter
 
 ```bash
-# 1. Éditez le fichier de service — remplacez /home/ebi et User=ebi par votre chemin/utilisateur
+ccdb start    # démarrer le bot (lit .env dans le répertoire courant)
+ccdb start --env /path/to/.env   # emplacement .env personnalisé
+```
+
+Envoyez un message dans le canal configuré — Claude répondra dans un nouveau fil.
+
+### Exécuter comme Service systemd (Production)
+
+```bash
 sudo cp discord-bot.service /etc/systemd/system/mybot.service
 sudo nano /etc/systemd/system/mybot.service
-
-# 2. Activer et démarrer
 sudo systemctl daemon-reload
 sudo systemctl enable mybot.service
 sudo systemctl start mybot.service
-
-# 3. Vérifier le statut
-sudo systemctl status mybot.service
 journalctl -u mybot.service -f
 ```
 
-**Ce que fait `scripts/pre-start.sh`** (exécuté comme `ExecStartPre` avant le processus du bot) :
+### Cogs Personnalisés (Étendez Sans Forker)
 
-1. **`git pull --ff-only`** — récupère le code le plus récent depuis `origin main`
-2. **`uv sync`** — synchronise les dépendances selon `uv.lock`
-3. **Validation des imports** — vérifie que `claude_discord.main` s'importe correctement
-4. **Rollback automatique** — en cas d'échec de l'import, revient au commit précédent et réessaie ; envoie une notification via Discord webhook
-5. **Nettoyage des worktrees** — supprime les git worktrees orphelins laissés par des sessions qui ont planté
+Ajoutez vos propres fonctionnalités en déposant des fichiers Python dans un répertoire — sans fork, sans sous-classe, sans package :
 
-Le script détecte dynamiquement la racine du dépôt via `readlink -f $0`, donc aucune modification de chemin n'est nécessaire dans le script lui-même, quel que soit l'emplacement du clone. Le binaire `uv` est également auto-détecté depuis `PATH` ; utilisez la variable `CCDB_UV_BIN` pour spécifier un chemin personnalisé.
+```bash
+ccdb start --cogs-dir ./my-cogs/
+# Ou : CUSTOM_COGS_DIR=./my-cogs ccdb start
+```
 
-Configurez `DISCORD_WEBHOOK_URL` dans `.env` pour recevoir des notifications d'échec (optionnel).
+Chaque fichier `.py` doit exposer `async def setup(bot, runner, components)`.
 
-### Installer comme paquet
+---
 
-Si vous avez déjà un bot discord.py en fonctionnement (Discord n'autorise qu'une connexion Gateway par token) :
+### Bot Minimal (Installer comme Package)
 
 ```bash
 uv add git+https://github.com/ebibibi/claude-code-discord-bridge.git
 ```
 
+Créez `bot.py` :
+
 ```python
+import asyncio
+import os
+from dotenv import load_dotenv
+import discord
 from discord.ext import commands
 from claude_discord import ClaudeRunner, setup_bridge
 
-bot = commands.Bot(...)
-runner = ClaudeRunner(command="claude", model="sonnet")
+load_dotenv()
+
+intents = discord.Intents.default()
+intents.message_content = True
+
+bot = commands.Bot(command_prefix="!", intents=intents)
+runner = ClaudeRunner(
+    command="claude",
+    model="sonnet",
+    working_dir="/path/to/your/project",
+)
 
 @bot.event
 async def on_ready():
+    print(f"Logged in as {bot.user}")
     await setup_bridge(
         bot,
         runner,
-        claude_channel_id=YOUR_CHANNEL_ID,
-        allowed_user_ids={YOUR_USER_ID},
+        claude_channel_id=int(os.environ["DISCORD_CHANNEL_ID"]),
+        allowed_user_ids={int(os.environ["DISCORD_OWNER_ID"])},
     )
+
+asyncio.run(bot.start(os.environ["DISCORD_BOT_TOKEN"]))
 ```
 
-`setup_bridge()` connecte tous les Cogs automatiquement. Les nouveaux Cogs ajoutés à ccdb sont inclus sans modifications du code consommateur.
-
-Mettre à jour vers la dernière version :
+`setup_bridge()` connecte automatiquement tous les Cogs. Mise à jour vers la dernière version :
 
 ```bash
 uv lock --upgrade-package claude-code-discord-bridge && uv sync
@@ -288,212 +284,36 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 
 | Variable | Description | Défaut |
 |----------|-------------|--------|
-| `DISCORD_BOT_TOKEN` | Votre token de bot Discord | (obligatoire) |
-| `DISCORD_CHANNEL_ID` | ID du canal pour le chat Claude | (obligatoire) |
-| `CLAUDE_COMMAND` | Chemin vers le Claude Code CLI | `claude` |
-| `CLAUDE_MODEL` | Modèle à utiliser | `sonnet` |
-| `CLAUDE_PERMISSION_MODE` | Mode de permission du CLI | `acceptEdits` |
-| `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | Ignorer toutes les vérifications de permissions (à utiliser avec précaution) | `false` |
-| `CLAUDE_WORKING_DIR` | Répertoire de travail pour Claude | répertoire courant |
-| `MAX_CONCURRENT_SESSIONS` | Nombre maximum de sessions Claude CLI parallèles (s'applique à tous les chemins : chat, skills, scheduler, webhooks) | `3` |
+| `DISCORD_BOT_TOKEN` | Token du bot Discord | (requis) |
+| `DISCORD_CHANNEL_ID` | ID de canal pour le chat Claude | (requis) |
+| `CCDB_BACKEND` | Backend CLI à utiliser : `claude` ou `codex` | `claude` |
+| `CCDB_COMMAND` | Chemin ou nom du binaire CLI (remplace `CLAUDE_COMMAND`) | _(auto)_ |
+| `CCDB_MODEL` | Modèle à utiliser (remplace `CLAUDE_MODEL`) | `sonnet` |
+| `CCDB_PERMISSION_MODE` | Mode de permission CLI (remplace `CLAUDE_PERMISSION_MODE`) | `acceptEdits` |
+| `CCDB_DANGEROUSLY_SKIP_PERMISSIONS` | Ignorer toutes les vérifications de permission | `false` |
+| `CCDB_WORKING_DIR` | Répertoire de travail CLI | répertoire courant |
+| `CCDB_ALLOWED_TOOLS` | Liste d'outils autorisés séparés par des virgules | (optionnel) |
+| `CCDB_CHANNEL_IDS` | IDs de canaux supplémentaires pour configuration multi-canal | (optionnel) |
+| `CLAUDE_COMMAND` | Chemin CLI Claude (nom hérité — préférer `CCDB_COMMAND`) | `claude` |
+| `CLAUDE_MODEL` | Modèle (nom hérité — préférer `CCDB_MODEL`) | `sonnet` |
+| `CLAUDE_PERMISSION_MODE` | Mode de permission (nom hérité — préférer `CCDB_PERMISSION_MODE`) | `acceptEdits` |
+| `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | Ignorer les permissions (nom hérité) | `false` |
+| `CLAUDE_WORKING_DIR` | Répertoire de travail (nom hérité) | répertoire courant |
+| `MAX_CONCURRENT_SESSIONS` | Maximum de sessions CLI parallèles | `3` |
 | `SESSION_TIMEOUT_SECONDS` | Timeout d'inactivité de session | `300` |
-| `DISCORD_OWNER_ID` | ID utilisateur à @mentionner quand Claude a besoin d'une saisie | (optionnel) |
-| `COORDINATION_CHANNEL_ID` | ID du canal utilisé comme valeur de repli par défaut pour le canal AI Lounge | (optionnel) |
-| `WORKTREE_BASE_DIR` | Répertoire de base pour scanner les worktrees de session (active le nettoyage automatique) | (optionnel) |
-| `CLI_SESSIONS_PATH` | Chemin vers `~/.claude/projects` pour la découverte de sessions CLI (active `/sync-sessions`) | (optionnel) |
-| `MENTION_ONLY_CHANNEL_IDS` | IDs de canal séparés par des virgules où le bot répond uniquement quand il est @mentionné | (optionnel) |
-| `INLINE_REPLY_CHANNEL_IDS` | IDs de canal séparés par des virgules où le bot répond en ligne (sans créer de fil) | (optionnel) |
-| `CHAT_ONLY_CHANNEL_IDS` | IDs de canal séparés par des virgules où seules les réponses texte de Claude sont affichées (embeds d'outils/thinking/Todo masqués) | (optionnel) |
-| `THREAD_INBOX_ENABLED` | Active la boîte de réception persistante des fils (classe les sessions en `waiting`/`done`/`ambiguous` via `claude -p` ; affiché dans le tableau de bord des fils) | `false` |
-| `THREAD_AUTO_RENAME` | Renomme automatiquement les titres des nouveaux fils avec Claude AI — génère un titre court et descriptif du premier message utilisateur via un appel `claude -p` en arrière-plan (sans délai de démarrage de session) | `false` |
-| `CCDB_CLI_ENV_FILE` | Chemin vers un fichier `KEY=VALUE` dont les variables sont fusionnées dans l'environnement du sous-processus CLI à chaque invocation. Les modifications prennent effet immédiatement sans redémarrer le bot. Utile pour le routage d'API temporaire (ex. Azure Foundry) | (optionnel) |
-
-### Modes d'autorisation — Ce qui fonctionne en mode `-p`
-
-Le CLI Claude Code s'exécute en **mode `-p` (non interactif)** lorsqu'il est utilisé via ccdb. Dans ce mode, le CLI **ne peut pas demander d'autorisation** — les outils nécessitant une approbation sont immédiatement rejetés. Il s'agit d'une [contrainte de conception du CLI](https://code.claude.com/docs/en/headless), pas d'une limitation de ccdb.
-
-| Mode | Comportement en mode `-p` | Recommandation |
-|------|----------------------|----------------|
-| `default` | ❌ **Tous les outils rejetés** — inutilisable | Ne pas utiliser |
-| `acceptEdits` | ⚠️ Edit/Write approuvés automatiquement, Bash rejeté (Claude utilise Write pour les opérations sur fichiers) | Option minimale viable |
-| `bypassPermissions` | ✅ Tous les outils approuvés | Fonctionne, mais préférer l'option ci-dessous |
-| **`CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`** | ✅ **Tous les outils approuvés** | **Recommandé** — ccdb restreint déjà l'accès via `allowed_user_ids` |
-
-**Notre recommandation :** Définissez `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`. Puisque ccdb contrôle qui peut interagir avec Claude via `allowed_user_ids`, les vérifications d'autorisation au niveau du CLI ajoutent des frictions sans bénéfice sécuritaire réel. Le «dangerously» dans le nom reflète l'avertissement général du CLI ; dans le contexte de ccdb où l'accès est déjà contrôlé, c'est le choix pratique.
-
-**Pour un contrôle plus fin**, utilisez `CLAUDE_ALLOWED_TOOLS` pour autoriser des outils spécifiques sans contourner complètement les permissions :
-
-```env
-# Exemple : autoriser les opérations sur fichiers et l'exécution de code, mais pas l'accès web
-CLAUDE_ALLOWED_TOOLS=Bash,Read,Write,Edit,Glob,Grep
-
-# Exemple : mode lecture seule — Claude peut explorer mais pas modifier
-CLAUDE_ALLOWED_TOOLS=Read,Glob,Grep
-```
-
-Noms d'outils courants : `Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`, `WebFetch`, `WebSearch`, `NotebookEdit`. Définissez `CLAUDE_PERMISSION_MODE=default` lors de l'utilisation (d'autres modes peuvent écraser ce paramètre).
-
-> **Pourquoi les boutons d'autorisation n'apparaissent-ils pas dans Discord ?** Le mode `-p` du CLI n'émet jamais d'événements `permission_request`, donc il n'y a rien à afficher pour ccdb. Les boutons `AskUserQuestion` que vous voyez (invites de sélection de Claude) sont un mécanisme différent qui fonctionne correctement. Voir [#210](https://github.com/ebibibi/claude-code-discord-bridge/issues/210) pour l'investigation complète.
-
----
-
-## Configuration du Bot Discord
-
-1. Créez une nouvelle application sur le [Portail Développeur Discord](https://discord.com/developers/applications)
-2. Créez un bot et copiez le token
-3. Activez **Message Content Intent** dans Privileged Gateway Intents
-4. Invitez le bot avec ces permissions :
-   - Send Messages
-   - Create Public Threads
-   - Send Messages in Threads
-   - Add Reactions
-   - Manage Messages (pour le nettoyage des réactions)
-   - Read Message History
-
----
-
-## GitHub + Automatisation avec Claude Code
-
-### Exemple : Synchronisation Automatique de Documentation
-
-À chaque push sur `main`, Claude Code :
-1. Récupère les derniers changements et analyse le diff
-2. Met à jour la documentation en anglais
-3. Traduit en japonais (ou toute langue cible)
-4. Crée un PR avec un résumé bilingue
-5. Active l'auto-merge — fusionne automatiquement quand le CI passe
-
-**GitHub Actions :**
-
-```yaml
-# .github/workflows/docs-sync.yml
-name: Documentation Sync
-on:
-  push:
-    branches: [main]
-jobs:
-  trigger:
-    if: "!contains(github.event.head_commit.message, '[docs-sync]')"
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          curl -X POST "${{ secrets.DISCORD_WEBHOOK_URL }}" \
-            -H "Content-Type: application/json" \
-            -d '{"content": "🔄 docs-sync"}'
-```
-
-**Configuration du bot :**
-
-```python
-from claude_discord import WebhookTriggerCog, WebhookTrigger, ClaudeRunner
-
-runner = ClaudeRunner(command="claude", model="sonnet")
-
-triggers = {
-    "🔄 docs-sync": WebhookTrigger(
-        prompt="Analysez les changements, mettez à jour les docs, créez un PR avec résumé bilingue, activez l'auto-merge.",
-        working_dir="/home/user/my-project",
-        timeout=600,
-    ),
-}
-
-await bot.add_cog(WebhookTriggerCog(
-    bot=bot,
-    runner=runner,
-    triggers=triggers,
-    channel_ids={YOUR_CHANNEL_ID},
-))
-```
-
-**Sécurité :** Les prompts sont définis côté serveur. Les webhooks sélectionnent uniquement quel déclencheur activer — pas d'injection arbitraire de prompts.
-
-### Exemple : Auto-approbation des PRs du Propriétaire
-
-```yaml
-# .github/workflows/auto-approve.yml
-name: Auto Approve Owner PRs
-on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-jobs:
-  auto-approve:
-    if: github.event.pull_request.user.login == 'your-username'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
-    steps:
-      - env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --approve
-          gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --squash
-```
-
----
-
-## Tâches Planifiées
-
-Enregistrez des tâches Claude Code périodiques à l'exécution — sans changements de code, sans redéploiements.
-
-Depuis une session Discord, Claude peut enregistrer une tâche :
-
-```bash
-# Claude appelle cela depuis une session :
-curl -X POST "$CCDB_API_URL/api/tasks" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "Vérifier les dépendances obsolètes et ouvrir une issue si trouvées", "interval_seconds": 604800}'
-```
-
-Ou enregistrez depuis vos propres scripts :
-
-```bash
-curl -X POST http://localhost:8080/api/tasks \
-  -H "Authorization: Bearer your-secret" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "Scan de sécurité hebdomadaire", "interval_seconds": 604800}'
-```
-
-La boucle maître de 30 secondes détecte les tâches dues et crée des sessions Claude Code automatiquement.
-
----
-
-## Mise à Jour Automatique
-
-Mettez automatiquement à jour le bot quand une nouvelle version est publiée :
-
-```python
-from claude_discord import AutoUpgradeCog, UpgradeConfig
-
-config = UpgradeConfig(
-    package_name="claude-code-discord-bridge",
-    trigger_prefix="🔄 bot-upgrade",
-    working_dir="/home/user/my-bot",
-    restart_command=["sudo", "systemctl", "restart", "my-bot.service"],
-    restart_approval=True,  # Réagissez avec ✅ pour confirmer le redémarrage
-)
-
-await bot.add_cog(AutoUpgradeCog(bot, config))
-```
-
-Avant de redémarrer, `AutoUpgradeCog` :
-
-1. **Prend un snapshot des sessions actives** — Collecte tous les fils avec des sessions Claude en cours (duck typing : tout Cog avec un dict `_active_runners` est découvert automatiquement).
-2. **Draine** — Attend que les sessions actives se terminent naturellement.
-3. **Marque pour reprise** — Sauvegarde les IDs de fils actifs dans la table des reprises en attente. Au prochain démarrage, ces sessions reprennent automatiquement avec un prompt « bot redémarré, veuillez continuer ».
-4. **Redémarre** — Exécute la commande de redémarrage configurée.
-
-Tout Cog avec une propriété `active_count` est découvert automatiquement et drainé :
-
-```python
-class MyCog(commands.Cog):
-    @property
-    def active_count(self) -> int:
-        return len(self._running_tasks)
-```
-
-> **Couverture :** `AutoUpgradeCog` couvre les redémarrages déclenchés par mise à jour. Pour *tous les autres* arrêts (`systemctl stop`, `bot.close()`, SIGTERM), `ClaudeChatCog.cog_unload()` fournit un deuxième filet de sécurité automatique.
+| `DISCORD_OWNER_ID` | ID utilisateur à @mentionner quand Claude a besoin d'entrée | (optionnel) |
+| `COORDINATION_CHANNEL_ID` | ID de canal comme fallback par défaut pour AI Lounge | (optionnel) |
+| `MENTION_ONLY_CHANNEL_IDS` | IDs de canaux où le bot répond seulement quand @mentionné (séparés par virgule) | (optionnel) |
+| `INLINE_REPLY_CHANNEL_IDS` | IDs de canaux de réponse inline (séparés par virgule, sans créer de fil) | (optionnel) |
+| `CHAT_ONLY_CHANNEL_IDS` | IDs de canaux en mode chat uniquement (séparés par virgule) | (optionnel) |
+| `WORKTREE_BASE_DIR` | Répertoire de base pour scanner les worktrees de session | (optionnel) |
+| `CLI_SESSIONS_PATH` | Chemin pour la découverte de sessions CLI (`~/.claude/projects`) | (optionnel) |
+| `CUSTOM_COGS_DIR` | Répertoire contenant les fichiers Cog personnalisés | (optionnel) |
+| `THREAD_INBOX_ENABLED` | Activer la boîte de réception de fils persistante | `false` |
+| `THREAD_AUTO_RENAME` | Renommer automatiquement les nouveaux fils avec un titre généré par Claude | `false` |
+| `CCDB_CLI_ENV_FILE` | Chemin vers le fichier `KEY=VALUE` fusionné dans l'environnement du sous-processus CLI | (optionnel) |
+| `API_HOST` | Adresse de liaison de l'API REST | `127.0.0.1` |
+| `API_PORT` | Port de l'API REST (active l'API REST quand configuré) | (optionnel) |
 
 ---
 
@@ -509,102 +329,56 @@ uv add "claude-code-discord-bridge[api]"
 
 | Méthode | Chemin | Description |
 |---------|--------|-------------|
-| GET | `/api/health` | Vérification de l'état |
-| POST | `/api/notify` | Envoyer une notification immédiate |
-| POST | `/api/schedule` | Planifier une notification |
+| GET | `/api/health` | Vérification de santé |
+| POST | `/api/notify` | Envoyer notification immédiate |
+| POST | `/api/schedule` | Planifier notification |
 | GET | `/api/scheduled` | Lister les notifications en attente |
-| DELETE | `/api/scheduled/{id}` | Annuler une notification |
-| POST | `/api/tasks` | Enregistrer une tâche Claude Code planifiée |
+| DELETE | `/api/scheduled/{id}` | Annuler notification |
+| POST | `/api/tasks` | Enregistrer tâche Claude Code périodique |
 | GET | `/api/tasks` | Lister les tâches enregistrées |
-| DELETE | `/api/tasks/{id}` | Supprimer une tâche |
-| PATCH | `/api/tasks/{id}` | Mettre à jour une tâche (activer/désactiver, changer le calendrier) |
-| POST | `/api/spawn` | Créer un nouveau fil Discord et démarrer une session Claude Code (non bloquant) |
-| POST | `/api/mark-resume` | Marquer un fil pour reprise automatique au prochain démarrage du bot |
-
-```bash
-# Envoyer une notification
-curl -X POST http://localhost:8080/api/notify \
-  -H "Authorization: Bearer your-secret" \
-  -H "Content-Type: application/json" \
-  -d '{"message": "Build réussi !", "title": "CI/CD"}'
-
-# Enregistrer une tâche récurrente
-curl -X POST http://localhost:8080/api/tasks \
-  -H "Authorization: Bearer your-secret" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "Résumé quotidien de standup", "interval_seconds": 86400}'
-```
+| DELETE | `/api/tasks/{id}` | Supprimer tâche |
+| PATCH | `/api/tasks/{id}` | Mettre à jour tâche |
+| POST | `/api/spawn` | Créer nouveau fil Discord et démarrer session Claude Code (non bloquant) |
+| POST | `/api/mark-resume` | Marquer fil pour reprise automatique au prochain démarrage du bot |
+| GET | `/api/lounge` | Lire les messages récents de l'AI Lounge |
+| POST | `/api/lounge` | Publier message dans l'AI Lounge |
 
 ---
 
 ## Architecture
 
 ```
+claude_code_core/          # Bibliothèque centrale partagée (indépendante du backend)
+  backend.py               # Protocole SessionBackend + fabrique create_backend()
+  codex_runner.py          # Backend OpenAI Codex CLI
+  runner.py                # Gestionnaire de sous-processus Claude CLI
+  parser.py                # Analyseur d'événements stream-json
+  types.py                 # Définitions de types pour messages SDK
 claude_discord/
-  main.py                  # Point d'entrée autonome (setup_bridge + chargeur de Cogs personnalisés)
+  main.py                  # Point d'entrée autonome
   cli.py                   # Point d'entrée CLI (commandes ccdb setup/start)
-  setup.py                 # setup_bridge() — câblage des Cogs en un appel
-  cog_loader.py            # Chargeur dynamique de Cogs personnalisés (CUSTOM_COGS_DIR)
-  bot.py                   # Classe Discord Bot
-  protocols.py             # Protocoles partagés (DrainAware)
-  concurrency.py           # Instructions de worktree + registre des sessions actives
-  lounge.py                # Constructeur de prompts pour AI Lounge
-  session_sync.py          # Découverte et importation de sessions CLI
-  worktree.py              # WorktreeManager — cycle de vie sécurisé de git worktree
+  setup.py                 # setup_bridge()
   cogs/
-    claude_chat.py         # Chat interactif (création de fils, gestion des messages)
-    skill_command.py       # Commande slash /skill avec autocomplétion
-    session_manage.py      # /sessions, /sync-sessions, /resume, /resume-info, /sync-settings
-    session_sync.py        # Logique de création de fils et de publication pour sync-sessions
-    prompt_builder.py      # build_prompt_and_images() — fonction pure, sans état Cog/Bot
-    scheduler.py           # Exécuteur de tâches Claude Code périodiques
-    webhook_trigger.py     # Webhook → tâche Claude Code (CI/CD)
-    auto_upgrade.py        # Webhook → mise à jour de package + redémarrage avec drainage
-    event_processor.py     # EventProcessor — machine à états pour événements stream-json
-    run_config.py          # RunConfig dataclass — regroupe tous les paramètres d'exécution CLI
-    _run_helper.py         # Couche d'orchestration fine
-  claude/
-    runner.py              # Gestionnaire de sous-processus Claude CLI
-    parser.py              # Parseur d'événements stream-json
-    types.py               # Définitions de types pour les messages SDK
-  database/
-    models.py              # Schéma SQLite
-    repository.py          # CRUD des sessions
-    task_repo.py           # CRUD des tâches planifiées
-    ask_repo.py            # CRUD des AskUserQuestion en attente
-    notification_repo.py   # CRUD des notifications planifiées
-    lounge_repo.py         # CRUD des messages AI Lounge
-    resume_repo.py         # CRUD de reprise au démarrage
-    settings_repo.py       # Paramètres par serveur
-  discord_ui/
-    status.py              # Gestionnaire de réactions emoji (avec debounce)
-    chunker.py             # Découpage de messages avec connaissance des blocs et tableaux
-    embeds.py              # Constructeurs d'embeds Discord
-    views.py               # Bouton d'arrêt et composants UI partagés
-    ask_bus.py             # Bus d'événements pour la communication AskUserQuestion
-    ask_view.py            # Boutons/Menus de Sélection pour AskUserQuestion
-    ask_handler.py         # collect_ask_answers() — UI + cycle de vie DB d'AskUserQuestion
-    streaming_manager.py   # StreamingMessageManager — éditions de messages en place avec debounce
-    tool_timer.py          # LiveToolTimer — compteur de temps écoulé pour outils longs
-    thread_dashboard.py    # Embed épinglé en direct affichant les états de session
-    plan_view.py           # Boutons Approuver/Annuler pour Plan Mode (ExitPlanMode)
-    permission_view.py     # Boutons Autoriser/Refuser pour les demandes de permission d'outil
-    elicitation_view.py    # Interface Discord pour MCP Elicitation (formulaire Modal ou bouton URL)
-    file_sender.py         # Livraison de fichiers via .ccdb-attachments
+    claude_chat.py         # Chat interactif
+    skill_command.py       # Commande slash /skill
+    session_manage.py      # Gestion de session
+    scheduler.py           # Exécuteur de tâches périodiques
+    webhook_trigger.py     # Webhook → exécution de tâche Claude Code
+    auto_upgrade.py        # Auto-mise à jour + redémarrage avec vidange
   ext/
-    api_server.py          # API REST (optionnel, nécessite aiohttp)
-  utils/
-    logger.py              # Configuration du logging
+    api_server.py          # API REST (optionnel)
+examples/
+  ebibot/                  # Exemple réel
 ```
 
 ### Philosophie de Conception
 
-- **Invocation CLI, pas API** — Invoque `claude -p --output-format stream-json`, donnant les fonctionnalités complètes de Claude Code (CLAUDE.md, skills, outils, mémoire) sans les réimplémenter
-- **Concurrence d'abord** — Plusieurs sessions simultanées sont le cas attendu, pas un cas limite ; chaque session reçoit des instructions de worktree, le registre et le AI Lounge gèrent le reste
-- **Discord comme colle** — Discord fournit UI, fils, réactions, webhooks et notifications persistantes ; pas de frontend personnalisé nécessaire
-- **Framework, pas application** — Installez comme paquet, ajoutez des Cogs à votre bot existant, configurez via le code
+- **Spawn de CLI, pas API** — Invoque `claude -p --output-format stream-json`, obtenant toutes les fonctionnalités de Claude Code sans les réimplémenter. Sans clé API, sans facturation par token.
+- **Concurrence d'abord** — Plusieurs sessions simultanées sont le cas attendu, pas un cas limite
+- **Discord comme colle** — Discord fournit UI, threading, réactions, webhooks et notifications persistantes
+- **Framework, pas application** — Installez comme package, ajoutez des Cogs à votre bot existant
 - **Extensibilité sans code** — Ajoutez des tâches planifiées et des déclencheurs webhook sans toucher au code source
-- **Sécurité par la simplicité** — ~3000 lignes de Python auditables ; seulement subprocess exec, pas d'expansion shell
+- **Sécurité par simplicité** — ~8000 lignes de Python auditable ; seulement subprocess exec, pas d'expansion de shell
 
 ---
 
@@ -614,37 +388,38 @@ claude_discord/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-1050+ tests couvrant le parseur, le découpage, le référentiel, le runner, le streaming, les déclencheurs webhook, la mise à jour automatique (incluant la commande `/upgrade`, l'invocation depuis un fil et le bouton d'approbation), l'API REST, l'UI AskUserQuestion, le tableau de bord des fils, les tâches planifiées, la synchronisation de sessions, AI Lounge, la reprise au démarrage, le changement de modèle, la détection de compactage, les embeds de progression TodoWrite, et l'analyse d'événements permission/elicitation/plan-mode.
+Plus de 1365 tests couvrant l'analyseur, le chunker, le référentiel, le runner, le streaming, les déclencheurs webhook, l'auto-mise à jour, l'API REST, l'UI AskUserQuestion, le tableau de bord des fils, les tâches planifiées, la synchronisation de session, l'AI Lounge, la reprise au démarrage, le changement de modèle, la détection de compaction, les embeds de progression TodoWrite, le chargeur de Cogs personnalisés, le protocole SessionBackend, CodexRunner et la fabrique de backends.
 
 ---
 
-## Comment Ce Projet A Été Construit
+## Comment ce Projet a été Construit
 
-**L'intégralité de ce code base a été écrite par [Claude Code](https://docs.anthropic.com/en/docs/claude-code)**, l'agent de codage IA d'Anthropic. L'auteur humain ([@ebibibi](https://github.com/ebibibi)) a fourni les exigences et la direction en langage naturel, mais n'a pas lu ni édité manuellement le code source.
+**Ce codebase est développé par [Claude Code](https://docs.anthropic.com/en/docs/claude-code)**, l'agent de codage AI d'Anthropic, sous la direction de [@ebibibi](https://github.com/ebibibi). L'auteur humain définit les exigences, révise les pull requests et approuve tous les changements — Claude Code fait l'implémentation.
 
-Cela signifie :
-
-- **Tout le code a été généré par IA** — architecture, implémentation, tests, documentation
-- **L'auteur humain ne peut pas garantir l'exactitude au niveau du code** — examinez le source si vous avez besoin d'assurance
-- **Les rapports de bugs et les PRs sont les bienvenus** — Claude Code sera utilisé pour les traiter
-- **C'est un exemple concret de logiciel open source écrit par une IA**
-
-Le projet a démarré le 2026-02-18 et continue d'évoluer à travers des conversations itératives avec Claude Code.
+Le projet a commencé le 2026-02-18 et continue d'évoluer grâce à des conversations itératives avec Claude Code.
 
 ---
 
-## Exemple Concret
+## Exemple Réel
 
-**[EbiBot](https://github.com/ebibibi/discord-bot)** — Un bot Discord personnel construit sur ce framework. Inclut la synchronisation automatique de documentation (anglais + japonais), les notifications push, le watchdog Todoist, les vérifications de santé planifiées et le CI/CD avec GitHub Actions. Utilisez-le comme référence pour construire votre propre bot.
+**[`examples/ebibot/`](examples/ebibot/)** — Un bot Discord personnel construit sur ce framework, inclus directement dans ce dépôt. Démontre le chargeur de Cog personnalisé avec :
+
+- **ReminderCog** — Commande slash `/remind HH:MM "message"` + boucle d'envoi de 30 secondes
+- **WatchdogCog** — Moniteur de tâches Todoist en retard
+- **AutoUpgradeCog** — Auto-mise à jour via webhook GitHub + systemctl restart
+- **DocsSyncCog** — Synchronisation automatique de documentation à chaque push
+- **AlertResponderCog** — Cog de surveillance d'alertes générique
+
+Exécutez avec : `ccdb start --cogs-dir examples/ebibot/cogs/`
 
 ---
 
-## Inspiré par
+## Inspiré Par
 
-- [OpenClaw](https://github.com/openclaw/openclaw) — Réactions emoji de statut, debounce de messages, découpage avec connaissance des blocs
-- [claude-code-discord-bot](https://github.com/timoconnellaus/claude-code-discord-bot) — Approche d'invocation CLI + stream-json
-- [claude-code-discord](https://github.com/zebbern/claude-code-discord) — Schémas de contrôle des permissions
-- [claude-sandbox-bot](https://github.com/RhysSullivan/claude-sandbox-bot) — Modèle de fil par conversation
+- [OpenClaw](https://github.com/openclaw/openclaw) — Réactions emoji de statut, debouncing de messages, chunking conscient des fences
+- [claude-code-discord-bot](https://github.com/timoconnellaus/claude-code-discord-bot) — Approche CLI spawn + stream-json
+- [claude-code-discord](https://github.com/zebbern/claude-code-discord) — Modèles de contrôle de permissions
+- [claude-sandbox-bot](https://github.com/RhysSullivan/claude-sandbox-bot) — Modèle de conversation par fil
 
 ---
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -3,20 +3,24 @@
 > **注意:** これは英語のオリジナルドキュメントを自動翻訳したものです。
 > 内容に相違がある場合は、[英語版](../../README.md)が優先されます。
 
-# claude-code-discord-bridge
+# Claude & Codex Discord Bridge
+
+*パッケージ名: `claude-code-discord-bridge`（ケバブケース）*
 
 [![CI](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**スマホの Discord から Claude Code をガンガン使おう。複数スレッドを同時に回して、本格開発もOK。**
+**スマホの Discord から Claude Code _または_ OpenAI Codex をガンガン使おう。複数スレッドを同時に回して、本格開発もOK。**
 
-Discord のスレッドを開くだけで、Claude Code セッションが立ち上がります。スマートフォンから何スレッドでも並行して動かせます — あるスレッドで機能開発、別のスレッドで PR レビュー、さらに別のスレッドでバックグラウンドタスク。全部同時進行。コンフリクトしないように、ブリッジがセッション間の調整を完全自動化します。
+Discord のスレッドを開くだけで、Claude Code または OpenAI Codex のセッションが立ち上がります。スマートフォンから何スレッドでも並行して動かせます — あるスレッドで機能開発、別のスレッドで PR レビュー、さらに別のスレッドでバックグラウンドタスク。スレッドごとにバックエンドを混在させながら、全部同時進行。コンフリクトしないように、ブリッジがセッション間の調整を完全自動化します。
+
+**既存のサブスクリプションをそのまま活用。API キーの設定は不要。** ccdb は公式 CLI の上で動作します — Claude Code（[Claude Pro/Max サブスクリプション](https://claude.ai/pricing)に含まれる）と OpenAI Codex（[ChatGPT Plus/Pro/Business](https://chatgpt.com)に含まれる）。`/backend` でバックエンドを切り替えるか、スレッドごとに設定 — 予測可能なコストで Discord 経由で両方の AI を利用できます。
 
 **[English](../../README.md)** | **[简体中文](../zh-CN/README.md)** | **[한국어](../ko/README.md)** | **[Español](../es/README.md)** | **[Português](../pt-BR/README.md)** | **[Français](../fr/README.md)**
 
-> **免責事項:** このプロジェクトは Anthropic とは無関係であり、承認や公式な関係はありません。「Claude」および「Claude Code」は Anthropic, PBC の商標です。これは Claude Code CLI と連携する独立したオープンソースツールです。
+> **免責事項:** このプロジェクトは Anthropic および OpenAI とは無関係であり、承認や公式な関係はありません。「Claude」および「Claude Code」は Anthropic, PBC の商標、「OpenAI」「Codex」「ChatGPT」は OpenAI の商標です。これは Claude Code CLI と OpenAI Codex CLI に連携する独立したオープンソースツールです。
 
 > **Claude Code によって完全構築。** このコードベース全体（アーキテクチャ、実装、テスト、ドキュメント）は Claude Code 自身によって書かれました。人間の著者は自然言語で要件と方向性を提供しましたが、ソースコードを手動で編集していません。詳細は[このプロジェクトの構築方法](#このプロジェクトの構築方法)をご覧ください。
 

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -3,280 +3,292 @@
 > **참고:** 이 문서는 원본 영어 문서의 자동 번역본입니다.
 > 내용이 다를 경우 [영어 버전](../../README.md)이 우선합니다.
 
-# claude-code-discord-bridge
+# Claude & Codex Discord Bridge
+
+*패키지명: `claude-code-discord-bridge` (케밥 케이스)*
 
 [![CI](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**Discord를 통해 여러 Claude Code 세션을 안전하게 병렬로 실행하세요.**
+**스마트폰에서 Claude Code _또는_ OpenAI Codex를 사용하세요. 멀티 스레드, 동시 진행, 실전 개발까지.**
 
-각 Discord 스레드는 격리된 Claude Code 세션이 됩니다. 필요한 만큼 세션을 실행하세요: 한 스레드에서 기능을 개발하고, 다른 스레드에서 PR을 검토하고, 세 번째 스레드에서 예약된 작업을 실행합니다. 브리지가 자동으로 조율을 처리하므로 동시 세션이 서로 충돌하지 않습니다.
+스마트폰 Discord 앱에서 Claude Code 또는 OpenAI Codex를 실행하고, 여러 스레드를 열어 개발 세션을 병렬로 진행하세요 — 키보드 없이도 가능합니다. 각 Discord 스레드는 완전히 격리된 AI 세션이 됩니다. 한 스레드에서 기능 개발, 다른 스레드에서 PR 리뷰, 세 번째 스레드에서 백그라운드 작업 — 동시에, 심지어 스레드마다 다른 백엔드를 사용할 수도 있습니다. 브리지가 모든 조율을 처리하여 세션들이 서로 충돌하지 않습니다.
+
+**기존 구독을 그대로 활용. API 키 설정 불필요.** ccdb는 공식 CLI 위에서 실행됩니다 — Claude Code([Claude Pro/Max 구독](https://claude.ai/pricing) 포함)와 OpenAI Codex([ChatGPT Plus/Pro/Business](https://chatgpt.com) 포함). `/backend`로 백엔드를 전환하거나 스레드별로 설정하세요 — 예측 가능한 비용으로 Discord를 통해 두 AI를 모두 사용할 수 있습니다.
 
 **[English](../../README.md)** | **[日本語](../ja/README.md)** | **[简体中文](../zh-CN/README.md)** | **[Español](../es/README.md)** | **[Português](../pt-BR/README.md)** | **[Français](../fr/README.md)**
 
-> **면책 조항:** 이 프로젝트는 Anthropic과 관련이 없으며 Anthropic의 승인이나 공식 연결을 받지 않았습니다. "Claude"와 "Claude Code"는 Anthropic, PBC의 상표입니다. 이것은 Claude Code CLI와 인터페이스하는 독립적인 오픈 소스 도구입니다.
+> **면책 조항:** 이 프로젝트는 Anthropic 또는 OpenAI와 제휴, 보증 또는 공식 관계가 없습니다. "Claude"와 "Claude Code"는 Anthropic, PBC의 상표이며, "OpenAI", "Codex", "ChatGPT"는 OpenAI의 상표입니다. 이것은 Claude Code CLI 및 OpenAI Codex CLI와 인터페이스하는 독립적인 오픈소스 도구입니다.
 
-> **Claude Code로 완전히 구축되었습니다.** 이 전체 코드베이스—아키텍처, 구현, 테스트, 문서—는 Claude Code 자체에 의해 작성되었습니다. 인간 저자는 자연어로 요구사항과 방향을 제공했지만 소스 코드를 직접 읽거나 편집하지 않았습니다. [이 프로젝트가 구축된 방법](#이-프로젝트가-구축된-방법)을 참조하세요.
+> **Claude Code로 완전히 구축.** 전체 코드베이스 — 아키텍처, 구현, 테스트, 문서 — 는 Claude Code 자체가 작성했습니다. 인간 저자는 자연어로 요구사항과 방향을 제공했습니다. [이 프로젝트의 구축 방법](#이-프로젝트의-구축-방법)을 참조하세요.
 
 ---
 
-## 핵심 아이디어: 두려움 없는 병렬 세션
+## 핵심 아이디어: 충돌 없는 병렬 세션
 
-별도의 Discord 스레드에서 Claude Code에 작업을 보낼 때, 브리지는 자동으로 세 가지를 수행합니다:
+여러 Discord 스레드에서 Claude Code에 작업을 보내면, 브리지는 자동으로 네 가지를 수행합니다:
 
-1. **동시성 알림 주입** — 모든 세션의 시스템 프롬프트에 필수 지침이 포함됩니다: git worktree를 만들고, 그 안에서만 작업하고, 메인 작업 디렉토리를 직접 건드리지 마세요.
+1. **동시성 알림 주입** — 모든 세션의 시스템 프롬프트에 필수 지침이 포함됩니다: git worktree 생성, 그 안에서만 작업, 메인 작업 디렉토리 직접 수정 금지.
 
-2. **활성 세션 레지스트리** — 각 실행 중인 세션은 다른 세션들에 대해 알고 있습니다. 두 세션이 같은 저장소를 수정하려 할 경우, 충돌 대신 조율할 수 있습니다.
+2. **활성 세션 레지스트리** — 실행 중인 각 세션은 다른 세션들의 존재를 알고 있습니다. 두 세션이 같은 저장소를 건드리려 할 경우, 충돌 대신 조율할 수 있습니다.
 
-3. **AI Lounge** — 모든 세션 프롬프트에 주입되는 공유 「대기실」 채널. 작업 시작 전 다른 세션의 메시지를 읽어 상황을 파악하고, 파괴적인 작업(force push, 봇 재시작 등) 전에 반드시 확인합니다.
+3. **AI Lounge** — 모든 세션의 프롬프트에 주입되는 "휴게실" 채널. 시작 전에 각 세션은 최근 라운지 메시지를 읽어 다른 세션들의 동향을 파악합니다. 파괴적인 작업(강제 푸시, 봇 재시작, DB 삭제) 전에 세션은 라운지를 먼저 확인합니다.
 
 ```
-스레드 A (기능)   ──→  Claude Code (worktree-A)  ─┐
-스레드 B (PR 검토) ──→  Claude Code (worktree-B)   ├─→  #ai-lounge
-스레드 C (문서)   ──→  Claude Code (worktree-C)  ─┘    "A: 인증 리팩토링 중"
-                                                         "B: PR #42 검토 완료"
+스레드 A (기능)    ──→  Claude Code (worktree-A)  ─┐
+스레드 B (PR 리뷰) ──→  Claude Code (worktree-B)   ├─→  #ai-lounge
+스레드 C (문서)    ──→  Claude Code (worktree-C)  ─┘    "A: auth 리팩토링 진행 중"
+                                                         "B: PR #42 리뷰 완료"
                                                          "C: README 업데이트 중"
 ```
 
-경쟁 조건 없음. 작업 손실 없음. 병합 충돌 없음.
+경쟁 조건 없음. 작업 손실 없음. 머지 충돌 없음.
 
 ---
 
 ## 할 수 있는 것들
 
-### 대화형 채팅 (모바일 / 데스크탑)
+### 인터랙티브 채팅 (모바일 / 데스크탑)
 
-Discord가 실행되는 어디서든 Claude Code를 사용하세요—폰, 태블릿, 데스크탑. 각 메시지는 영속적인 Claude Code 세션과 1:1로 매핑되는 스레드를 만들거나 계속합니다.
+Discord가 실행되는 모든 곳에서 Claude Code 사용 — 스마트폰, 태블릿, 데스크탑. 각 메시지는 스레드를 생성하거나 계속하며, 지속적인 Claude Code 세션과 1:1로 매핑됩니다.
 
 ### 병렬 개발
 
-여러 스레드를 동시에 엽니다. 각각은 자체 컨텍스트, 작업 디렉토리, git worktree를 가진 독립적인 Claude Code 세션입니다. 유용한 패턴:
+여러 스레드를 동시에 열기. 각 스레드는 독자적인 컨텍스트, 작업 디렉토리, git worktree를 가진 독립적인 Claude Code 세션입니다. 유용한 패턴:
 
-- **기능 + 검토 병렬**: 한 스레드에서 기능을 시작하는 동안 Claude가 다른 스레드에서 PR을 검토합니다.
-- **여러 기여자**: 다른 팀원들이 각자 스레드를 가지고; 세션은 AI Lounge를 통해 서로를 인식합니다.
-- **안전하게 실험**: 스레드 A에서 방법을 시도하는 동안 스레드 B는 안정적인 코드를 유지합니다.
+- **기능 + 리뷰 병렬 진행**: 한 스레드에서 기능 개발하면서 Claude가 다른 스레드에서 PR 리뷰.
+- **여러 기여자**: 팀원 각자가 자신의 스레드를 가지며, AI Lounge를 통해 세션들이 서로의 동향 파악.
+- **안전한 실험**: 스레드 A에서 접근법을 시도하면서 스레드 B는 안정적인 코드 유지.
 
-### 예약된 작업 (SchedulerCog)
+### 예약 작업 (SchedulerCog)
 
-Discord 대화 또는 REST API를 통해 주기적인 Claude Code 작업을 등록하세요—코드 변경 없이, 재배포 없이. 작업은 SQLite에 저장되고 구성 가능한 스케줄에 따라 실행됩니다. Claude는 세션 중에 `POST /api/tasks`를 사용하여 작업을 자체 등록할 수 있습니다.
+코드 변경, 재배포 없이 Discord 대화 또는 REST API로 주기적인 Claude Code 작업을 등록. 작업은 SQLite에 저장되고 설정 가능한 일정에 따라 실행됩니다.
 
 ```
 /skill name:goodmorning         → 즉시 실행
 Claude가 POST /api/tasks 호출  → 주기적 작업 등록
-SchedulerCog (30초 마스터 루프) → 만료된 작업 자동 실행
+SchedulerCog (30초 마스터 루프) → 기한 된 작업 자동 실행
 ```
 
 ### CI/CD 자동화
 
-Discord 웹훅을 통해 GitHub Actions에서 Claude Code 작업을 트리거합니다. Claude는 자율적으로 실행됩니다—코드 읽기, 문서 업데이트, PR 생성, 자동 병합 활성화.
+Discord webhook을 통해 GitHub Actions에서 Claude Code 작업을 트리거. Claude가 자율적으로 실행 — 코드 읽기, 문서 업데이트, PR 생성, 자동 머지 활성화.
 
-```
-GitHub Actions → Discord Webhook → Bridge → Claude Code CLI
-                                                  ↓
-GitHub PR ←── git push ←── Claude Code ──────────┘
-```
-
-**실제 예시:** `main`에 푸시할 때마다 Claude가 diff를 분석하고, 영어 + 일본어 문서를 업데이트하고, 이중 언어 요약으로 PR을 만들고, 자동 병합을 활성화합니다. 사람의 개입 없이.
+**실제 예시:** main에 푸시할 때마다 Claude가 diff를 분석하고, 영문 + 일문 문서를 업데이트하고, 이중 언어 PR을 생성하고, 자동 머지를 활성화합니다. 사람 개입 없음.
 
 ### 세션 동기화
 
-이미 Claude Code CLI를 직접 사용하고 있나요? `/sync-sessions`로 기존 터미널 세션을 Discord 스레드로 동기화하세요. 최근 대화 메시지를 백필하여 컨텍스트를 잃지 않고 폰에서 CLI 세션을 계속할 수 있습니다.
+이미 Claude Code CLI를 직접 사용 중이라면? `/sync-sessions`으로 기존 터미널 세션을 Discord 스레드로 동기화. 최근 대화 메시지를 백필하여 컨텍스트 손실 없이 스마트폰에서 CLI 세션을 계속할 수 있습니다.
+
+### AI Lounge
+
+모든 동시 세션이 서로 발표하고, 업데이트를 읽고, 파괴적인 작업 전에 조율하는 공유 "휴게실" 채널. 각 Claude 세션은 `--append-system-prompt`를 통해 자동으로 라운지 컨텍스트를 받습니다 — 대화 기록이 아닌 에페메랄 시스템 컨텍스트로 주입되어 장기 세션에서 "Prompt is too long" 오류를 방지합니다.
 
 ### 프로그래밍 방식 세션 생성
 
-스크립트, GitHub Actions 또는 다른 Claude 세션에서 Discord 메시지 상호작용 없이 새 Claude Code 세션을 생성합니다.
+스크립트, GitHub Actions, 또는 다른 Claude 세션에서 Discord 메시지 상호작용 없이 새로운 Claude Code 세션 생성.
 
 ```bash
 # 다른 Claude 세션이나 CI 스크립트에서:
 curl -X POST "$CCDB_API_URL/api/spawn" \
   -H "Content-Type: application/json" \
-  -d '{"prompt": "저장소에 보안 스캔 실행", "thread_name": "보안 스캔"}'
-# 스레드 ID와 함께 즉시 반환; Claude는 백그라운드에서 실행
+  -d '{"prompt": "저장소에 보안 스캔 실행", "thread_name": "Security Scan"}'
+# 스레드 생성 후 즉시 반환; Claude는 백그라운드에서 실행
 ```
-
-Claude 서브프로세스는 `DISCORD_THREAD_ID`를 환경 변수로 받으므로, 실행 중인 세션이 자식 세션을 생성하여 작업을 병렬화할 수 있습니다.
-
-### 시작 시 재개
-
-봇이 세션 중에 재시작하면, 중단된 Claude 세션은 봇이 다시 온라인 상태가 될 때 자동으로 재개됩니다. 세션은 세 가지 방법으로 재개 표시됩니다:
-
-- **자동 (업그레이드 재시작)** — `AutoUpgradeCog`가 패키지 업그레이드 재시작 직전에 모든 활성 세션의 스냅샷을 찍고 자동으로 표시합니다.
-- **자동 (모든 종료)** — `ClaudeChatCog.cog_unload()`가 어떤 메커니즘으로든 봇이 종료될 때 (`systemctl stop`, `bot.close()`, SIGTERM 등) 모든 실행 중인 세션을 표시합니다.
-- **수동** — 어떤 세션이든 `POST /api/mark-resume`을 직접 호출할 수 있습니다.
 
 ---
 
-## 기능
+## 기능 목록
 
-### 대화형 채팅
+### 인터랙티브 채팅
 
 #### 🔗 세션 기본
-- **Thread = Session** — Discord 스레드와 Claude Code 세션 간 1:1 매핑
-- **세션 지속성** — `--resume`을 통해 메시지 전반에 걸쳐 대화 재개
-- **동시 세션** — 구성 가능한 한도로 여러 병렬 세션
-- **지우지 않고 중지** — `/stop`으로 세션을 중지하면서 재개를 위해 보존
-- **세션 중단** — 활성 스레드에 새 메시지를 보내면 실행 중인 세션에 SIGINT 전송 후 새 지시로 새로 시작; 수동 `/stop` 불필요
-- **스레드 자동 이름 변경** — `THREAD_AUTO_RENAME=true`일 때, 각 새 스레드가 첫 번째 메시지를 기반으로 Claude가 생성한 제목으로 자동 이름 변경됨 (백그라운드 작업, 세션 시작 지연 없음)
+- **채팅 전용 모드** — `CHAT_ONLY_CHANNEL_IDS`로 Claude 텍스트 응답만 표시; 도구 embed, 사고 블록, 세션 embed, 할 일 목록 숨김
+- **스레드 = 세션** — Discord 스레드와 Claude Code 세션 1:1 매핑
+- **목표 추적** — `/goal <조건>` 완료 조건 설정; Claude가 조건 충족까지 계속 작업
+- **세션 지속성** — `--resume`으로 메시지 간 대화 계속
+- **동시 세션** — 설정 가능한 제한으로 여러 병렬 세션
+- **지우지 않고 중지** — `/stop`으로 재개 가능하도록 세션 보존하며 중지
+- **세션 중단** — 활성 스레드에 새 메시지 전송 시 실행 중인 세션에 SIGINT 전송 후 새 지침으로 시작
+- **스레드 자동 이름 변경** — `THREAD_AUTO_RENAME=true`로 Claude 생성 제목으로 자동 이름 변경
 
 #### 📡 실시간 피드백
-- **실시간 상태** — 이모지 반응: 🧠 생각 중, 🛠️ 파일 읽기, 💻 편집, 🌐 웹 검색
-- **스트리밍 텍스트** — Claude가 작업하는 동안 중간 어시스턴트 텍스트 표시
-- **도구 결과 임베드** — 10초마다 증가하는 경과 시간과 함께 실시간 도구 호출 결과; 한 줄 결과는 인라인으로 표시, 여러 줄 결과는 확장 버튼 뒤에 접혀서 표시
-- **확장 사고** — 추론이 스포일러 태그 임베드로 표시 (클릭하여 표시)
-- **스레드 대시보드** — 활성 vs. 대기 스레드를 보여주는 실시간 고정 임베드; 입력이 필요할 때 소유자 @멘션
+- **실시간 상태** — 이모지 반응: 🧠 사고 중, 🛠️ 파일 읽기, 💻 편집 중, 🌐 웹 검색
+- **스트리밍 텍스트** — Claude가 작업하는 동안 중간 텍스트 실시간 표시
+- **도구 결과 embed** — 라이브 도구 호출 결과, 경과 시간 표시
+- **확장 사고** — 추론을 스포일러 태그 embed로 표시 (클릭하여 펼치기)
+- **스레드 대시보드** — 활성 vs. 대기 스레드 표시하는 라이브 고정 embed
 
-#### 🤝 사람-AI 협업
-- **대화형 질문** — `AskUserQuestion`이 Discord 버튼 또는 선택 메뉴로 렌더링됨; 답변으로 세션 재개; 버튼은 봇 재시작 후에도 유지됨
-- **Plan Mode** — Claude가 `ExitPlanMode`를 호출하면 Discord embed에 전체 계획과 승인/취소 버튼이 표시됨; 승인 후에만 Claude가 진행; 5분 타임아웃 시 자동 취소
-- **도구 권한 요청** — Claude가 도구 실행 권한이 필요할 때 Discord에 도구 이름과 입력이 포함된 허용/거부 버튼 표시; 2분 후 자동 거부
-- **MCP Elicitation** — MCP 서버가 Discord를 통해 사용자 입력을 요청할 수 있음 (폼 모드: JSON 스키마에서 최대 5개의 Modal 필드; URL 모드: URL 버튼 + 완료 확인); 5분 타임아웃
-- **TodoWrite 실시간 진행상황** — Claude가 `TodoWrite`를 호출하면 단일 Discord embed가 게시되고 각 업데이트마다 in-place로 편집됨; ✅ 완료, 🔄 활성 (`activeForm` 레이블 포함), ⬜ 대기 중 표시
+#### 🤝 Human-in-the-Loop
+- **인터랙티브 질문** — `AskUserQuestion`을 Discord 버튼 또는 선택 메뉴로 렌더링; 봇 재시작 후에도 버튼 유효
+- **계획 모드** — `ExitPlanMode` 호출 시 Discord embed에 전체 계획과 승인/취소 버튼 표시; 5분 타임아웃
+- **도구 권한 요청** — 허용/거부 버튼; 2분 무응답 시 자동 거부
+- **MCP Elicitation** — MCP 서버가 Discord를 통해 사용자 입력 요청; 5분 타임아웃
+- **TodoWrite 실시간 진행** — 단일 Discord embed 인플레이스 업데이트; ✅ 완료, 🔄 진행 중, ⬜ 대기 표시
 
 #### 📊 관찰 가능성
-- **토큰 사용량** — 세션 완료 임베드에 캐시 히트율과 토큰 수 표시
-- **컨텍스트 사용량** — 컨텍스트 윈도우 백분율 (입력 + 캐시 토큰, 출력 제외) 및 자동 압축까지 남은 용량이 세션 완료 embed에 표시됨; 83.5% 초과 시 ⚠️ 경고
-- **압축 감지** — 컨텍스트 압축 발생 시 스레드에 알림 (트리거 유형 + 압축 전 토큰 수)
-- **하드 정지 알림** — 활동이 없으면 스레드에 메시지 전송 (확장 사고 또는 컨텍스트 압축); Claude가 재개하면 자동 초기화. 임계값은 모델에 따라 자동 조정: 표준 모델 30초, Opus 120초 (더 긴 사고 시간)
-- **시간 초과 알림** — 경과 시간과 재개 안내가 포함된 임베드
-- **스레드 수신함** — `THREAD_INBOX_ENABLED=true`일 때, 대시보드에 지속적인 📬 수신함 섹션이 표시됨; 각 세션 종료 후 Claude가 경량 `claude -p` 호출로 마지막 메시지를 `waiting`/`done`/`ambiguous`로 분류; 회신을 기다리는 스레드는 봇 재시작 후에도 유지되며 회신할 때까지 표시됨
+- **토큰 사용량** — 세션 완료 embed에 캐시 히트율과 토큰 수 표시
+- **컨텍스트 사용량** — 컨텍스트 창 백분율 표시; 83.5% 이상 시 ⚠️ 경고
+- **압축 감지** — 컨텍스트 압축 발생 시 스레드 내 알림
+- **장시간 중단 알림** — 활동 없음 알림 (표준 모델 30초, Opus 120초)
+- **타임아웃 알림** — 경과 시간과 재개 안내가 포함된 embed
+- **StatusLine 표시** — Claude가 `statusLine` 설정 시 각 세션 후 Discord에 표시
+- **스레드 수신함** — `THREAD_INBOX_ENABLED=true`로 📬 수신함 섹션 표시
 
 #### 🔌 입력 및 스킬
-- **첨부파일 지원** — 텍스트 파일이 프롬프트에 자동으로 추가됨 (최대 5 × 50KB); 이미지는 `--image` 플래그를 통해 다운로드 및 전달 (최대 4 × 5MB)
-- **스킬 실행** — 자동완성, 선택적 인수, 스레드 내 재개를 지원하는 `/skill` 슬래시 명령
-- **핫 리로드** — `~/.claude/skills/`에 추가된 새 스킬 자동으로 선택 (60초 새로 고침, 재시작 없음)
+- **첨부 파일 지원** — 텍스트 파일 자동 추가 (최대 5개, 각 200 KB); 이미지는 CDN URL로 전송 (최대 4 × 5 MB)
+- **주문형 파일 전달** — Claude가 `.ccdb-attachments`에 경로 작성; 세션 완료 시 Discord 첨부 파일로 전송
+- **스킬 실행** — 자동완성이 있는 `/skill` 명령; 설치된 플러그인 스킬 자동 검색
+- **핫 리로드** — `~/.claude/skills/`에 추가된 새 스킬 자동 감지 (60초 갱신)
 
-### 동시성 & 조율
-- **Worktree 지침 자동 주입** — 모든 파일을 건드리기 전에 `git worktree` 사용을 촉구하는 모든 세션
-- **자동 worktree 정리** — 세션 worktree (`wt-{thread_id}`)는 세션 종료 시와 봇 시작 시 자동으로 제거됨; 더러운 worktree는 절대 자동으로 제거되지 않음 (안전 불변성)
-- **활성 세션 레지스트리** — 인메모리 레지스트리; 각 세션은 다른 세션이 무엇을 하는지 볼 수 있음
-- **AI Lounge** — 공유 «휴게실» 채널; `--append-system-prompt`를 통해 컨텍스트 주입 (일시적, 히스토리에 절대 누적되지 않음) 하여 긴 세션이 «Prompt is too long»에 도달하지 않도록 함; 세션이 의도를 게시하고, 서로의 상태를 읽으며, 파괴적 작업 전에 확인; 인간에게는 실시간 활동 피드로 보임
-- **조율 채널** — `COORDINATION_CHANNEL_ID` 환경 변수는 AI Lounge 채널의 기본 폴백으로 사용됨 (봇 측 라이프사이클 자동 알림은 제거됨)
+### 동시성 및 조율
+- **Worktree 지침 자동 주입** — 모든 세션에 파일 건드리기 전 `git worktree` 사용 촉구
+- **자동 worktree 정리** — 세션 종료 및 봇 시작 시 자동 삭제; 더티 worktree는 절대 자동 삭제 안 함
+- **활성 세션 레지스트리** — 인메모리 레지스트리; 각 세션이 다른 세션 상태 파악
+- **AI Lounge** — 공유 "휴게실" 채널; `--append-system-prompt`로 컨텍스트 주입 (기록에 누적 안 됨)
+- **조율 채널** — `COORDINATION_CHANNEL_ID`가 AI Lounge 채널의 기본 폴백으로 사용
 
-### 예약된 작업
-- **SchedulerCog** — 30초 마스터 루프를 가진 SQLite 기반 주기적 작업 실행기
-- **자체 등록** — Claude가 채팅 세션 중에 `POST /api/tasks`를 통해 작업 등록
-- **코드 변경 없음** — 런타임에 작업 추가, 제거 또는 수정
+### 예약 작업
+- **SchedulerCog** — SQLite 기반, 30초 마스터 루프
+- **자기 등록** — Claude가 채팅 세션 중 `POST /api/tasks`로 작업 등록
+- **코드 변경 불필요** — 런타임에 작업 추가, 제거, 수정
 - **활성화/비활성화** — 삭제 없이 작업 일시 중지 (`PATCH /api/tasks/{id}`)
 
 ### CI/CD 자동화
 - **Webhook 트리거** — GitHub Actions 또는 모든 CI/CD 시스템에서 Claude Code 작업 트리거
-- **자동 업그레이드** — 업스트림 패키지 출시 시 봇 자동 업데이트
-- **드레인 인식 재시작** — 재시작 전에 활성 세션이 완료될 때까지 대기
-- **자동 재개 표시** — 활성 세션은 모든 종료 시 자동으로 재개 표시됨; 봇이 다시 온라인 상태가 된 후 중단된 곳에서 계속
-- **재시작 승인** — 업그레이드 적용 전 선택적 확인 게이트
+- **자동 업그레이드** — 업스트림 패키지 릴리스 시 봇 자동 업데이트
+- **DrainAware 재시작** — 재시작 전 활성 세션 완료 대기
+- **자동 재개 마킹** — 모든 종료 시 활성 세션 자동 마킹
+- **수동 업그레이드 트리거** — `/upgrade` 슬래시 명령 (opt-in)
 
 ### 세션 관리
-- **세션 동기화** — CLI 세션을 Discord 스레드로 가져오기 (`/sync-sessions`); `/sync-settings`로 동기화 설정 (스레드 스타일, 시간 범위, 최소 결과 수) 확인 및 변경
-- **세션 목록** — 출처 (Discord / CLI / 전체)와 시간 범위로 필터링하는 `/sessions`
-- **세션 재개** — `/resume`는 최근 세션 (최대 25개) 선택 메뉴를 표시하고 선택한 세션을 새 스레드에서 재개; 선택적 `query` 파라미터로 키워드 검색 (요약 및 작업 디렉토리 매칭), `filter=orphaned`로 삭제된 스레드의 세션만 표시; 모든 채널이나 스레드에서 사용 가능 — 항상 설정된 메인 채널에 새 스레드 생성
-- **재개 정보** — `/resume-info`는 터미널에서 현재 세션을 계속하는 CLI 명령 표시 (스레드 전용)
-- **세션 초기화** — `/clear`는 현재 스레드의 Claude Code 세션을 초기화하고 새 스레드를 만들지 않고 처음부터 시작
-- **시작 시 재개** — 중단된 세션은 모든 봇 재시작 후 자동으로 재시작됨
-- **프로그래밍 방식 생성** — `POST /api/spawn`이 어떤 스크립트나 Claude 서브프로세스에서도 새 Discord 스레드 + Claude 세션 생성
-- **스레드 ID 주입** — `DISCORD_THREAD_ID` 환경 변수가 모든 Claude 서브프로세스에 전달됨
-- **StatusLine 표시** — Claude Code `settings.json`에 `statusLine`이 설정된 경우 각 세션 응답 후 Discord에 표시
-- **Worktree 관리** — `/worktree-list` 및 `/worktree-cleanup` 명령
-- **대화 되감기** — `/rewind`는 Claude가 생성한 작업 파일을 보존하면서 대화 기록만 초기화; 확인 메시지에 되감기 시점의 컨텍스트 사용률이 표시되어 이유를 파악하기 쉬움
-- **대화 포크** — `/fork`는 `--fork-session`을 사용해 현재 세션 상태에서 새 스레드를 생성; 원본 스레드에 영향 없이 다른 방향을 탐색 가능
-- **컨텍스트 가시화** — `/context`는 시각적 진행 막대로 현재 컨텍스트 윈도우 사용률 표시; 83.5% 임계값에 가까워지면 ⚠️ 자동 압축 경고 표시
-- **속도 제한 모니터링** — `/usage`는 Claude API 속도 제한 사용률을 퍼센트 막대와 각 제한 유형별 초기화까지 남은 시간과 함께 표시
-- **내장 도움말** — `/help`는 사용 가능한 모든 슬래시 명령과 기본 사용법을 표시 (일시적, 호출자에게만 보임)
-- **런타임 모델 전환** — `/model-show`는 현재 전역 모델과 스레드별 세션 모델 표시; `/model-set`은 재시작 없이 모든 새 세션의 모델 변경
-- **런타임 도구 권한** — `/tools-show`는 현재 허용된 도구 표시; `/tools-set`은 도구 켜기/끄기 선택 메뉴 열기; `/tools-reset`은 `.env` 기본값으로 복원 — 모두 재시작 불필요
+- **내장 도움말** — `/help`로 모든 슬래시 명령 표시 (에페메랄)
+- **세션 동기화** — `/sync-sessions`으로 CLI 세션을 Discord 스레드로 가져오기
+- **세션 목록** — 출처 및 시간 창으로 필터링 (`/sessions`)
+- **세션 재개** — `/resume`으로 새 스레드에서 선택한 세션 재개
+- **세션 지우기** — `/clear`로 현재 스레드의 세션 초기화
+- **시작 재개** — 봇 재부팅 후 중단된 세션 자동 재개
+- **프로그래밍 방식 생성** — `POST /api/spawn`으로 스크립트에서 새 스레드 + 세션 생성
+- **Worktree 관리** — `/worktree-list` 및 `/worktree-cleanup`
+- **런타임 모델 전환** — `/model-show` 및 `/model-set`, 재시작 없이
+- **대화 되감기** — `/rewind`로 선택한 사용자 턴으로 세션 JSONL 자르기
+- **대화 포크** — `/fork`으로 독립적인 세션 복사본으로 새 스레드 생성
 
 ### 보안
-- **Shell 주입 없음** — `asyncio.create_subprocess_exec`만 사용, 절대 `shell=True` 없음
-- **세션 ID 검증** — `--resume`에 전달하기 전 엄격한 정규식
+- **쉘 주입 없음** — `asyncio.create_subprocess_exec`만 사용, `shell=True` 절대 없음
+- **세션 ID 유효성 검사** — `--resume`에 전달 전 엄격한 정규식 검사
 - **플래그 주입 방지** — 모든 프롬프트 앞에 `--` 구분자
-- **시크릿 격리** — 봇 토큰이 서브프로세스 환경에서 제거됨
-- **사용자 인가** — `allowed_user_ids`가 Claude를 호출할 수 있는 사람 제한
-- **로그 주입 방지** — 사용자 제공 API 값은 로그에 기록하기 전에 정리됨 (개행 문자 및 ANSI 이스케이프 시퀀스 제거)
+- **시크릿 격리** — 봇 토큰을 서브프로세스 환경에서 제거
+- **사용자 인증** — `allowed_user_ids`로 Claude 호출 가능 사용자 제한
+- **로그 주입 방지** — 로그 작성 전 사용자 제공 API 값 정화
 
 ---
 
-## 빠른 시작
+## 빠른 시작 — 5분 안에 Discord에서 Claude 실행
 
-### 요구사항
+**전제 조건:** Python 3.10+, 설치 및 인증된 [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code).
 
-- Python 3.10+
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) 설치 및 인증
-- Message Content intent가 활성화된 Discord 봇 토큰
-- [uv](https://docs.astral.sh/uv/) (권장) 또는 pip
+**플랫폼 지원:** 주로 **Linux**에서 개발 및 테스트됩니다. macOS와 Windows는 지원되고 CI를 통과하지만, 실제 테스트는 적습니다 — 버그 보고 환영.
 
-### 독립형
+### 1단계 — Discord 봇 생성 (일회성, 약 2분)
+
+1. [discord.com/developers/applications](https://discord.com/developers/applications) → **New Application**으로 이동
+2. **Bot**으로 이동 → Privileged Gateway Intents에서 **Message Content Intent** 활성화
+3. 봇 **Token** 복사
+4. **OAuth2 → URL Generator**: 범위 `bot` + `applications.commands`, 권한: Send Messages, Create Public Threads, Send Messages in Threads, Add Reactions, Manage Messages, Read Message History
+5. 생성된 URL 열기 → 봇을 서버에 초대
+
+### 2단계 — 설정 마법사 실행
+
+클론이나 `.env` 편집 불필요 — 마법사가 모두 처리합니다:
 
 ```bash
+# uvx 사용 (설치 불필요):
+uvx --from "git+https://github.com/ebibibi/claude-code-discord-bridge.git" ccdb setup
+
+# 또는 클론 후:
 git clone https://github.com/ebibibi/claude-code-discord-bridge.git
 cd claude-code-discord-bridge
-
-cp .env.example .env
-# 봇 토큰과 채널 ID로 .env 편집
-
-uv run python -m claude_discord.main
+uv run ccdb setup
 ```
+
+### 시작 / 중지
+
+```bash
+ccdb start    # 봇 시작 (현재 디렉토리의 .env 읽기)
+ccdb start --env /path/to/.env   # 사용자 지정 .env 위치
+```
+
+설정된 채널에 메시지 전송 — Claude가 새 스레드에서 응답합니다.
 
 ### systemd 서비스로 실행 (프로덕션)
 
-프로덕션 환경에서는 systemd로 관리하면 부팅 시 자동 시작과 장애 시 자동 재시작이 가능합니다.
-
-리포지토리에는 템플릿 파일 `discord-bot.service`와 `scripts/pre-start.sh`가 포함되어 있습니다. 복사 후 경로와 사용자명을 수정하세요:
-
 ```bash
-# 1. 서비스 파일 편집 — /home/ebi와 User=ebi를 본인의 경로/사용자로 변경
 sudo cp discord-bot.service /etc/systemd/system/mybot.service
 sudo nano /etc/systemd/system/mybot.service
-
-# 2. 활성화 및 시작
 sudo systemctl daemon-reload
 sudo systemctl enable mybot.service
 sudo systemctl start mybot.service
-
-# 3. 상태 확인
-sudo systemctl status mybot.service
 journalctl -u mybot.service -f
 ```
 
-**`scripts/pre-start.sh` 동작** (봇 프로세스 시작 전 `ExecStartPre`로 실행):
+### 커스텀 Cog (포크 없이 확장)
 
-1. **`git pull --ff-only`** — `origin main`에서 최신 코드 가져오기
-2. **`uv sync`** — `uv.lock`에 따라 의존성 동기화
-3. **임포트 검증** — `claude_discord.main`이 정상적으로 임포트되는지 확인
-4. **자동 롤백** — 임포트 실패 시 이전 커밋으로 되돌리고 재시도. Discord webhook으로 성공/실패 알림 전송
-5. **Worktree 정리** — 충돌된 세션이 남긴 git worktree 삭제
+Python 파일을 디렉토리에 추가하는 것만으로 사용자 지정 기능 추가 — 포크, 서브클래스, 패키지 불필요:
 
-스크립트는 `readlink -f $0`을 통해 저장소 루트를 동적으로 감지하므로, 어느 사용자가 어디에 클론해도 스크립트 내 경로를 수정할 필요가 없습니다. `uv` 바이너리도 `PATH`에서 자동으로 찾습니다. 커스텀 경로가 필요하면 `CCDB_UV_BIN` 환경 변수로 지정하세요.
+```bash
+ccdb start --cogs-dir ./my-cogs/
+# 또는: CUSTOM_COGS_DIR=./my-cogs ccdb start
+```
 
-`.env`에 `DISCORD_WEBHOOK_URL`을 설정하면 장애 알림을 받을 수 있습니다 (선택사항).
+각 `.py` 파일은 `async def setup(bot, runner, components)`를 노출해야 합니다.
 
-### 패키지로 설치
+---
 
-이미 discord.py 봇이 있는 경우 (Discord는 토큰당 하나의 Gateway 연결만 허용):
+### 최소 봇 (패키지로 설치)
 
 ```bash
 uv add git+https://github.com/ebibibi/claude-code-discord-bridge.git
 ```
 
+`bot.py` 생성:
+
 ```python
+import asyncio
+import os
+from dotenv import load_dotenv
+import discord
 from discord.ext import commands
 from claude_discord import ClaudeRunner, setup_bridge
 
-bot = commands.Bot(...)
-runner = ClaudeRunner(command="claude", model="sonnet")
+load_dotenv()
+
+intents = discord.Intents.default()
+intents.message_content = True
+
+bot = commands.Bot(command_prefix="!", intents=intents)
+runner = ClaudeRunner(
+    command="claude",
+    model="sonnet",
+    working_dir="/path/to/your/project",
+)
 
 @bot.event
 async def on_ready():
+    print(f"Logged in as {bot.user}")
     await setup_bridge(
         bot,
         runner,
-        claude_channel_id=YOUR_CHANNEL_ID,
-        allowed_user_ids={YOUR_USER_ID},
+        claude_channel_id=int(os.environ["DISCORD_CHANNEL_ID"]),
+        allowed_user_ids={int(os.environ["DISCORD_OWNER_ID"])},
     )
+
+asyncio.run(bot.start(os.environ["DISCORD_BOT_TOKEN"]))
 ```
 
-`setup_bridge()`가 모든 Cog를 자동으로 연결합니다.
-
-최신 버전으로 업데이트:
+`setup_bridge()`가 모든 Cog를 자동으로 연결합니다. 최신 버전으로 업데이트:
 
 ```bash
 uv lock --upgrade-package claude-code-discord-bridge && uv sync
@@ -290,61 +302,99 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 |------|------|--------|
 | `DISCORD_BOT_TOKEN` | Discord 봇 토큰 | (필수) |
 | `DISCORD_CHANNEL_ID` | Claude 채팅 채널 ID | (필수) |
-| `CLAUDE_COMMAND` | Claude Code CLI 경로 | `claude` |
-| `CLAUDE_MODEL` | 사용할 모델 | `sonnet` |
-| `CLAUDE_PERMISSION_MODE` | CLI 권한 모드 | `acceptEdits` |
-| `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | 모든 권한 검사 건너뛰기 (주의하여 사용) | `false` |
-| `CLAUDE_WORKING_DIR` | Claude 작업 디렉토리 | 현재 디렉토리 |
-| `MAX_CONCURRENT_SESSIONS` | 최대 동시 Claude CLI 세션 수 (채팅·스킬·스케줄러·웹훅 등 모든 경로에 적용) | `3` |
-| `SESSION_TIMEOUT_SECONDS` | 세션 비활성 시간 초과 | `300` |
-| `DISCORD_OWNER_ID` | Claude가 입력이 필요할 때 @멘션할 사용자 ID | (선택) |
+| `CCDB_BACKEND` | 사용할 CLI 백엔드: `claude` 또는 `codex` | `claude` |
+| `CCDB_COMMAND` | CLI 바이너리 경로 또는 이름 (`CLAUDE_COMMAND` 재정의) | _(자동)_ |
+| `CCDB_MODEL` | 사용할 모델 (`CLAUDE_MODEL` 재정의) | `sonnet` |
+| `CCDB_PERMISSION_MODE` | CLI 권한 모드 (`CLAUDE_PERMISSION_MODE` 재정의) | `acceptEdits` |
+| `CCDB_DANGEROUSLY_SKIP_PERMISSIONS` | 모든 권한 검사 건너뛰기 | `false` |
+| `CCDB_WORKING_DIR` | CLI 작업 디렉토리 | 현재 디렉토리 |
+| `CCDB_ALLOWED_TOOLS` | 허용 도구 쉼표 구분 목록 | (선택) |
+| `CCDB_CHANNEL_IDS` | 멀티 채널 설정용 추가 채널 ID | (선택) |
+| `CLAUDE_COMMAND` | Claude CLI 경로 (구버전 — `CCDB_COMMAND` 권장) | `claude` |
+| `CLAUDE_MODEL` | 모델 (구버전 — `CCDB_MODEL` 권장) | `sonnet` |
+| `CLAUDE_PERMISSION_MODE` | 권한 모드 (구버전 — `CCDB_PERMISSION_MODE` 권장) | `acceptEdits` |
+| `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | 권한 건너뛰기 (구버전) | `false` |
+| `CLAUDE_WORKING_DIR` | 작업 디렉토리 (구버전) | 현재 디렉토리 |
+| `MAX_CONCURRENT_SESSIONS` | 최대 병렬 세션 수 | `3` |
+| `SESSION_TIMEOUT_SECONDS` | 세션 비활성 타임아웃 | `300` |
+| `DISCORD_OWNER_ID` | Claude가 입력 필요 시 @멘션할 사용자 ID | (선택) |
 | `COORDINATION_CHANNEL_ID` | AI Lounge 채널의 기본 폴백 채널 ID | (선택) |
-| `WORKTREE_BASE_DIR` | 세션 worktree 스캔 기본 디렉토리 (자동 정리 활성화) | (선택) |
-| `CLI_SESSIONS_PATH` | CLI 세션 탐색 경로 (`~/.claude/projects`), `/sync-sessions` 활성화에 필요 | (선택) |
-| `MENTION_ONLY_CHANNEL_IDS` | 봇이 @멘션될 때만 응답하는 채널 ID (쉼표로 구분) | (선택) |
-| `INLINE_REPLY_CHANNEL_IDS` | 인라인 답장 채널 ID (쉼표로 구분, 스레드 생성 없음) | (선택) |
-| `CHAT_ONLY_CHANNEL_IDS` | Claude의 텍스트 응답만 표시하는 채널 ID (쉼표로 구분, 도구 임베드/thinking/Todo 숨김) | (선택) |
-| `THREAD_INBOX_ENABLED` | 지속적인 스레드 수신함 활성화 (`claude -p`로 세션을 `waiting`/`done`/`ambiguous`로 분류; 스레드 대시보드에 표시) | `false` |
-| `THREAD_AUTO_RENAME` | Claude AI를 사용하여 새 스레드 제목 자동 이름 변경 — 백그라운드 `claude -p` 호출로 첫 번째 사용자 메시지에서 짧고 설명적인 제목 생성 (세션 시작 지연 없음) | `false` |
-| `CCDB_CLI_ENV_FILE` | CLI 서브프로세스 호출마다 환경 변수에 병합할 `KEY=VALUE` 파일 경로. 봇을 재시작하지 않고 즉시 반영됨. 임시 API 라우팅(예: Azure Foundry 전환)에 유용 | (선택 사항) |
-
-### 권한 모드 — `-p` 모드에서 작동하는 기능
-
-ccdb를 통해 사용할 때 Claude Code CLI는 **`-p`(비대화형) 모드**로 실행됩니다. 이 모드에서 CLI는 **권한 확인을 요청할 수 없으며** — 승인이 필요한 도구는 즉시 거부됩니다. 이는 ccdb의 제한이 아니라 [CLI의 설계 제약](https://code.claude.com/docs/en/headless)입니다.
-
-| 모드 | `-p` 모드에서의 동작 | 권장 |
-|------|----------------------|----------------|
-| `default` | ❌ **모든 도구 거부** — 사용 불가 | 사용하지 않음 |
-| `acceptEdits` | ⚠️ Edit/Write 자동 승인, Bash 거부 (Claude가 파일 작업에 Write로 폴백) | 최소 동작 옵션 |
-| `bypassPermissions` | ✅ 모든 도구 승인 | 작동하나, 아래 플래그 권장 |
-| **`CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`** | ✅ **모든 도구 승인** | **권장** — ccdb가 이미 `allowed_user_ids`로 접근 제한 |
-
-**권장 설정:** `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`를 설정하세요. ccdb가 `allowed_user_ids`를 통해 Claude와의 상호작용을 제어하므로, CLI 수준의 권한 검사는 실질적인 보안 이점 없이 마찰만 추가합니다. 이름의 「dangerously」는 CLI의 범용 경고를 반영한 것이며, 접근이 이미 게이팅된 ccdb 컨텍스트에서는 실용적인 선택입니다.
-
-**세밀한 제어를 위해** `CLAUDE_ALLOWED_TOOLS`를 사용하면 모든 권한을 우회하지 않고 특정 도구만 허용할 수 있습니다:
-
-```env
-# 예시: 파일 작업과 코드 실행은 허용하지만 웹 접근은 불허
-CLAUDE_ALLOWED_TOOLS=Bash,Read,Write,Edit,Glob,Grep
-
-# 예시: 읽기 전용 모드 — Claude가 탐색할 수 있지만 수정 불가
-CLAUDE_ALLOWED_TOOLS=Read,Glob,Grep
-```
-
-주요 도구 이름: `Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`, `WebFetch`, `WebSearch`, `NotebookEdit`. 이 기능 사용 시 `CLAUDE_PERMISSION_MODE=default`로 설정하세요 (다른 모드에서는 재정의될 수 있습니다).
-
-> **Discord에 권한 버튼이 나타나지 않는 이유?** CLI의 `-p` 모드는 `permission_request` 이벤트를 발생시키지 않으므로 ccdb에 표시할 내용이 없습니다. 표시되는 `AskUserQuestion` 버튼(Claude의 선택 프롬프트)은 다른 메커니즘으로 정상 작동합니다. 자세한 조사는 [#210](https://github.com/ebibibi/claude-code-discord-bridge/issues/210)을 참조하세요.
+| `MENTION_ONLY_CHANNEL_IDS` | @멘션 시에만 응답하는 채널 ID (쉼표 구분) | (선택) |
+| `INLINE_REPLY_CHANNEL_IDS` | 인라인 응답 채널 ID (쉼표 구분, 스레드 미생성) | (선택) |
+| `CHAT_ONLY_CHANNEL_IDS` | 채팅 전용 모드 채널 ID (쉼표 구분) | (선택) |
+| `WORKTREE_BASE_DIR` | 세션 worktree 스캔 기본 디렉토리 | (선택) |
+| `CLI_SESSIONS_PATH` | CLI 세션 검색 경로 (`~/.claude/projects`) | (선택) |
+| `CUSTOM_COGS_DIR` | 시작 시 로드할 커스텀 Cog 파일 디렉토리 | (선택) |
+| `THREAD_INBOX_ENABLED` | 지속적인 스레드 수신함 활성화 | `false` |
+| `THREAD_AUTO_RENAME` | Claude AI로 새 스레드 제목 자동 이름 변경 | `false` |
+| `CCDB_CLI_ENV_FILE` | CLI 서브프로세스에 매번 병합할 `KEY=VALUE` 파일 경로 | (선택) |
+| `API_HOST` | REST API 바인드 주소 | `127.0.0.1` |
+| `API_PORT` | REST API 포트 (설정 시 활성화) | (선택) |
 
 ---
 
-## Discord 봇 설정
+## REST API
 
-1. [Discord Developer Portal](https://discord.com/developers/applications)에서 새 애플리케이션 만들기
-2. 봇 만들기 및 토큰 복사
-3. Privileged Gateway Intents에서 **Message Content Intent** 활성화
-4. 다음 권한으로 봇 초대:
-   - Send Messages, Create Public Threads, Send Messages in Threads
-   - Add Reactions, Manage Messages, Read Message History
+알림 및 작업 관리를 위한 선택적 REST API. aiohttp 필요:
+
+```bash
+uv add "claude-code-discord-bridge[api]"
+```
+
+### 엔드포인트
+
+| 메서드 | 경로 | 설명 |
+|--------|------|------|
+| GET | `/api/health` | 헬스 체크 |
+| POST | `/api/notify` | 즉시 알림 전송 |
+| POST | `/api/schedule` | 알림 예약 |
+| GET | `/api/scheduled` | 대기 중인 알림 목록 |
+| DELETE | `/api/scheduled/{id}` | 알림 취소 |
+| POST | `/api/tasks` | 주기적 Claude Code 작업 등록 |
+| GET | `/api/tasks` | 등록된 작업 목록 |
+| DELETE | `/api/tasks/{id}` | 작업 삭제 |
+| PATCH | `/api/tasks/{id}` | 작업 업데이트 |
+| POST | `/api/spawn` | 새 Discord 스레드 생성 및 Claude Code 세션 시작 (논블로킹) |
+| POST | `/api/mark-resume` | 다음 봇 시작 시 자동 재개를 위해 스레드 마킹 |
+| GET | `/api/lounge` | 최근 AI Lounge 메시지 읽기 |
+| POST | `/api/lounge` | AI Lounge에 메시지 게시 |
+
+---
+
+## 아키텍처
+
+```
+claude_code_core/          # 백엔드 무관 공유 핵심 라이브러리
+  backend.py               # SessionBackend 프로토콜 + create_backend() 팩토리
+  codex_runner.py          # OpenAI Codex CLI 백엔드
+  runner.py                # Claude CLI 서브프로세스 관리자
+  parser.py                # stream-json 이벤트 파서
+  types.py                 # SDK 메시지 타입 정의
+claude_discord/
+  main.py                  # 독립 실행 엔트리포인트
+  cli.py                   # CLI 엔트리포인트 (ccdb setup/start)
+  setup.py                 # setup_bridge()
+  cogs/
+    claude_chat.py         # 인터랙티브 채팅
+    skill_command.py       # /skill 슬래시 명령
+    session_manage.py      # 세션 관리
+    scheduler.py           # 주기적 작업 실행기
+    webhook_trigger.py     # Webhook → Claude Code 작업 실행
+    auto_upgrade.py        # 자동 업그레이드 + 재시작
+  ext/
+    api_server.py          # REST API (선택)
+examples/
+  ebibot/                  # 실제 예시: 커스텀 Cog가 있는 개인 봇
+```
+
+### 설계 철학
+
+- **CLI 스폰, API 아님** — 완전한 Claude Code 기능 획득, API 키 불필요, 토큰당 요금 없음
+- **동시성 우선** — 여러 동시 세션이 예상 사례, 엣지 케이스 아님
+- **Discord를 접착제로** — Discord가 UI, 스레딩, 반응, webhook, 지속적인 알림 제공
+- **프레임워크, 애플리케이션 아님** — 패키지로 설치, 기존 봇에 Cog 추가
+- **코드 없는 확장성** — 소스 변경 없이 예약 작업 및 webhook 트리거 추가
+- **단순함으로 보안** — 약 8000줄의 감사 가능한 Python; subprocess exec만, 쉘 확장 없음
 
 ---
 
@@ -354,21 +404,38 @@ CLAUDE_ALLOWED_TOOLS=Read,Glob,Grep
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-1050+ 테스트가 파서, 분할기, 저장소, 러너, 스트리밍, 웹훅 트리거, 자동 업그레이드(`/upgrade` 슬래시 명령, 스레드 호출 및 승인 버튼 포함), REST API, AskUserQuestion UI, 스레드 대시보드, 예약 작업, 세션 동기화, AI Lounge, 시작 시 재개, 모델 전환, 압축 감지, TodoWrite 진행 embed, 권한/elicitation/plan-mode 이벤트 파싱을 커버합니다.
+파서, 청커, 저장소, 러너, 스트리밍, webhook 트리거, 자동 업그레이드, REST API, AskUserQuestion UI, 스레드 대시보드, 예약 작업, 세션 동기화, AI Lounge, 시작 재개, 모델 전환, 압축 감지, TodoWrite 진행 embed, 커스텀 Cog 로더, SessionBackend 프로토콜, CodexRunner, 백엔드 팩토리를 커버하는 1365+ 테스트.
 
 ---
 
-## 이 프로젝트가 구축된 방법
+## 이 프로젝트의 구축 방법
 
-**이 전체 코드베이스는 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)**에 의해 작성되었습니다. 인간 저자 ([@ebibibi](https://github.com/ebibibi))는 자연어로 요구사항과 방향을 제공했지만 소스 코드를 직접 읽거나 편집하지 않았습니다.
+**이 코드베이스는 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)** — Anthropic의 AI 코딩 에이전트 — 가 [@ebibibi](https://github.com/ebibibi)의 지도 하에 개발했습니다. 인간 저자는 요구사항을 정의하고, PR을 리뷰하고, 모든 변경사항을 승인합니다 — Claude Code가 구현을 담당합니다.
 
-이 프로젝트는 2026-02-18에 시작되었으며 Claude Code와의 반복적인 대화를 통해 계속 발전합니다.
+프로젝트는 2026-02-18에 시작되었으며, Claude Code와의 반복적인 대화를 통해 계속 발전하고 있습니다.
 
 ---
 
 ## 실제 예시
 
-**[EbiBot](https://github.com/ebibibi/discord-bot)** — 이 프레임워크를 기반으로 구축된 개인 Discord 봇. 자체 봇을 구축하기 위한 참고 자료로 활용하세요.
+**[`examples/ebibot/`](examples/ebibot/)** — 이 프레임워크 위에 구축된 개인 Discord 봇으로, 커스텀 Cog 로더를 시연합니다:
+
+- **ReminderCog** — `/remind HH:MM "message"` 슬래시 명령 + 30초 전송 루프
+- **WatchdogCog** — Todoist 기한 초과 작업 모니터
+- **AutoUpgradeCog** — GitHub webhook + systemctl restart로 자가 업데이트
+- **DocsSyncCog** — 푸시 시 webhook을 통해 문서 자동 번역
+- **AlertResponderCog** — 범용 알림 모니터링 Cog
+
+실행: `ccdb start --cogs-dir examples/ebibot/cogs/`
+
+---
+
+## 영감을 받은 프로젝트
+
+- [OpenClaw](https://github.com/openclaw/openclaw) — 이모지 상태 반응, 메시지 디바운싱, fence 인식 청킹
+- [claude-code-discord-bot](https://github.com/timoconnellaus/claude-code-discord-bot) — CLI 스폰 + stream-json 접근 방식
+- [claude-code-discord](https://github.com/zebbern/claude-code-discord) — 권한 제어 패턴
+- [claude-sandbox-bot](https://github.com/RhysSullivan/claude-sandbox-bot) — 스레드별 대화 모델
 
 ---
 

--- a/docs/pt-BR/README.md
+++ b/docs/pt-BR/README.md
@@ -3,40 +3,45 @@
 > **Nota:** Esta é uma versão autotraduzida da documentação original em inglês.
 > Em caso de discrepâncias, a [versão em inglês](../../README.md) prevalece.
 
-# claude-code-discord-bridge
+# Claude & Codex Discord Bridge
+
+*Nome do pacote: `claude-code-discord-bridge` (kebab-case)*
 
 [![CI](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**Execute múltiplas sessões do Claude Code em paralelo — com segurança — pelo Discord.**
+**Use Claude Code _ou_ OpenAI Codex no seu celular. Múltiplas threads. Tudo ao mesmo tempo. Desenvolvimento real incluído.**
 
-Cada thread do Discord vira uma sessão isolada do Claude Code. Inicie quantas precisar: trabalhe em uma feature em uma thread, revise um PR em outra, execute uma tarefa agendada em uma terceira. O bridge cuida da coordenação automaticamente para que sessões simultâneas não interfiram entre si.
+Abra Claude Code ou OpenAI Codex no Discord do seu smartphone, inicie múltiplas threads e execute sessões de desenvolvimento em paralelo — tudo sem tocar em um teclado. Cada thread do Discord se torna uma sessão de IA completamente isolada. Trabalhe em um recurso em uma thread, revise um PR em outra e execute uma tarefa em segundo plano em uma terceira — simultaneamente, misturando backends por thread. A bridge cuida de toda a coordenação para que as sessões nunca se sobreponham.
+
+**Use suas assinaturas existentes. Sem configuração de API key.** ccdb roda sobre as CLIs oficiais — Claude Code (inclusa na sua [assinatura Claude Pro/Max](https://claude.ai/pricing)) e OpenAI Codex (inclusa no [ChatGPT Plus/Pro/Business](https://chatgpt.com)). Troque backends com `/backend` ou configure por thread — seu time acessa ambas as IAs pelo Discord a custo previsível.
 
 **[English](../../README.md)** | **[日本語](../ja/README.md)** | **[简体中文](../zh-CN/README.md)** | **[한국어](../ko/README.md)** | **[Español](../es/README.md)** | **[Français](../fr/README.md)**
 
-> **Aviso:** Este projeto não é afiliado, endossado ou oficialmente conectado à Anthropic. "Claude" e "Claude Code" são marcas registradas da Anthropic, PBC. Esta é uma ferramenta open source independente que interage com o Claude Code CLI.
+> **Aviso:** Este projeto não é afiliado, endossado ou oficialmente conectado à Anthropic ou OpenAI. "Claude" e "Claude Code" são marcas registradas da Anthropic, PBC; "OpenAI", "Codex" e "ChatGPT" são marcas registradas da OpenAI. Esta é uma ferramenta de código aberto independente que faz interface com o Claude Code CLI e o OpenAI Codex CLI.
 
-> **Construído inteiramente pelo Claude Code.** Todo este código base — arquitetura, implementação, testes, documentação — foi escrito pelo Claude Code. O autor humano forneceu requisitos e direção em linguagem natural, mas não leu nem editou manualmente o código fonte. Veja [Como este projeto foi construído](#como-este-projeto-foi-construído).
+> **Construído inteiramente pelo Claude Code.** Todo este codebase — arquitetura, implementação, testes, documentação — foi escrito pelo próprio Claude Code. O autor humano forneceu requisitos e direcionamento. Veja [Como Este Projeto Foi Construído](#como-este-projeto-foi-construído).
 
 ---
 
 ## A Grande Ideia: Sessões Paralelas Sem Medo
 
-Quando você envia tarefas ao Claude Code em threads separadas do Discord, o bridge faz três coisas automaticamente:
+Quando você envia tarefas para o Claude Code em threads separadas do Discord, a bridge faz quatro coisas automaticamente:
 
-1. **Injeção de aviso de concorrência** — O prompt de sistema de cada sessão inclui instruções obrigatórias: crie um git worktree, trabalhe apenas dentro dele, nunca toque diretamente no diretório de trabalho principal.
+1. **Injeção de aviso de concorrência** — O system prompt de cada sessão inclui instruções obrigatórias: criar um git worktree, trabalhar apenas dentro dele, nunca tocar o diretório de trabalho principal diretamente.
 
-2. **Registro de sessões ativas** — Cada sessão em execução conhece as outras. Se duas sessões estiverem prestes a tocar no mesmo repositório, elas podem se coordenar ao invés de conflitar.
+2. **Registro de sessões ativas** — Cada sessão em execução sabe das outras. Se duas sessões forem tocar o mesmo repositório, elas podem coordenar em vez de conflitar.
 
-3. **AI Lounge** — Uma «sala de espera» compartilhada injetada no prompt de cada sessão. Antes de começar, cada sessão lê as mensagens recentes do Lounge para entender o que as outras estão fazendo. Antes de operações destrutivas (force push, reinício do bot, etc.), as sessões verificam o Lounge primeiro.
+3. **AI Lounge** — Um "saguão" injetado em cada prompt. Antes de começar, cada sessão lê as mensagens recentes do lounge para ver o que as outras estão fazendo. Antes de operações destrutivas (force push, reinício do bot, drop de DB), as sessões verificam o lounge primeiro.
 
 ```
-Thread A (feature)    ──→  Claude Code (worktree-A)  ─┐
-Thread B (revisão PR) ──→  Claude Code (worktree-B)   ├─→  #ai-lounge
-Thread C (docs)       ──→  Claude Code (worktree-C)  ─┘    "A: refactor auth em progresso"
-                                                            "B: revisão PR #42 concluída"
-                                                            "C: atualizando README"
+Thread A (feature)   ──→  Claude Code (worktree-A)  ─┐
+Thread B (PR review) ──→  Claude Code (worktree-B)   ├─→  #ai-lounge
+Thread C (docs)      ──→  Claude Code (worktree-C)  ─┘    "A: refactor auth em andamento"
+                                                           "B: revisão PR #42 concluída"
+                                                           "C: atualizando README"
 ```
 
 Sem race conditions. Sem trabalho perdido. Sem surpresas no merge.
@@ -47,63 +52,35 @@ Sem race conditions. Sem trabalho perdido. Sem surpresas no merge.
 
 ### Chat Interativo (Mobile / Desktop)
 
-Use o Claude Code de qualquer lugar onde o Discord funcione — celular, tablet ou desktop. Cada mensagem cria ou continua uma thread, mapeada 1:1 para uma sessão persistente do Claude Code.
+Use Claude Code de qualquer lugar que o Discord funcione — celular, tablet ou desktop. Cada mensagem cria ou continua uma thread, mapeando 1:1 a uma sessão persistente do Claude Code.
 
 ### Desenvolvimento Paralelo
 
 Abra múltiplas threads simultaneamente. Cada uma é uma sessão independente do Claude Code com seu próprio contexto, diretório de trabalho e git worktree. Padrões úteis:
 
-- **Feature + revisão em paralelo**: Inicie uma feature em uma thread enquanto o Claude revisa um PR em outra.
-- **Múltiplos colaboradores**: Diferentes membros do time têm sua própria thread; as sessões ficam cientes umas das outras via o AI Lounge.
-- **Experimente com segurança**: Tente uma abordagem na thread A enquanto mantém a thread B no código estável.
+- **Feature + revisão em paralelo**: Inicie um recurso em uma thread enquanto o Claude revisa um PR em outra.
+- **Múltiplos contribuidores**: Diferentes membros da equipe têm suas próprias threads; sessões ficam cientes umas das outras via AI Lounge.
+- **Experimente com segurança**: Tente uma abordagem na thread A mantendo a thread B em código estável.
 
 ### Tarefas Agendadas (SchedulerCog)
 
-Registre tarefas periódicas do Claude Code a partir de uma conversa no Discord ou via REST API — sem mudanças de código, sem redeploys. As tarefas são armazenadas no SQLite e executadas conforme um agendamento configurável. O Claude pode auto-registrar tarefas durante uma sessão usando `POST /api/tasks`.
+Registre tarefas periódicas do Claude Code de uma conversa do Discord ou via REST API — sem alterações de código, sem redeploys.
 
 ```
 /skill name:goodmorning         → executa imediatamente
-Claude chama POST /api/tasks   → registra tarefa periódica
-SchedulerCog (loop a cada 30s) → dispara tarefas no horário certo
+Claude chama POST /api/tasks    → registra tarefa periódica
+SchedulerCog (loop 30s)         → dispara tarefas vencidas automaticamente
 ```
 
 ### Automação CI/CD
 
-Acione tarefas do Claude Code a partir do GitHub Actions via webhooks do Discord. O Claude roda autonomamente — lê código, atualiza docs, cria PRs, ativa auto-merge.
+Dispare tarefas do Claude Code a partir do GitHub Actions via webhooks do Discord. Claude roda autonomamente — lê código, atualiza documentação, cria PRs, habilita auto-merge.
 
-```
-GitHub Actions → Discord Webhook → Bridge → Claude Code CLI
-                                                  ↓
-GitHub PR ←── git push ←── Claude Code ──────────┘
-```
-
-**Exemplo real:** A cada push para `main`, o Claude analisa o diff, atualiza documentação em inglês + japonês, cria um PR com resumo bilíngue e ativa o auto-merge. Zero interação humana.
+**Exemplo real:** A cada push para `main`, Claude analisa o diff, atualiza documentação em inglês + japonês, cria um PR bilíngue e habilita auto-merge. Zero interação humana.
 
 ### Sincronização de Sessões
 
-Já usa o Claude Code CLI diretamente? Sincronize suas sessões de terminal existentes em threads do Discord com `/sync-sessions`. Preenche mensagens recentes de conversa para que você possa continuar uma sessão CLI pelo celular sem perder contexto.
-
-### Criação Programática de Sessões
-
-Crie novas sessões do Claude Code a partir de scripts, GitHub Actions ou outras sessões do Claude — sem interação com mensagens do Discord.
-
-```bash
-# De outra sessão do Claude ou um script CI:
-curl -X POST "$CCDB_API_URL/api/spawn" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "Executar scan de segurança no repositório", "thread_name": "Scan de Segurança"}'
-# Retorna imediatamente com o ID da thread; Claude roda em segundo plano
-```
-
-Subprocessos do Claude recebem `DISCORD_THREAD_ID` como variável de ambiente, então uma sessão em execução pode criar sessões filhas para paralelizar o trabalho.
-
-### Retomada ao Iniciar
-
-Se o bot reiniciar no meio de uma sessão, as sessões do Claude interrompidas são automaticamente retomadas quando o bot volta online. As sessões são marcadas para retomada de três formas:
-
-- **Automático (reinício por atualização)** — `AutoUpgradeCog` tira um snapshot de todas as sessões ativas logo antes de um reinício por atualização de pacote e as marca automaticamente.
-- **Automático (qualquer encerramento)** — `ClaudeChatCog.cog_unload()` marca todas as sessões em execução quando o bot encerra por qualquer mecanismo (`systemctl stop`, `bot.close()`, SIGTERM, etc.).
-- **Manual** — Qualquer sessão pode chamar `POST /api/mark-resume` diretamente.
+Já usa Claude Code CLI diretamente? Sincronize suas sessões de terminal existentes em threads do Discord com `/sync-sessions`. Retroalimenta mensagens de conversa recentes para que você possa continuar uma sessão CLI do seu celular sem perder contexto.
 
 ---
 
@@ -111,172 +88,191 @@ Se o bot reiniciar no meio de uma sessão, as sessões do Claude interrompidas s
 
 ### Chat Interativo
 
-#### 🔗 Sessão Básica
-- **Thread = Session** — Mapeamento 1:1 entre thread do Discord e sessão do Claude Code
-- **Persistência de sessão** — Retoma conversas entre mensagens via `--resume`
+#### 🔗 Básico de Sessão
+- **Modo somente chat** — `CHAT_ONLY_CHANNEL_IDS` mostra apenas respostas de texto do Claude; embeds de ferramentas, blocos de pensamento, embeds de sessão e listas de tarefas ficam ocultos
+- **Thread = Sessão** — Mapeamento 1:1 entre thread do Discord e sessão do Claude Code
+- **Acompanhamento de objetivo** — `/goal <condição>` define condição de conclusão; Claude continua trabalhando até a condição ser atendida
+- **Persistência de sessão** — Continue conversas entre mensagens via `--resume`
 - **Sessões concorrentes** — Múltiplas sessões paralelas com limite configurável
 - **Parar sem limpar** — `/stop` para uma sessão preservando-a para retomada
-- **Interrupção de sessão** — Enviar uma nova mensagem a uma thread ativa envia SIGINT à sessão em execução e reinicia com a nova instrução; sem necessidade de `/stop` manual
-- **Renomeação automática de threads** — Quando `THREAD_AUTO_RENAME=true`, cada nova thread é automaticamente renomeada com um título gerado pelo Claude baseado na primeira mensagem (tarefa em segundo plano, nunca atrasa o início da sessão)
+- **Interrupção de sessão** — Enviar nova mensagem para thread ativa envia SIGINT e começa com nova instrução
+- **Auto-renomear threads** — Com `THREAD_AUTO_RENAME=true`, cada nova thread é automaticamente renomeada
 
 #### 📡 Feedback em Tempo Real
-- **Status em tempo real** — Reações emoji: 🧠 pensando, 🛠️ lendo arquivos, 💻 editando, 🌐 pesquisa web
-- **Texto em streaming** — Texto intermediário do assistente aparece enquanto o Claude trabalha
-- **Embeds de resultados de ferramentas** — Resultados ao vivo com tempo decorrido aumentando a cada 10s; resultados de uma linha exibidos diretamente, resultados de múltiplas linhas recolhidos atrás de um botão de expansão
-- **Pensamento estendido** — Raciocínio exibido como embeds com spoiler (clique para revelar)
-- **Painel de threads** — Embed fixado ao vivo mostrando quais threads estão ativas vs. aguardando; owner é @mencionado quando input é necessário
+- **Status em tempo real** — Reações emoji: 🧠 pensando, 🛠️ lendo arquivos, 💻 editando, 🌐 busca na web
+- **Texto em streaming** — Texto intermediário aparece enquanto o Claude trabalha
+- **Embeds de resultado de ferramenta** — Resultados de chamadas de ferramentas ao vivo com tempo decorrido
+- **Pensamento estendido** — Raciocínio mostrado como embeds com tag spoiler (clique para revelar)
+- **Dashboard de thread** — Embed fixado ao vivo mostrando quais threads estão ativas vs. aguardando
 
-#### 🤝 Colaboração Humano-IA
-- **Perguntas interativas** — `AskUserQuestion` renderiza como Botões do Discord ou Menu de Seleção; a sessão retoma com sua resposta; botões sobrevivem a reinícios do bot
-- **Plan Mode** — Quando Claude chama `ExitPlanMode`, um embed do Discord exibe o plano completo com botões Aprovar/Cancelar; Claude prossegue somente após aprovação; cancelamento automático após 5 minutos
-- **Solicitações de permissão de ferramenta** — Quando Claude precisa de permissão para executar uma ferramenta, o Discord exibe botões Permitir/Negar com o nome e a entrada da ferramenta; negação automática após 2 minutos
-- **MCP Elicitation** — Servidores MCP podem solicitar entrada do usuário via Discord (modo formulário: até 5 campos Modal do esquema JSON; modo URL: botão URL + confirmação); timeout de 5 minutos
-- **Progresso em tempo real do TodoWrite** — Quando Claude chama `TodoWrite`, um único embed do Discord é postado e editado in-place a cada atualização; mostra ✅ concluído, 🔄 ativo (com rótulo `activeForm`), ⬜ pendente
+#### 🤝 Human-in-the-Loop
+- **Perguntas interativas** — `AskUserQuestion` renderizado como Botões ou Menu de Seleção do Discord
+- **Modo Plan** — `ExitPlanMode` mostra embed com botões Aprovar/Cancelar; 5 minutos de timeout
+- **Solicitações de permissão de ferramenta** — Botões Permitir/Negar; auto-negação após 2 minutos
+- **MCP Elicitation** — Servidores MCP podem solicitar entrada do usuário via Discord; 5 minutos de timeout
+- **Progresso TodoWrite ao vivo** — Embed único do Discord editado no lugar; mostra ✅ concluído, 🔄 ativo, ⬜ pendente
 
 #### 📊 Observabilidade
-- **Uso de tokens** — Taxa de acerto de cache e contagem de tokens exibidos no embed de sessão completa
-- **Uso de contexto** — Percentual da janela de contexto (tokens de entrada + cache, excluindo saída) e capacidade restante até o auto-compact exibidos no embed de sessão concluída; ⚠️ aviso quando acima de 83,5%
-- **Detecção de compactação** — Notifica na thread quando a compactação de contexto ocorre (tipo de gatilho + contagem de tokens antes da compactação)
-- **Notificação de travamento** — Mensagem na thread quando não há atividade (pensamento estendido ou compressão de contexto); reinicia automaticamente quando Claude retoma. Os limites se adaptam ao modelo: 30 s para modelos padrão, 120 s para Opus (pausas de reflexão mais longas)
-- **Notificações de timeout** — Embed com tempo decorrido e guia de retomada ao atingir timeout
-- **Caixa de entrada de threads** — Quando `THREAD_INBOX_ENABLED=true`, o painel exibe uma seção 📬 persistente; após cada sessão terminar, o Claude classifica a última mensagem (`waiting`/`done`/`ambiguous`) via uma chamada leve a `claude -p`; threads aguardando resposta sobrevivem a reinícios do bot e são exibidas até você responder
+- **Uso de tokens** — Taxa de acerto de cache e contagens de tokens no embed de sessão concluída
+- **Uso de contexto** — Percentual da janela de contexto; aviso ⚠️ acima de 83.5%
+- **Detecção de compactação** — Notifica na thread quando compactação de contexto ocorre
+- **Notificação de parada longa** — Mensagem na thread após inatividade (30s padrão, 120s para Opus)
+- **Notificações de timeout** — Embed com tempo decorrido e guia de retomada
+- **Exibição de StatusLine** — Exibe o status do Claude após cada sessão
+- **Caixa de entrada de thread** — Com `THREAD_INBOX_ENABLED=true`, seção 📬 no dashboard
 
-#### 🔌 Entrada e Skills
-- **Suporte a anexos** — Arquivos de texto adicionados automaticamente ao prompt (até 5 × 50 KB); imagens baixadas e passadas via `--image` (até 4 × 5 MB)
-- **Execução de skills** — Comando `/skill` com autocomplete, argumentos opcionais, retomada dentro da thread
-- **Hot reload** — Novos skills adicionados a `~/.claude/skills/` são detectados automaticamente (atualização a cada 60s, sem reinício)
+#### 🔌 Entrada e Habilidades
+- **Suporte a anexos** — Arquivos de texto adicionados automaticamente (até 5 arquivos, 200 KB cada); imagens como URLs de CDN (até 4 × 5 MB)
+- **Entrega de arquivos sob demanda** — Claude escreve caminho em `.ccdb-attachments`; enviado como anexo do Discord na conclusão da sessão
+- **Execução de habilidades** — Comando `/skill` com autocompletar; habilidades de plugins instalados também descobertas
+- **Hot reload** — Novas habilidades em `~/.claude/skills/` detectadas automaticamente (atualização de 60s)
 
 ### Concorrência e Coordenação
-- **Instruções de worktree auto-injetadas** — Cada sessão recebe instruções para usar `git worktree` antes de tocar em qualquer arquivo
-- **Limpeza automática de worktree** — Worktrees de sessão (`wt-{thread_id}`) são removidos automaticamente ao final da sessão e na inicialização do bot; worktrees com alterações nunca são removidos automaticamente (invariante de segurança)
+- **Instruções de Worktree auto-injetadas** — Cada sessão instruída a usar `git worktree`
+- **Limpeza automática de worktree** — Worktrees de sessão removidos automaticamente; worktrees sujos nunca são removidos automaticamente
 - **Registro de sessões ativas** — Registro em memória; cada sessão vê o que as outras estão fazendo
-- **AI Lounge** — Canal «sala de descanso» compartilhado; contexto injetado via `--append-system-prompt` (efêmero, nunca acumula no histórico) para que sessões longas nunca atinjam «Prompt is too long»; sessões publicam intenções, leem o status umas das outras e verificam antes de operações destrutivas; os humanos veem como um feed de atividade em tempo real
-- **Canal de coordenação** — A variável de ambiente `COORDINATION_CHANNEL_ID` é usada como fallback padrão para o canal AI Lounge (notificações automáticas de ciclo de vida do bot foram removidas)
+- **AI Lounge** — Canal compartilhado; contexto injetado via `--append-system-prompt` (nunca acumula no histórico)
+- **Canal de coordenação** — `COORDINATION_CHANNEL_ID` como fallback padrão para AI Lounge
 
 ### Tarefas Agendadas
-- **SchedulerCog** — Executor de tarefas periódicas com suporte SQLite e um loop mestre de 30 segundos
-- **Auto-registro** — O Claude registra tarefas via `POST /api/tasks` durante uma sessão de chat
-- **Sem mudanças de código** — Adiciona, remove ou modifica tarefas em tempo de execução
-- **Ativar/desativar** — Pausa tarefas sem excluí-las (`PATCH /api/tasks/{id}`)
+- **SchedulerCog** — Executor de tarefas periódicas com suporte SQLite, loop mestre de 30 segundos
+- **Auto-registro** — Claude registra tarefas via `POST /api/tasks`
+- **Sem alterações de código** — Adicione, remova ou modifique tarefas em tempo de execução
+- **Ativar/desativar** — Pause tarefas sem excluir (`PATCH /api/tasks/{id}`)
 
 ### Automação CI/CD
-- **Disparadores webhook** — Aciona tarefas do Claude Code a partir do GitHub Actions ou qualquer sistema CI/CD
-- **Auto-atualização** — Atualiza automaticamente o bot quando pacotes upstream são publicados
-- **Reinício com drenagem** — Aguarda sessões ativas terminarem antes de reiniciar
-- **Marcação automática de retomada** — Sessões ativas são automaticamente marcadas para retomada em qualquer encerramento (reinício por atualização via `AutoUpgradeCog`, ou qualquer outro encerramento via `ClaudeChatCog.cog_unload()`); retomam de onde pararam após o reinício do bot
-- **Aprovação de reinício** — Portão opcional para confirmar atualizações antes de aplicá-las
+- **Gatilhos de Webhook** — Dispare tarefas do GitHub Actions ou qualquer sistema CI/CD
+- **Auto-upgrade** — Atualiza o bot automaticamente quando pacotes upstream são lançados
+- **Reinício DrainAware** — Aguarda sessões ativas terminarem antes de reiniciar
+- **Marcação automática de retomada** — Sessões ativas marcadas automaticamente em qualquer desligamento
+- **Gatilho manual de upgrade** — Comando `/upgrade` (opt-in via `slash_command_enabled=True`)
 
-### Gerenciamento de Sessões
-- **Sincronização de sessões** — Importa sessões CLI como threads do Discord (`/sync-sessions`); `/sync-settings` para visualizar ou alterar preferências de sincronização (estilo de thread, janela de tempo, resultados mínimos)
-- **Lista de sessões** — `/sessions` com filtragem por origem (Discord / CLI / todas) e janela de tempo
-- **Retomada de sessão** — `/resume` mostra um menu de seleção com sessões recentes (até 25) e retoma a selecionada em uma nova thread; parâmetro opcional `query` para busca por palavra-chave (corresponde a resumo e diretório de trabalho), `filter=orphaned` para mostrar apenas sessões de threads excluídas; funciona de qualquer canal ou thread — sempre cria uma nova thread no canal principal configurado
-- **Informações de retomada** — `/resume-info` mostra o comando CLI para continuar a sessão atual em um terminal (apenas em threads)
-- **Limpar sessão** — `/clear` redefine a sessão do Claude Code para a thread atual, começando do zero sem criar uma nova thread
-- **Retomada ao iniciar** — Sessões interrompidas reiniciam automaticamente após qualquer reinício do bot; `AutoUpgradeCog` (reinícios por atualização) e `ClaudeChatCog.cog_unload()` (todos os outros encerramentos) as marcam automaticamente, ou use `POST /api/mark-resume` manualmente
-- **Criação programática** — `POST /api/spawn` cria uma nova thread do Discord + sessão do Claude de qualquer script ou subprocesso do Claude; retorna um 201 não bloqueante imediatamente após a criação da thread
-- **Injeção de ID da thread** — A variável de ambiente `DISCORD_THREAD_ID` é passada para cada subprocesso do Claude, permitindo que sessões criem sessões filhas via `$CCDB_API_URL/api/spawn`
-- **Exibição de StatusLine** — Se o `settings.json` do Claude Code tiver `statusLine` configurado, sua saída é exibida no Discord após cada resposta de sessão
-- **Gerenciamento de worktree** — `/worktree-list` mostra todos os worktrees de sessão ativos com status limpo/sujo; `/worktree-cleanup` remove worktrees limpos órfãos (suporta preview com `dry_run`)
-- **Rebobinar conversa** — `/rewind` redefine o histórico de conversa mantendo os arquivos de trabalho que o Claude criou; a mensagem de confirmação mostra o % de uso do contexto no momento do reset
-- **Bifurcar conversa** — `/fork` usa `--fork-session` para criar uma nova thread que continua do mesmo estado de sessão, permitindo explorar uma direção diferente sem afetar a thread original
-- **Visibilidade do contexto** — `/context` exibe o % de uso da janela de contexto com uma barra de progresso visual; mostra aviso ⚠️ de autocompactação ao se aproximar do limite de 83.5%
-- **Monitoramento de rate limit** — `/usage` exibe a utilização do rate limit da API Claude com barra de percentual e contagem regressiva até o reset por tipo de limite
-- **Ajuda integrada** — `/help` exibe todos os comandos slash disponíveis e uso básico (efêmero, visível apenas para quem invocou)
-- **Troca de modelo em tempo de execução** — `/model-show` exibe o modelo global atual e o modelo de sessão por thread; `/model-set` altera o modelo para todas as novas sessões sem reiniciar
-- **Permissões de ferramenta em tempo de execução** — `/tools-show` exibe as ferramentas atualmente permitidas; `/tools-set` abre um menu de seleção para ativar/desativar ferramentas; `/tools-reset` reverte ao padrão do `.env` — tudo sem reiniciar
+### Gerenciamento de Sessão
+- **Ajuda integrada** — `/help` mostra todos os comandos slash disponíveis (efêmero)
+- **Sincronização de sessão** — Importa sessões CLI como threads do Discord (`/sync-sessions`)
+- **Lista de sessões** — `/sessions` com filtragem por origem e janela de tempo
+- **Retomar sessão** — `/resume` mostra menu de seleção e retoma em nova thread
+- **Limpar sessão** — `/clear` redefine a sessão do Claude Code da thread atual
+- **Retomada na inicialização** — Sessões interrompidas retomam automaticamente após qualquer reinicialização do bot
+- **Spawn programático** — `POST /api/spawn` cria nova thread + sessão a partir de qualquer script
+- **Gerenciamento de Worktree** — `/worktree-list` e `/worktree-cleanup`
+- **Troca de modelo em tempo de execução** — `/model-show` e `/model-set`, sem reiniciar
+- **Rebobinagem de conversa** — `/rewind` trunca a sessão no turno selecionado
+- **Bifurcação de conversa** — `/fork` cria cópia independente de sessão em nova thread
 
 ### Segurança
 - **Sem injeção de shell** — Apenas `asyncio.create_subprocess_exec`, nunca `shell=True`
-- **Validação de ID de sessão** — Regex estrito antes de passar para `--resume`
+- **Validação de ID de sessão** — Regex estrita antes de passar para `--resume`
 - **Prevenção de injeção de flags** — Separador `--` antes de todos os prompts
-- **Isolamento de segredos** — Token do bot removido do ambiente do subprocesso
-- **Autorização de usuário** — `allowed_user_ids` restringe quem pode invocar o Claude
-- **Prevenção de injeção em logs** — Valores de API fornecidos pelo usuário são sanitizados (remoção de quebras de linha e sequências de escape ANSI) antes de serem escritos nos logs
+- **Isolamento de secrets** — Token do bot removido do ambiente do subprocesso
+- **Autorização de usuário** — `allowed_user_ids` restringe quem pode invocar Claude
+- **Prevenção de injeção de log** — Valores de API fornecidos pelo usuário sanitizados antes de escrever nos logs
 
 ---
 
-## Início Rápido
+## Início Rápido — Claude no Discord em 5 Minutos
 
-### Requisitos
+**Pré-requisitos:** Python 3.10+, [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) instalado e autenticado.
 
-- Python 3.10+
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) instalado e autenticado
-- Token de bot Discord com Message Content intent habilitado
-- [uv](https://docs.astral.sh/uv/) (recomendado) ou pip
+**Suporte de plataforma:** Principalmente desenvolvido e testado no **Linux**. macOS e Windows são suportados e passam no CI, mas recebem menos testes no mundo real.
 
-### Execução autônoma
+### Passo 1 — Criar um Bot do Discord (uma vez, ~2 minutos)
+
+1. Vá para [discord.com/developers/applications](https://discord.com/developers/applications) → **New Application**
+2. Navegue para **Bot** → habilite **Message Content Intent** em Privileged Gateway Intents
+3. Copie o **Token** do bot
+4. Vá para **OAuth2 → URL Generator**: Escopos `bot` + `applications.commands`, Permissões: Send Messages, Create Public Threads, Send Messages in Threads, Add Reactions, Manage Messages, Read Message History
+5. Abra a URL gerada → convide o bot para seu servidor
+
+### Passo 2 — Execute o Assistente de Configuração
+
+Sem necessidade de clonar ou editar `.env` — o assistente faz tudo:
 
 ```bash
+# Com uvx (sem necessidade de instalação):
+uvx --from "git+https://github.com/ebibibi/claude-code-discord-bridge.git" ccdb setup
+
+# Ou após clonar:
 git clone https://github.com/ebibibi/claude-code-discord-bridge.git
 cd claude-code-discord-bridge
-
-cp .env.example .env
-# Edite .env com seu token de bot e ID do canal
-
-uv run python -m claude_discord.main
+uv run ccdb setup
 ```
 
-### Executar como serviço systemd (produção)
-
-Em produção, gerenciar via systemd garante inicialização automática na boot e reinício em caso de falha.
-
-O repositório inclui modelos prontos: `discord-bot.service` e `scripts/pre-start.sh`. Copie e ajuste os caminhos e o usuário:
+### Iniciar / Parar
 
 ```bash
-# 1. Edite o arquivo de serviço — substitua /home/ebi e User=ebi pelo seu caminho/usuário
+ccdb start    # iniciar o bot (lê .env no diretório atual)
+ccdb start --env /path/to/.env   # localização personalizada do .env
+```
+
+Envie uma mensagem no canal configurado — Claude responderá em uma nova thread.
+
+### Executar como Serviço systemd (Produção)
+
+```bash
 sudo cp discord-bot.service /etc/systemd/system/mybot.service
 sudo nano /etc/systemd/system/mybot.service
-
-# 2. Habilitar e iniciar
 sudo systemctl daemon-reload
 sudo systemctl enable mybot.service
 sudo systemctl start mybot.service
-
-# 3. Verificar status
-sudo systemctl status mybot.service
 journalctl -u mybot.service -f
 ```
 
-**O que `scripts/pre-start.sh` faz** (executado como `ExecStartPre` antes do processo do bot):
+### Cogs Personalizados (Estenda Sem Fork)
 
-1. **`git pull --ff-only`** — obtém o código mais recente de `origin main`
-2. **`uv sync`** — sincroniza dependências conforme `uv.lock`
-3. **Validação de importação** — verifica se `claude_discord.main` importa corretamente
-4. **Rollback automático** — se a importação falhar, reverte para o commit anterior e tenta novamente; envia notificação via Discord webhook
-5. **Limpeza de worktrees** — remove git worktrees órfãos de sessões que falharam
+Adicione suas próprias funcionalidades colocando arquivos Python em um diretório — sem fork, sem subclasse, sem pacote:
 
-O script detecta dinamicamente a raiz do repositório via `readlink -f $0`, então não é necessário editar caminhos no script independentemente de onde o clone foi feito. O binário `uv` também é auto-detectado do `PATH`; use a variável `CCDB_UV_BIN` para especificar um caminho personalizado.
+```bash
+ccdb start --cogs-dir ./my-cogs/
+# Ou: CUSTOM_COGS_DIR=./my-cogs ccdb start
+```
 
-Configure `DISCORD_WEBHOOK_URL` no `.env` para receber notificações de falha (opcional).
+Cada arquivo `.py` deve expor `async def setup(bot, runner, components)`.
 
-### Instalar como pacote
+---
 
-Se você já tem um bot discord.py rodando (Discord permite apenas uma conexão Gateway por token):
+### Bot Mínimo (Instalar como Pacote)
 
 ```bash
 uv add git+https://github.com/ebibibi/claude-code-discord-bridge.git
 ```
 
+Crie `bot.py`:
+
 ```python
+import asyncio
+import os
+from dotenv import load_dotenv
+import discord
 from discord.ext import commands
 from claude_discord import ClaudeRunner, setup_bridge
 
-bot = commands.Bot(...)
-runner = ClaudeRunner(command="claude", model="sonnet")
+load_dotenv()
+
+intents = discord.Intents.default()
+intents.message_content = True
+
+bot = commands.Bot(command_prefix="!", intents=intents)
+runner = ClaudeRunner(
+    command="claude",
+    model="sonnet",
+    working_dir="/path/to/your/project",
+)
 
 @bot.event
 async def on_ready():
+    print(f"Logged in as {bot.user}")
     await setup_bridge(
         bot,
         runner,
-        claude_channel_id=YOUR_CHANNEL_ID,
-        allowed_user_ids={YOUR_USER_ID},
+        claude_channel_id=int(os.environ["DISCORD_CHANNEL_ID"]),
+        allowed_user_ids={int(os.environ["DISCORD_OWNER_ID"])},
     )
+
+asyncio.run(bot.start(os.environ["DISCORD_BOT_TOKEN"]))
 ```
 
-`setup_bridge()` conecta todos os Cogs automaticamente. Novos Cogs adicionados ao ccdb são incluídos sem mudanças no código do consumidor.
-
-Atualizar para a última versão:
+`setup_bridge()` conecta todos os Cogs automaticamente. Atualizar para a última versão:
 
 ```bash
 uv lock --upgrade-package claude-code-discord-bridge && uv sync
@@ -288,212 +284,36 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 
 | Variável | Descrição | Padrão |
 |----------|-----------|--------|
-| `DISCORD_BOT_TOKEN` | Seu token de bot Discord | (obrigatório) |
-| `DISCORD_CHANNEL_ID` | ID do canal para o chat do Claude | (obrigatório) |
-| `CLAUDE_COMMAND` | Caminho para o Claude Code CLI | `claude` |
-| `CLAUDE_MODEL` | Modelo a usar | `sonnet` |
-| `CLAUDE_PERMISSION_MODE` | Modo de permissão do CLI | `acceptEdits` |
-| `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | Pular todas as verificações de permissão (use com cuidado) | `false` |
-| `CLAUDE_WORKING_DIR` | Diretório de trabalho para o Claude | diretório atual |
-| `MAX_CONCURRENT_SESSIONS` | Máximo de sessões Claude CLI em paralelo (aplica-se a todos os caminhos: chat, skills, scheduler, webhooks) | `3` |
-| `SESSION_TIMEOUT_SECONDS` | Timeout de inatividade da sessão | `300` |
-| `DISCORD_OWNER_ID` | ID do usuário para @mencionar quando o Claude precisa de input | (opcional) |
-| `COORDINATION_CHANNEL_ID` | ID do canal usado como fallback padrão para o canal AI Lounge | (opcional) |
-| `WORKTREE_BASE_DIR` | Diretório base para escanear worktrees de sessão (ativa limpeza automática) | (opcional) |
-| `CLI_SESSIONS_PATH` | Caminho para `~/.claude/projects` para descoberta de sessões CLI (habilita `/sync-sessions`) | (opcional) |
-| `MENTION_ONLY_CHANNEL_IDS` | IDs de canal separados por vírgula onde o bot responde apenas quando @mencionado | (opcional) |
-| `INLINE_REPLY_CHANNEL_IDS` | IDs de canal separados por vírgula onde o bot responde inline (sem criar thread) | (opcional) |
-| `CHAT_ONLY_CHANNEL_IDS` | IDs de canal separados por vírgula onde apenas as respostas de texto do Claude são exibidas (embeds de ferramentas/thinking/Todo ocultos) | (opcional) |
-| `THREAD_INBOX_ENABLED` | Ativa a caixa de entrada persistente de threads (classifica sessões como `waiting`/`done`/`ambiguous` via `claude -p`; exibido no painel de threads) | `false` |
-| `THREAD_AUTO_RENAME` | Renomeia automaticamente títulos de novas threads com Claude AI — gera um título curto e descritivo da primeira mensagem do usuário via chamada `claude -p` em segundo plano (sem atrasar o início da sessão) | `false` |
-| `CCDB_CLI_ENV_FILE` | Caminho para um arquivo `KEY=VALUE` cujas variáveis são mescladas no ambiente do subprocesso CLI a cada invocação. As alterações entram em vigor imediatamente sem reiniciar o bot. Útil para roteamento de API temporário (ex.: Azure Foundry) | (opcional) |
-
-### Modos de Permissão — O Que Funciona no Modo `-p`
-
-O Claude Code CLI é executado em **modo `-p` (não-interativo)** quando usado através do ccdb. Neste modo, o CLI **não pode solicitar permissões** — ferramentas que requerem aprovação são rejeitadas imediatamente. Esta é uma [restrição de design do CLI](https://code.claude.com/docs/en/headless), não uma limitação do ccdb.
-
-| Modo | Comportamento no modo `-p` | Recomendação |
-|------|----------------------|----------------|
-| `default` | ❌ **Todas as ferramentas rejeitadas** — inutilizável | Não usar |
-| `acceptEdits` | ⚠️ Edit/Write aprovados automaticamente, Bash rejeitado (Claude usa Write para operações de arquivo) | Opção mínima viável |
-| `bypassPermissions` | ✅ Todas as ferramentas aprovadas | Funciona, mas prefira a opção abaixo |
-| **`CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`** | ✅ **Todas as ferramentas aprovadas** | **Recomendado** — ccdb já restringe o acesso via `allowed_user_ids` |
-
-**Nossa recomendação:** Configure `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`. Como o ccdb controla quem pode interagir com o Claude via `allowed_user_ids`, as verificações de permissão no nível do CLI adicionam fricção sem benefício real de segurança. O «dangerously» no nome reflete o aviso geral do CLI; no contexto do ccdb onde o acesso já é controlado, é a escolha prática.
-
-**Para controle granular**, use `CLAUDE_ALLOWED_TOOLS` para permitir ferramentas específicas sem bypassar completamente as permissões:
-
-```env
-# Exemplo: permitir operações de arquivo e execução de código, mas não acesso à web
-CLAUDE_ALLOWED_TOOLS=Bash,Read,Write,Edit,Glob,Grep
-
-# Exemplo: modo somente leitura — Claude pode explorar mas não modificar
-CLAUDE_ALLOWED_TOOLS=Read,Glob,Grep
-```
-
-Nomes de ferramentas comuns: `Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`, `WebFetch`, `WebSearch`, `NotebookEdit`. Configure `CLAUDE_PERMISSION_MODE=default` ao usar isso (outros modos podem sobrescrever).
-
-> **Por que os botões de permissão não aparecem no Discord?** O modo `-p` do CLI nunca emite eventos `permission_request`, então não há nada para o ccdb exibir. Os botões `AskUserQuestion` que você vê (prompts de seleção do Claude) são um mecanismo diferente que funciona corretamente. Veja [#210](https://github.com/ebibibi/claude-code-discord-bridge/issues/210) para a investigação completa.
-
----
-
-## Configuração do Bot Discord
-
-1. Crie uma nova aplicação no [Portal do Desenvolvedor Discord](https://discord.com/developers/applications)
-2. Crie um bot e copie o token
-3. Ative **Message Content Intent** em Privileged Gateway Intents
-4. Convide o bot com estas permissões:
-   - Send Messages
-   - Create Public Threads
-   - Send Messages in Threads
-   - Add Reactions
-   - Manage Messages (para limpeza de reações)
-   - Read Message History
-
----
-
-## GitHub + Automação com Claude Code
-
-### Exemplo: Sincronização Automática de Documentação
-
-A cada push para `main`, o Claude Code:
-1. Puxa as últimas mudanças e analisa o diff
-2. Atualiza a documentação em inglês
-3. Traduz para japonês (ou qualquer idioma alvo)
-4. Cria um PR com resumo bilíngue
-5. Ativa o auto-merge — faz merge automaticamente quando o CI passa
-
-**GitHub Actions:**
-
-```yaml
-# .github/workflows/docs-sync.yml
-name: Documentation Sync
-on:
-  push:
-    branches: [main]
-jobs:
-  trigger:
-    if: "!contains(github.event.head_commit.message, '[docs-sync]')"
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          curl -X POST "${{ secrets.DISCORD_WEBHOOK_URL }}" \
-            -H "Content-Type: application/json" \
-            -d '{"content": "🔄 docs-sync"}'
-```
-
-**Configuração do bot:**
-
-```python
-from claude_discord import WebhookTriggerCog, WebhookTrigger, ClaudeRunner
-
-runner = ClaudeRunner(command="claude", model="sonnet")
-
-triggers = {
-    "🔄 docs-sync": WebhookTrigger(
-        prompt="Analise mudanças, atualize docs, crie um PR com resumo bilíngue, ative auto-merge.",
-        working_dir="/home/user/my-project",
-        timeout=600,
-    ),
-}
-
-await bot.add_cog(WebhookTriggerCog(
-    bot=bot,
-    runner=runner,
-    triggers=triggers,
-    channel_ids={YOUR_CHANNEL_ID},
-))
-```
-
-**Segurança:** Prompts são definidos no lado do servidor. Webhooks apenas selecionam qual disparador acionar — sem injeção arbitrária de prompts.
-
-### Exemplo: Auto-aprovação de PRs do Proprietário
-
-```yaml
-# .github/workflows/auto-approve.yml
-name: Auto Approve Owner PRs
-on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-jobs:
-  auto-approve:
-    if: github.event.pull_request.user.login == 'your-username'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
-    steps:
-      - env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --approve
-          gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --squash
-```
-
----
-
-## Tarefas Agendadas
-
-Registre tarefas periódicas do Claude Code em tempo de execução — sem mudanças de código, sem redeploys.
-
-De dentro de uma sessão no Discord, o Claude pode registrar uma tarefa:
-
-```bash
-# Claude chama isso dentro de uma sessão:
-curl -X POST "$CCDB_API_URL/api/tasks" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "Verificar dependências desatualizadas e abrir uma issue se encontradas", "interval_seconds": 604800}'
-```
-
-Ou registre a partir dos seus próprios scripts:
-
-```bash
-curl -X POST http://localhost:8080/api/tasks \
-  -H "Authorization: Bearer your-secret" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "Scan semanal de segurança", "interval_seconds": 604800}'
-```
-
-O loop mestre de 30 segundos detecta tarefas pendentes e cria sessões do Claude Code automaticamente.
-
----
-
-## Auto-atualização
-
-Atualize automaticamente o bot quando uma nova versão é publicada:
-
-```python
-from claude_discord import AutoUpgradeCog, UpgradeConfig
-
-config = UpgradeConfig(
-    package_name="claude-code-discord-bridge",
-    trigger_prefix="🔄 bot-upgrade",
-    working_dir="/home/user/my-bot",
-    restart_command=["sudo", "systemctl", "restart", "my-bot.service"],
-    restart_approval=True,  # Reaja com ✅ para confirmar o reinício
-)
-
-await bot.add_cog(AutoUpgradeCog(bot, config))
-```
-
-Antes de reiniciar, o `AutoUpgradeCog`:
-
-1. **Tira snapshot das sessões ativas** — Coleta todas as threads com sessões do Claude em execução (duck typing: qualquer Cog com dict `_active_runners` é descoberto automaticamente).
-2. **Drena** — Aguarda as sessões ativas terminarem naturalmente.
-3. **Marca para retomada** — Salva IDs de threads ativas na tabela de retomadas pendentes. No próximo início, essas sessões são retomadas automaticamente com um prompt "bot reiniciado, por favor continue".
-4. **Reinicia** — Executa o comando de reinício configurado.
-
-Qualquer Cog com uma propriedade `active_count` é descoberto automaticamente e drenado:
-
-```python
-class MyCog(commands.Cog):
-    @property
-    def active_count(self) -> int:
-        return len(self._running_tasks)
-```
-
-> **Cobertura:** `AutoUpgradeCog` cobre reinícios por atualização. Para *todos os outros* encerramentos (`systemctl stop`, `bot.close()`, SIGTERM), `ClaudeChatCog.cog_unload()` fornece uma segunda rede de segurança automática.
+| `DISCORD_BOT_TOKEN` | Token do bot do Discord | (obrigatório) |
+| `DISCORD_CHANNEL_ID` | ID do canal para chat do Claude | (obrigatório) |
+| `CCDB_BACKEND` | Backend CLI a usar: `claude` ou `codex` | `claude` |
+| `CCDB_COMMAND` | Caminho ou nome do binário CLI (substitui `CLAUDE_COMMAND`) | _(auto)_ |
+| `CCDB_MODEL` | Modelo a usar (substitui `CLAUDE_MODEL`) | `sonnet` |
+| `CCDB_PERMISSION_MODE` | Modo de permissão CLI (substitui `CLAUDE_PERMISSION_MODE`) | `acceptEdits` |
+| `CCDB_DANGEROUSLY_SKIP_PERMISSIONS` | Pular todas as verificações de permissão | `false` |
+| `CCDB_WORKING_DIR` | Diretório de trabalho CLI | diretório atual |
+| `CCDB_ALLOWED_TOOLS` | Lista separada por vírgula de ferramentas permitidas | (opcional) |
+| `CCDB_CHANNEL_IDS` | IDs de canal adicionais para configuração multi-canal | (opcional) |
+| `CLAUDE_COMMAND` | Caminho do CLI Claude (nome legado — preferir `CCDB_COMMAND`) | `claude` |
+| `CLAUDE_MODEL` | Modelo (nome legado — preferir `CCDB_MODEL`) | `sonnet` |
+| `CLAUDE_PERMISSION_MODE` | Modo de permissão (nome legado — preferir `CCDB_PERMISSION_MODE`) | `acceptEdits` |
+| `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | Pular permissões (nome legado) | `false` |
+| `CLAUDE_WORKING_DIR` | Diretório de trabalho (nome legado) | diretório atual |
+| `MAX_CONCURRENT_SESSIONS` | Máximo de sessões CLI paralelas | `3` |
+| `SESSION_TIMEOUT_SECONDS` | Timeout de inatividade de sessão | `300` |
+| `DISCORD_OWNER_ID` | ID de usuário para @mencionar quando Claude precisar de entrada | (opcional) |
+| `COORDINATION_CHANNEL_ID` | ID de canal como fallback padrão para AI Lounge | (opcional) |
+| `MENTION_ONLY_CHANNEL_IDS` | IDs de canal onde o bot só responde quando @mencionado (separados por vírgula) | (opcional) |
+| `INLINE_REPLY_CHANNEL_IDS` | IDs de canal de resposta inline (separados por vírgula, sem criar thread) | (opcional) |
+| `CHAT_ONLY_CHANNEL_IDS` | IDs de canal em modo somente chat (separados por vírgula) | (opcional) |
+| `WORKTREE_BASE_DIR` | Diretório base para escanear worktrees de sessão | (opcional) |
+| `CLI_SESSIONS_PATH` | Caminho para descoberta de sessões CLI (`~/.claude/projects`) | (opcional) |
+| `CUSTOM_COGS_DIR` | Diretório contendo arquivos Cog personalizados | (opcional) |
+| `THREAD_INBOX_ENABLED` | Habilitar caixa de entrada de thread persistente | `false` |
+| `THREAD_AUTO_RENAME` | Auto-renomear novas threads com título gerado pelo Claude | `false` |
+| `CCDB_CLI_ENV_FILE` | Caminho para arquivo `KEY=VALUE` mesclado no ambiente do subprocesso CLI | (opcional) |
+| `API_HOST` | Endereço de bind da REST API | `127.0.0.1` |
+| `API_PORT` | Porta da REST API (habilita REST API quando configurada) | (opcional) |
 
 ---
 
@@ -511,100 +331,54 @@ uv add "claude-code-discord-bridge[api]"
 |--------|---------|-----------|
 | GET | `/api/health` | Verificação de saúde |
 | POST | `/api/notify` | Enviar notificação imediata |
-| POST | `/api/schedule` | Agendar uma notificação |
+| POST | `/api/schedule` | Agendar notificação |
 | GET | `/api/scheduled` | Listar notificações pendentes |
-| DELETE | `/api/scheduled/{id}` | Cancelar uma notificação |
-| POST | `/api/tasks` | Registrar uma tarefa agendada do Claude Code |
+| DELETE | `/api/scheduled/{id}` | Cancelar notificação |
+| POST | `/api/tasks` | Registrar tarefa periódica do Claude Code |
 | GET | `/api/tasks` | Listar tarefas registradas |
-| DELETE | `/api/tasks/{id}` | Remover uma tarefa |
-| PATCH | `/api/tasks/{id}` | Atualizar uma tarefa (ativar/desativar, mudar agendamento) |
+| DELETE | `/api/tasks/{id}` | Remover tarefa |
+| PATCH | `/api/tasks/{id}` | Atualizar tarefa |
 | POST | `/api/spawn` | Criar nova thread do Discord e iniciar sessão do Claude Code (não bloqueante) |
-| POST | `/api/mark-resume` | Marcar thread para retomada automática no próximo início do bot |
-
-```bash
-# Enviar notificação
-curl -X POST http://localhost:8080/api/notify \
-  -H "Authorization: Bearer your-secret" \
-  -H "Content-Type: application/json" \
-  -d '{"message": "Build com sucesso!", "title": "CI/CD"}'
-
-# Registrar tarefa recorrente
-curl -X POST http://localhost:8080/api/tasks \
-  -H "Authorization: Bearer your-secret" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "Resumo diário de standup", "interval_seconds": 86400}'
-```
+| POST | `/api/mark-resume` | Marcar thread para retomada automática na próxima inicialização do bot |
+| GET | `/api/lounge` | Ler mensagens recentes do AI Lounge |
+| POST | `/api/lounge` | Publicar mensagem no AI Lounge |
 
 ---
 
 ## Arquitetura
 
 ```
+claude_code_core/          # Biblioteca central compartilhada (independente de backend)
+  backend.py               # Protocolo SessionBackend + fábrica create_backend()
+  codex_runner.py          # Backend OpenAI Codex CLI
+  runner.py                # Gerenciador de subprocesso Claude CLI
+  parser.py                # Analisador de eventos stream-json
+  types.py                 # Definições de tipo para mensagens SDK
 claude_discord/
-  main.py                  # Ponto de entrada autônomo (setup_bridge + carregador de Cogs personalizados)
+  main.py                  # Ponto de entrada independente
   cli.py                   # Ponto de entrada CLI (comandos ccdb setup/start)
-  setup.py                 # setup_bridge() — conexão de Cogs com uma chamada
-  cog_loader.py            # Carregador dinâmico de Cogs personalizados (CUSTOM_COGS_DIR)
-  bot.py                   # Classe Discord Bot
-  protocols.py             # Protocolos compartilhados (DrainAware)
-  concurrency.py           # Instruções de worktree + registro de sessões ativas
-  lounge.py                # Construtor de prompts para AI Lounge
-  session_sync.py          # Descoberta e importação de sessões CLI
-  worktree.py              # WorktreeManager — ciclo de vida seguro de git worktree
+  setup.py                 # setup_bridge()
   cogs/
-    claude_chat.py         # Chat interativo (criação de threads, manipulação de mensagens)
-    skill_command.py       # Comando slash /skill com autocomplete
-    session_manage.py      # /sessions, /sync-sessions, /resume, /resume-info, /sync-settings
-    session_sync.py        # Lógica de criação de threads e publicação para sync-sessions
-    prompt_builder.py      # build_prompt_and_images() — função pura, sem estado Cog/Bot
-    scheduler.py           # Executor de tarefas periódicas do Claude Code
-    webhook_trigger.py     # Webhook → tarefa do Claude Code (CI/CD)
-    auto_upgrade.py        # Webhook → atualização de pacote + reinício com drenagem
-    event_processor.py     # EventProcessor — máquina de estados para eventos stream-json
-    run_config.py          # RunConfig dataclass — agrupa todos os parâmetros de execução CLI
-    _run_helper.py         # Camada de orquestração fina
-  claude/
-    runner.py              # Gerenciador de subprocessos Claude CLI
-    parser.py              # Parser de eventos stream-json
-    types.py               # Definições de tipos para mensagens SDK
-  database/
-    models.py              # Schema SQLite
-    repository.py          # CRUD de sessões
-    task_repo.py           # CRUD de tarefas agendadas
-    ask_repo.py            # CRUD de AskUserQuestion pendentes
-    notification_repo.py   # CRUD de notificações agendadas
-    lounge_repo.py         # CRUD de mensagens do AI Lounge
-    resume_repo.py         # CRUD de retomada ao iniciar
-    settings_repo.py       # Configurações por servidor
-  discord_ui/
-    status.py              # Gerenciador de reações emoji (com debounce)
-    chunker.py             # Divisão de mensagens com conhecimento de blocos e tabelas
-    embeds.py              # Construtores de embeds do Discord
-    views.py               # Botão de parada e componentes UI compartilhados
-    ask_bus.py             # Bus de eventos para comunicação AskUserQuestion
-    ask_view.py            # Botões/Menus de Seleção para AskUserQuestion
-    ask_handler.py         # collect_ask_answers() — UI + ciclo de vida DB de AskUserQuestion
-    streaming_manager.py   # StreamingMessageManager — edições de mensagem in-place com debounce
-    tool_timer.py          # LiveToolTimer — contador de tempo decorrido para ferramentas longas
-    thread_dashboard.py    # Embed fixado ao vivo mostrando estados de sessão
-    plan_view.py           # Botões Aprovar/Cancelar para Plan Mode (ExitPlanMode)
-    permission_view.py     # Botões Permitir/Negar para solicitações de permissão de ferramenta
-    elicitation_view.py    # Interface Discord para MCP Elicitation (formulário Modal ou botão URL)
-    file_sender.py         # Entrega de arquivos via .ccdb-attachments
+    claude_chat.py         # Chat interativo
+    skill_command.py       # Comando slash /skill
+    session_manage.py      # Gerenciamento de sessão
+    scheduler.py           # Executor de tarefas periódicas
+    webhook_trigger.py     # Webhook → execução de tarefa Claude Code
+    auto_upgrade.py        # Auto-upgrade + reinício com drenagem
   ext/
-    api_server.py          # REST API (opcional, requer aiohttp)
-  utils/
-    logger.py              # Configuração de logging
+    api_server.py          # REST API (opcional)
+examples/
+  ebibot/                  # Exemplo do mundo real
 ```
 
 ### Filosofia de Design
 
-- **Invocação CLI, não API** — Invoca `claude -p --output-format stream-json`, dando recursos completos do Claude Code (CLAUDE.md, skills, ferramentas, memória) sem reimplementá-los
-- **Concorrência primeiro** — Múltiplas sessões simultâneas são o caso esperado, não um edge case; cada sessão recebe instruções de worktree, o registro e o AI Lounge cuidam do resto
-- **Discord como cola** — Discord fornece UI, threads, reações, webhooks e notificações persistentes; sem frontend personalizado necessário
-- **Framework, não aplicação** — Instale como pacote, adicione Cogs ao seu bot existente, configure via código
-- **Extensibilidade sem código** — Adicione tarefas agendadas e disparadores webhook sem tocar no código fonte
-- **Segurança pela simplicidade** — ~3000 linhas de Python auditáveis; apenas subprocess exec, sem expansão de shell
+- **CLI spawn, não API** — Invoca `claude -p --output-format stream-json`, obtendo todos os recursos do Claude Code sem reimplementá-los. Sem API key, sem cobrança por token.
+- **Concorrência primeiro** — Múltiplas sessões simultâneas são o caso esperado, não um caso especial
+- **Discord como cola** — Discord fornece UI, threading, reações, webhooks e notificações persistentes
+- **Framework, não aplicação** — Instale como pacote, adicione Cogs ao seu bot existente
+- **Extensibilidade sem código** — Adicione tarefas agendadas e gatilhos de webhook sem tocar no código-fonte
+- **Segurança por simplicidade** — ~8000 linhas de Python auditável; apenas subprocess exec, sem expansão de shell
 
 ---
 
@@ -614,37 +388,38 @@ claude_discord/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-1050+ testes cobrindo parser, chunker, repositório, runner, streaming, disparadores webhook, auto-atualização (incluindo o comando `/upgrade`, invocação de thread e botão de aprovação), REST API, UI do AskUserQuestion, painel de threads, tarefas agendadas, sincronização de sessões, AI Lounge, retomada na inicialização, troca de modelo, detecção de compactação, embeds de progresso do TodoWrite, e análise de eventos de permissão/elicitation/plan-mode.
+Mais de 1365 testes cobrindo analisador, chunker, repositório, runner, streaming, gatilhos de webhook, auto-upgrade, REST API, AskUserQuestion UI, dashboard de thread, tarefas agendadas, sincronização de sessão, AI Lounge, retomada na inicialização, troca de modelo, detecção de compactação, embeds de progresso TodoWrite, carregador de Cogs personalizados, protocolo SessionBackend, CodexRunner e fábrica de backends.
 
 ---
 
 ## Como Este Projeto Foi Construído
 
-**Todo este código base foi escrito pelo [Claude Code](https://docs.anthropic.com/en/docs/claude-code)**, o agente de codificação com IA da Anthropic. O autor humano ([@ebibibi](https://github.com/ebibibi)) forneceu requisitos e direção em linguagem natural, mas não leu nem editou manualmente o código fonte.
+**Este codebase é desenvolvido pelo [Claude Code](https://docs.anthropic.com/en/docs/claude-code)**, o agente de codificação AI da Anthropic, sob a direção de [@ebibibi](https://github.com/ebibibi). O autor humano define requisitos, revisa pull requests e aprova todas as mudanças — Claude Code faz a implementação.
 
-Isso significa:
-
-- **Todo o código foi gerado por IA** — arquitetura, implementação, testes, documentação
-- **O autor humano não pode garantir correção no nível do código** — revise o fonte se precisar de certeza
-- **Relatórios de bugs e PRs são bem-vindos** — Claude Code será usado para resolvê-los
-- **Este é um exemplo real de software open source escrito por IA**
-
-O projeto começou em 2026-02-18 e continua evoluindo através de conversas iterativas com Claude Code.
+O projeto começou em 2026-02-18 e continua evoluindo através de conversas iterativas com o Claude Code.
 
 ---
 
-## Exemplo Real
+## Exemplo do Mundo Real
 
-**[EbiBot](https://github.com/ebibibi/discord-bot)** — Um bot pessoal do Discord construído sobre este framework. Inclui sincronização automática de documentação (inglês + japonês), notificações push, watchdog do Todoist, verificações de saúde agendadas e CI/CD com GitHub Actions. Use-o como referência para construir seu próprio bot.
+**[`examples/ebibot/`](examples/ebibot/)** — Um bot pessoal do Discord construído sobre este framework, incluído diretamente neste repositório. Demonstra o carregador de Cog personalizado com:
+
+- **ReminderCog** — Comando slash `/remind HH:MM "message"` + loop de envio de 30 segundos
+- **WatchdogCog** — Monitor de tarefas vencidas do Todoist
+- **AutoUpgradeCog** — Auto-atualização via webhook do GitHub + systemctl restart
+- **DocsSyncCog** — Sincronização automática de documentação no push
+- **AlertResponderCog** — Cog genérico de monitoramento de alertas
+
+Execute com: `ccdb start --cogs-dir examples/ebibot/cogs/`
 
 ---
 
-## Inspirado em
+## Inspirado Por
 
-- [OpenClaw](https://github.com/openclaw/openclaw) — Reações emoji de status, debounce de mensagens, divisão com conhecimento de blocos
-- [claude-code-discord-bot](https://github.com/timoconnellaus/claude-code-discord-bot) — Abordagem de invocação CLI + stream-json
-- [claude-code-discord](https://github.com/zebbern/claude-code-discord) — Padrões de controle de permissões
-- [claude-sandbox-bot](https://github.com/RhysSullivan/claude-sandbox-bot) — Modelo de thread por conversa
+- [OpenClaw](https://github.com/openclaw/openclaw) — Reações de status emoji, debouncing de mensagens, chunking ciente de fence
+- [claude-code-discord-bot](https://github.com/timoconnellaus/claude-code-discord-bot) — Abordagem CLI spawn + stream-json
+- [claude-code-discord](https://github.com/zebbern/claude-code-discord) — Padrões de controle de permissão
+- [claude-sandbox-bot](https://github.com/RhysSullivan/claude-sandbox-bot) — Modelo de conversa por thread
 
 ---
 

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -3,68 +3,73 @@
 > **注意：** 这是原始英文文档的自动翻译版本。
 > 如有任何差异，以[英文版](../../README.md)为准。
 
-# claude-code-discord-bridge
+# Claude & Codex Discord Bridge
+
+*包名：`claude-code-discord-bridge`（短横线命名）*
 
 [![CI](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml/badge.svg)](https://github.com/ebibibi/claude-code-discord-bridge/actions/workflows/codeql.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**通过 Discord 安全地并行运行多个 Claude Code 会话。**
+**在手机上使用 Claude Code _或_ OpenAI Codex。多线程并行。全速开发。**
 
-每个 Discord 线程都成为一个隔离的 Claude Code 会话。按需启动任意数量的会话：在一个线程中开发功能，在另一个线程中审查 PR，在第三个线程中运行计划任务。桥接器自动处理协调，确保并发会话不会相互干扰。
+通过智能手机的 Discord 应用打开 Claude Code 或 OpenAI Codex，启动多个线程，并行运行开发会话——无需触碰键盘。每个 Discord 线程都成为完全隔离的 AI 会话。在一个线程中开发功能，在另一个线程中审查 PR，在第三个线程中运行后台任务——同时进行，甚至可以每个线程使用不同的后端。桥接器处理所有协调，让会话永不冲突。
+
+**使用现有订阅，无需配置 API 密钥。** ccdb 基于官方 CLI 运行——Claude Code（包含在 [Claude Pro/Max 订阅](https://claude.ai/pricing)中）和 OpenAI Codex（包含在 [ChatGPT Plus/Pro/Business](https://chatgpt.com)中）。通过 `/backend` 切换后端或按线程设置——以可预测的费用通过 Discord 使用两种 AI。
 
 **[English](../../README.md)** | **[日本語](../ja/README.md)** | **[한국어](../ko/README.md)** | **[Español](../es/README.md)** | **[Português](../pt-BR/README.md)** | **[Français](../fr/README.md)**
 
-> **免责声明：** 本项目与 Anthropic 无关，未获得 Anthropic 的认可或官方关联。"Claude"和"Claude Code"是 Anthropic, PBC 的商标。这是一个与 Claude Code CLI 交互的独立开源工具。
+> **免责声明：** 本项目与 Anthropic 或 OpenAI 没有任何关联、认可或官方关系。"Claude"和"Claude Code"是 Anthropic, PBC 的商标；"OpenAI"、"Codex"和"ChatGPT"是 OpenAI 的商标。这是一个与 Claude Code CLI 和 OpenAI Codex CLI 交互的独立开源工具。
 
-> **完全由 Claude Code 构建。** 本项目的完整代码库——架构、实现、测试、文档——均由 Claude Code 自行编写。人类作者提供了需求和方向，但未手动阅读或编辑源代码。详见[本项目的构建方式](#本项目的构建方式)。
+> **完全由 Claude Code 构建。** 整个代码库——架构、实现、测试、文档——均由 Claude Code 本身编写。人类作者提供需求和方向。详见[本项目的构建方式](#本项目的构建方式)。
 
 ---
 
-## 核心理念：无忧并行会话
+## 核心理念：无冲突并行会话
 
-当你在不同 Discord 线程中向 Claude Code 发送任务时，桥接器会自动完成四件事：
+当您在多个 Discord 线程中向 Claude Code 发送任务时，桥接器会自动完成四件事：
 
-1. **并发通知注入** — 每个会话的系统提示中都包含强制指令：创建 git worktree，仅在其中工作，绝不直接修改主工作目录。
+1. **并发指令注入** — 每个会话的系统提示都包含强制指令：创建 git worktree，只在其中工作，不直接修改主工作目录。
 
-2. **活跃会话注册表** — 每个运行中的会话都能了解其他会话的情况。如果两个会话即将操作同一个仓库，它们可以协调而非冲突。
+2. **活跃会话注册表** — 每个运行中的会话都知道其他会话的存在。如果两个会话将要操作同一个仓库，它们可以协调而非冲突。
 
-3. **AI Lounge** — 注入每个会话提示的「控え室」频道。开始工作前，每个会话会读取最近的 Lounge 消息来了解其他会话的动态。进行破坏性操作（force push、bot 重启、DB 操作等）前，会话会先确认 Lounge 内容，避免踩踏彼此的工作。
+3. **AI 休息室（AI Lounge）** — 注入每个会话提示的"休息室"频道。开始前，每个会话读取最近的休息室消息以了解其他会话的动态。在进行破坏性操作（强制推送、重启 Bot、删除数据库）前，会话会先检查休息室。
 
 ```
-线程 A (功能开发)  ──→  Claude Code (worktree-A)  ─┐
-线程 B (PR 审查)   ──→  Claude Code (worktree-B)   ├─→  #ai-lounge
-线程 C (文档)      ──→  Claude Code (worktree-C)  ─┘    "A: auth 重构进行中"
+线程 A（功能开发）  ──→  Claude Code (worktree-A)  ─┐
+线程 B（PR 审查）   ──→  Claude Code (worktree-B)   ├─→  #ai-lounge
+线程 C（文档）      ──→  Claude Code (worktree-C)  ─┘    "A: auth 重构进行中"
                                                          "B: PR #42 审查完成"
-                                                         "C: README 更新中"
+                                                         "C: 更新 README"
 ```
 
 无竞争条件。无工作丢失。无合并意外。
 
 ---
 
-## 功能概览
+## 能做什么
 
 ### 交互式聊天（移动端 / 桌面端）
 
-在任何运行 Discord 的设备上使用 Claude Code——手机、平板或桌面端。每条消息都会创建或继续一个线程，与持久化的 Claude Code 会话 1:1 映射。
+在任何 Discord 运行的地方使用 Claude Code——手机、平板或桌面。每条消息创建或继续一个线程，与持久化的 Claude Code 会话一一对应。
 
 ### 并行开发
 
-同时打开多个线程。每个都是独立的 Claude Code 会话，有自己的上下文、工作目录和 git worktree。实用模式：
+同时打开多个线程。每个线程都是独立的 Claude Code 会话，拥有自己的上下文、工作目录和 git worktree。常见用法：
 
-- **功能 + 审查并行**：在一个线程开发功能的同时，让 Claude 在另一个线程审查 PR。
-- **多人协作**：不同团队成员各有自己的线程；会话通过 AI Lounge 相互感知。
-- **安全实验**：在线程 A 尝试某种方案，同时线程 B 保持在稳定代码上。
+- **功能开发 + 同步审查**：在一个线程开发功能，同时 Claude 在另一个线程审查 PR。
+- **多人协作**：不同团队成员各有自己的线程；会话通过 AI Lounge 互相了解动态。
+- **安全实验**：在线程 A 尝试某种方案，同时线程 B 保持稳定代码。
 
-### 计划任务（SchedulerCog）
+### 定时任务（SchedulerCog）
 
-通过 Discord 对话或 REST API 注册定期 Claude Code 任务——无需修改代码，无需重新部署。任务存储在 SQLite 中，按可配置的计划运行。Claude 可在会话中通过 `POST /api/tasks` 自行注册任务。
+无需修改代码、无需重新部署，通过 Discord 对话或 REST API 注册定期 Claude Code 任务。任务存储在 SQLite 中，按可配置的计划运行。Claude 可在会话中通过 `POST /api/tasks` 自我注册任务。
 
 ```
-/skill name:goodmorning         → 立即运行
+/skill name:goodmorning         → 立即执行
 Claude 调用 POST /api/tasks    → 注册定期任务
-SchedulerCog（30 秒主循环）   → 自动触发到期任务
+SchedulerCog（30 秒主循环）     → 自动触发到期任务
 ```
 
 ### CI/CD 自动化
@@ -77,223 +82,236 @@ GitHub Actions → Discord Webhook → Bridge → Claude Code CLI
 GitHub PR ←── git push ←── Claude Code ──────────┘
 ```
 
-**实际案例：** 每次推送到 `main`，Claude 自动分析差异，更新英文和日文文档，创建双语摘要的 PR，并启用自动合并。全程无需人工干预。
+**实际案例：** 每次推送到 `main`，Claude 分析差异，更新英文 + 日文文档，创建双语 PR，并启用自动合并。零人工干预。
 
 ### 会话同步
 
-已在直接使用 Claude Code CLI？通过 `/sync-sessions` 将现有终端会话同步到 Discord 线程。回填近期对话消息，让你无需丢失上下文即可从手机继续 CLI 会话。
+已在直接使用 Claude Code CLI？通过 `/sync-sessions` 将现有终端会话同步到 Discord 线程。回填最近的对话消息，让您无需丢失上下文即可从手机继续 CLI 会话。
 
-### AI Lounge
+### AI 休息室（AI Lounge）
 
-所有并行会话共享的「控え室」频道——会话在此互相告知动态、读取彼此的更新，并在进行破坏性操作前先行确认。
-
-每个 Claude 会话都会在系统提示中自动收到 Lounge 上下文：来自其他会话的最近消息，以及进行破坏性操作前必须确认的规则。
+所有并发会话互相通报、协调的共享"休息室"频道。每个 Claude 会话通过 `--append-system-prompt` 自动接收休息室上下文——作为临时系统上下文而非对话历史注入，防止跨回合累积（避免长时间会话出现"Prompt is too long"错误）。
 
 ```bash
 # 会话在开始前发布意图：
 curl -X POST "$CCDB_API_URL/api/lounge" \
   -H "Content-Type: application/json" \
-  -d '{"message": "feature/oauth 上开始 auth 重构 — worktree-A", "label": "功能开发"}'
+  -d '{"message": "在 feature/oauth 上开始 auth 重构 — worktree-A", "label": "功能开发"}'
 
-# 读取最近的 Lounge 消息（也会自动注入每个会话）：
+# 读取最近的休息室消息（也自动注入每个会话）：
 curl "$CCDB_API_URL/api/lounge"
 ```
 
-Lounge 频道同时也是人类可见的活动动态——在 Discord 中打开它，即可一眼看清所有活跃 Claude 会话当前在做什么。
-
 ### 程序化会话创建
 
-从脚本、GitHub Actions 或其他 Claude 会话中创建新的 Claude Code 会话——无需 Discord 消息交互。
+从脚本、GitHub Actions 或其他 Claude 会话创建新的 Claude Code 会话，无需 Discord 消息交互。
 
 ```bash
 # 从另一个 Claude 会话或 CI 脚本：
 curl -X POST "$CCDB_API_URL/api/spawn" \
   -H "Content-Type: application/json" \
-  -d '{"prompt": "对仓库进行安全扫描", "thread_name": "安全扫描"}'
-# 立即返回线程 ID；Claude 在后台运行
+  -d '{"prompt": "对仓库运行安全扫描", "thread_name": "Security Scan"}'
+# 线程创建后立即返回；Claude 在后台运行
 ```
 
-Claude 子进程将 `DISCORD_THREAD_ID` 作为环境变量接收，因此运行中的会话可以创建子会话来并行化工作。
+**延迟启动 (`auto_start=false`)** — 创建线程并发布种子消息，但不立即启动 Claude。只有当用户回复时 Claude 才启动，并自动接收种子消息作为上下文。
 
 ### 启动恢复
 
-如果 bot 在会话中途重启，被中断的 Claude 会话会在 bot 重新上线时自动恢复。会话通过三种方式标记为待恢复：
-
-- **自动（升级重启）** — `AutoUpgradeCog` 在包升级重启前快照所有活跃会话并自动标记。
-- **自动（任意关闭）** — `ClaudeChatCog.cog_unload()` 在 bot 通过任何机制关闭时（`systemctl stop`、`bot.close()`、SIGTERM 等）标记所有运行中的会话。
-- **手动** — 任何会话都可以直接调用 `POST /api/mark-resume`。
+如果 Bot 在会话进行中重启，被中断的 Claude 会话在 Bot 重新上线时会自动恢复。
 
 ---
 
-## 功能详情
+## 功能列表
 
 ### 交互式聊天
 
-#### 🔗 基础会话
-- **Thread = Session** — Discord 线程与 Claude Code 会话 1:1 映射
+#### 🔗 会话基础
+- **纯聊天模式** — `CHAT_ONLY_CHANNEL_IDS` 只显示 Claude 的文本回复；工具 embed、思维块、会话 embed 和待办列表隐藏。适合公开频道。
+- **线程 = 会话** — Discord 线程与 Claude Code 会话 1:1 映射
+- **目标跟踪** — `/goal <条件>` 设置完成条件；Claude 持续工作直到满足条件
 - **会话持久化** — 通过 `--resume` 跨消息继续对话
-- **并发会话** — 多个并行会话，可配置上限
-- **不清除内容停止** — `/stop` 停止会话同时保留以便恢复
-- **会话中断** — 向活跃线程发送新消息会向正在运行的会话发送 SIGINT 并以新指令重新开始；无需手动 `/stop`
-- **线程自动重命名** — 启用 `THREAD_AUTO_RENAME=true` 后，每个新线程将根据首条消息由 Claude 生成的简短标题自动重命名（后台任务，不影响会话启动速度）
+- **并发会话** — 可配置限制的多并行会话
+- **停止但不清除** — `/stop` 暂停会话同时保留以供恢复
+- **会话中断** — 向活跃线程发送新消息时自动发送 SIGINT 并以新指令重新开始
+- **自动重命名线程** — `THREAD_AUTO_RENAME=true` 时自动生成描述性标题
 
 #### 📡 实时反馈
-- **实时状态** — 表情反应：🧠 思考中，🛠️ 读取文件，💻 编辑中，🌐 网页搜索
-- **流式文本** — Claude 工作时中间助手文本实时显示
-- **工具结果显示** — 实时工具调用结果，含每 10 秒更新的耗时计数器；单行输出直接内联显示，多行输出折叠在展开按钮后
-- **扩展思考** — 推理以剧透标签 embed 显示（点击展开）
-- **线程面板** — 实时置顶 embed，显示各线程活跃/等待状态；需要输入时 @提及所有者
+- **实时状态** — 表情反应：🧠 思考中，🛠️ 读取文件，💻 编辑中，🌐 网络搜索
+- **流式文本** — Claude 工作时中间文本实时显示
+- **工具结果 embed** — 实时工具调用结果，含已用时间计时器
+- **扩展思维** — 推理以剧透标签 embed 显示（点击展开）
+- **线程仪表板** — 实时固定 embed 显示活跃/等待线程状态
 
 #### 🤝 人机协作
-- **交互式问题** — `AskUserQuestion` 渲染为 Discord 按钮或下拉菜单；选择后会话继续；按钮在 bot 重启后仍可用
-- **Plan Mode** — Claude 调用 `ExitPlanMode` 时，Discord embed 显示完整计划并附带批准/取消按钮；仅在批准后 Claude 才继续执行；5 分钟超时自动取消
-- **工具权限请求** — Claude 需要执行工具权限时，Discord 显示带工具名称和输入的允许/拒绝按钮；2 分钟后自动拒绝
-- **MCP Elicitation** — MCP 服务器可通过 Discord 请求用户输入（表单模式：JSON schema 最多 5 个 Modal 字段；URL 模式：URL 按钮 + 完成确认）；5 分钟超时
-- **TodoWrite 实时进度** — Claude 调用 `TodoWrite` 时，发布单个 Discord embed 并在每次更新时就地编辑；显示 ✅ 已完成、🔄 进行中（带 `activeForm` 标签）、⬜ 待处理
+- **交互式问题** — `AskUserQuestion` 渲染为 Discord 按钮或下拉菜单
+- **计划模式** — `ExitPlanMode` 触发带批准/取消按钮的 Discord embed；5 分钟超时
+- **工具权限请求** — 允许/拒绝按钮；2 分钟无响应自动拒绝
+- **MCP Elicitation** — MCP 服务器通过 Discord 请求用户输入；5 分钟超时
+- **TodoWrite 实时进度** — 单个 Discord embed 原地更新；显示 ✅ 已完成、🔄 进行中、⬜ 待处理
 
 #### 📊 可观测性
-- **Token 使用量** — 会话完成 embed 显示缓存命中率和 token 计数
-- **上下文使用量** — 会话完成 embed 中显示上下文窗口百分比（输入 + 缓存 token，不含输出）及自动压缩前剩余容量；超过 83.5% 时显示 ⚠️ 警告
-- **压缩检测** — 发生上下文压缩时在线程中通知（触发类型 + 压缩前 token 数）
-- **长期停滞通知** — 无活动时发送线程消息（扩展思考或上下文压缩）；Claude 恢复时自动重置。阈值根据模型自动调整：标准模型 30 秒，Opus 120 秒（思考停顿更长）
-- **超时通知** — 超时时显示含耗时和恢复指引的 embed
-- **线程收件箱** — 启用 `THREAD_INBOX_ENABLED=true` 后，面板显示持久的 📬 收件箱区域；每次会话结束时，Claude 通过轻量级 `claude -p` 调用将最后一条消息分类为 `waiting`/`done`/`ambiguous`；等待回复的线程在 bot 重启后仍保留，直到你回复为止
+- **Token 用量** — 会话完成 embed 中显示缓存命中率和 token 数量
+- **上下文用量** — 显示上下文窗口百分比；超过 83.5% 时 ⚠️ 警告
+- **压缩检测** — 上下文压缩时在线程内通知
+- **长时间停滞通知** — 无活动超过阈值时发送通知（标准模型 30s，Opus 120s）
+- **超时通知** — 显示已用时间和恢复指南
+- **StatusLine 显示** — 每次会话后显示 Claude 配置的状态行
+- **线程收件箱** — `THREAD_INBOX_ENABLED=true` 时显示 📬 收件箱
 
 #### 🔌 输入与技能
-- **附件支持** — 文本文件自动追加到提示（最多 5 个 × 50 KB）；图片通过 `--image` 标志下载传递（最多 4 × 5 MB）
-- **技能执行** — `/skill` 斜杠命令，含自动补全、可选参数、线程内恢复
-- **热重载** — `~/.claude/skills/` 中新增的技能自动加载（60 秒刷新，无需重启）
+- **附件支持** — 文本文件自动追加（最多 5 个文件，每个 200 KB）；图片通过 CDN URL 发送（最多 4 × 5 MB）
+- **按需文件发送** — Claude 写入 `.ccdb-attachments` 路径，会话完成时自动发送
+- **技能执行** — `/skill` 命令，带自动补全；已安装插件的技能自动发现
+- **热重载** — `~/.claude/skills/` 中的新技能自动检测（60 秒刷新）
 
 ### 并发与协调
-- **Worktree 指令自动注入** — 每个会话在操作任何文件前都会收到使用 `git worktree` 的提示
-- **自动 worktree 清理** — 会话 worktree（`wt-{thread_id}`）在会话结束时和 bot 启动时自动清理；有未提交更改的 worktree 永远不会被自动删除（安全不变量）
-- **活跃会话注册表** — 内存注册表；每个会话都能看到其他会话的状态
-- **AI Lounge** — 注入每个会话提示的共享「控え室」频道；会话发布意图、互相确认状态，并在破坏性操作前先行检查；对人类来说是实时活动动态
-- **协调频道** — `COORDINATION_CHANNEL_ID` 环境变量用作 AI Lounge 频道的默认回退（Bot 侧生命周期自动通知已移除）
+- **Worktree 指令自动注入** — 每个会话被提示使用 `git worktree`
+- **自动 worktree 清理** — 会话结束和 Bot 启动时自动清理；脏 worktree 永不自动删除
+- **活跃会话注册表** — 内存注册表；每个会话看到其他会话的动态
+- **AI Lounge** — 共享"休息室"；上下文通过 `--append-system-prompt` 注入（不在历史中累积）
+- **协调频道** — `COORDINATION_CHANNEL_ID` 用作 AI Lounge 的默认回退
 
-### 计划任务
-- **SchedulerCog** — SQLite 支持的定期任务执行器，含 30 秒主循环
-- **自注册** — Claude 在聊天会话中通过 `POST /api/tasks` 注册任务
-- **无需代码变更** — 运行时添加、删除或修改任务
-- **启用/禁用** — 不删除任务即可暂停（`PATCH /api/tasks/{id}`）
+### 定时任务
+- **SchedulerCog** — SQLite 支持，30 秒主循环
+- **自我注册** — Claude 通过 `POST /api/tasks` 注册任务
+- **无需修改代码** — 运行时添加、删除或修改任务
+- **启用/禁用** — `PATCH /api/tasks/{id}` 暂停任务
 
 ### CI/CD 自动化
-- **Webhook 触发** — 从 GitHub Actions 或任何 CI/CD 系统触发 Claude Code 任务
-- **自动升级** — 上游包发布时自动更新 bot
-- **感知排空重启** — 在重启前等待活跃会话完成
-- **自动恢复标记** — 活跃会话在任何关闭时自动标记为待恢复（升级重启通过 `AutoUpgradeCog`，其他关闭通过 `ClaudeChatCog.cog_unload()`）；bot 重新上线后从中断处继续
-- **重启确认** — 可选的升级确认门控
+- **Webhook 触发** — 从 GitHub Actions 或任何 CI/CD 系统触发任务
+- **自动升级** — 上游包发布时自动更新 Bot
+- **DrainAware 重启** — 重启前等待活跃会话完成
+- **自动恢复标记** — 任何关闭时活跃会话自动标记恢复
+- **手动升级触发** — `/upgrade` 斜杠命令（可选启用）
 
 ### 会话管理
-- **会话同步** — 将 CLI 会话导入为 Discord 线程（`/sync-sessions`）；`/sync-settings` 可查看或更改同步偏好（线程样式、时间窗口、最小结果数）
-- **会话列表** — `/sessions`，可按来源（Discord / CLI / 全部）和时间窗口筛选
-- **会话恢复** — `/resume` 显示最近会话（最多 25 个）的选择菜单，在新线程中恢复所选会话；可选 `query` 参数进行关键字搜索（匹配摘要和工作目录），`filter=orphaned` 仅显示已删除线程的会话；可从任何频道或线程执行 — 始终在配置的主频道中创建新线程
-- **恢复信息** — `/resume-info` 显示在终端继续当前会话的 CLI 命令（仅限线程内）
-- **清除会话** — `/clear` 重置当前线程的 Claude Code 会话，无需创建新线程即可从头开始
-- **启动恢复** — 中断的会话在任意 bot 重启后自动恢复；`AutoUpgradeCog`（升级重启）和 `ClaudeChatCog.cog_unload()`（其他关闭）自动标记，或通过 `POST /api/mark-resume` 手动标记
-- **程序化创建** — `POST /api/spawn` 从任意脚本或 Claude 子进程创建新 Discord 线程 + Claude 会话；创建线程后立即返回非阻塞 201
-- **线程 ID 注入** — `DISCORD_THREAD_ID` 环境变量传递给每个 Claude 子进程，使会话可通过 `$CCDB_API_URL/api/spawn` 创建子会话
-- **Worktree 管理** — `/worktree-list` 显示所有活跃会话 worktree 的干净/脏状态；`/worktree-cleanup` 清理孤立的干净 worktree（支持 `dry_run` 预览）
-- **会话回退** — `/rewind` 重置会话历史，同时保留 Claude 创建的工作文件；确认消息显示回退时的上下文使用率，帮助你了解为何需要回退
-- **会话分叉** — `/fork` 使用 `--fork-session` 从当前会话状态创建新线程，让你在不影响原线程的情况下探索不同方向
-- **上下文可视化** — `/context` 通过可视化进度条显示当前上下文窗口使用率；接近 83.5% 阈值时显示 ⚠️ 自动压缩警告
-- **速率限制监控** — `/usage` 显示 Claude API 速率限制使用率，包含百分比进度条和每种限制类型的重置倒计时
-- **内置帮助** — `/help` 显示所有可用斜杠命令和基本用法（仅对调用者可见的临时消息）
-- **运行时切换模型** — `/model-show` 显示当前全局模型和每个线程的会话模型；`/model-set` 无需重启即可更改所有新会话的模型
-- **运行时工具权限** — `/tools-show` 显示当前允许的工具；`/tools-set` 打开选择菜单切换工具开/关；`/tools-reset` 恢复到 `.env` 默认值 — 均无需重启
+- **内置帮助** — `/help` 显示所有斜杠命令（临时消息）
+- **会话同步** — `/sync-sessions` 将 CLI 会话导入为 Discord 线程
+- **会话列表** — `/sessions`，按来源和时间窗口过滤
+- **会话恢复** — `/resume` 在新线程中恢复选定会话
+- **会话清除** — `/clear` 重置当前线程的会话
+- **程序化生成** — `POST /api/spawn` 从脚本创建线程 + 会话
+- **Worktree 管理** — `/worktree-list` 和 `/worktree-cleanup`
+- **运行时模型切换** — `/model-show` 和 `/model-set`，无需重启
+- **对话回退** — `/rewind` 截断到选定回合
+- **对话分叉** — `/fork` 创建独立会话副本
 
 ### 安全性
-- **无 Shell 注入** — 仅使用 `asyncio.create_subprocess_exec`，从不使用 `shell=True`
-- **会话 ID 验证** — 传递给 `--resume` 前使用严格正则验证
-- **标志注入防护** — 所有提示前使用 `--` 分隔符
+- **无 shell 注入** — 仅使用 `asyncio.create_subprocess_exec`
+- **会话 ID 验证** — 严格正则验证
+- **标志注入防护** — `--` 分隔符
 - **密钥隔离** — Bot token 从子进程环境中移除
-- **用户授权** — `allowed_user_ids` 限制可调用 Claude 的用户
-- **日志注入防护** — 用户提供的 API 值在写入日志前会经过清理（去除换行符和 ANSI 转义序列）
+- **用户授权** — `allowed_user_ids` 限制访问
+- **日志注入防护** — 用户输入在写入日志前净化
 
 ---
 
-## 快速开始
+## 快速开始 — 5 分钟在 Discord 中运行 Claude
 
-### 前置条件
+**前提条件：** Python 3.10+，已安装并认证的 [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code)。
 
-- Python 3.10+
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) 已安装并认证
-- 启用了 Message Content intent 的 Discord Bot token
-- [uv](https://docs.astral.sh/uv/)（推荐）或 pip
+**平台支持：** 主要在 **Linux** 上开发和测试。macOS 和 Windows 受支持且通过 CI，但实际测试较少。
 
-### 独立运行
+### 第一步 — 创建 Discord Bot（一次性，约 2 分钟）
+
+1. 前往 [discord.com/developers/applications](https://discord.com/developers/applications) → **New Application**
+2. 导航到 **Bot** → 在 Privileged Gateway Intents 下启用 **Message Content Intent**
+3. 复制 Bot **Token**
+4. 前往 **OAuth2 → URL Generator**：作用域 `bot` + `applications.commands`，权限：Send Messages, Create Public Threads, Send Messages in Threads, Add Reactions, Manage Messages, Read Message History
+5. 打开生成的 URL → 将 Bot 邀请到您的服务器
+
+### 第二步 — 运行设置向导
+
+无需克隆或编辑 `.env`——向导为您完成一切：
 
 ```bash
+# 使用 uvx（无需安装）：
+uvx --from "git+https://github.com/ebibibi/claude-code-discord-bridge.git" ccdb setup
+
+# 或克隆后：
 git clone https://github.com/ebibibi/claude-code-discord-bridge.git
 cd claude-code-discord-bridge
-
-cp .env.example .env
-# 使用你的 Bot token 和频道 ID 编辑 .env
-
-uv run python -m claude_discord.main
+uv run ccdb setup
 ```
+
+### 启动 / 停止
+
+```bash
+ccdb start    # 启动 Bot（读取当前目录的 .env）
+ccdb start --env /path/to/.env   # 自定义 .env 位置
+```
+
+在配置的频道发送消息——Claude 将在新线程中回复。
 
 ### 作为 systemd 服务运行（生产环境）
 
-在生产环境中，建议通过 systemd 管理，以实现开机自启和故障自动重启。
-
-仓库提供了模板文件 `discord-bot.service` 和 `scripts/pre-start.sh`，复制后修改路径和用户名即可：
-
 ```bash
-# 1. 编辑服务文件 — 将 /home/ebi 和 User=ebi 替换为你的路径/用户
 sudo cp discord-bot.service /etc/systemd/system/mybot.service
 sudo nano /etc/systemd/system/mybot.service
-
-# 2. 启用并启动
 sudo systemctl daemon-reload
 sudo systemctl enable mybot.service
 sudo systemctl start mybot.service
-
-# 3. 查看状态
-sudo systemctl status mybot.service
 journalctl -u mybot.service -f
 ```
 
-**`scripts/pre-start.sh` 的功能**（在机器人进程启动前作为 `ExecStartPre` 运行）：
+### 自定义 Cog（无需 fork 即可扩展）
 
-1. **`git pull --ff-only`** — 从 `origin main` 拉取最新代码
-2. **`uv sync`** — 根据 `uv.lock` 同步依赖
-3. **导入验证** — 验证 `claude_discord.main` 可以正常导入
-4. **自动回滚** — 导入失败时回退到上一个提交并重试；通过 Discord webhook 发送通知
-5. **Worktree 清理** — 删除崩溃会话遗留的 git worktree
+将 Python 文件放入目录即可添加自定义功能：
 
-脚本通过 `readlink -f $0` 动态检测仓库根目录，无论用户在哪里克隆仓库都无需修改脚本中的路径。`uv` 二进制文件也从 `PATH` 自动检测；如需使用自定义路径，可通过 `CCDB_UV_BIN` 环境变量指定。
+```bash
+ccdb start --cogs-dir ./my-cogs/
+# 或：CUSTOM_COGS_DIR=./my-cogs ccdb start
+```
 
-在 `.env` 中设置 `DISCORD_WEBHOOK_URL` 可接收故障通知（可选）。
+每个 `.py` 文件必须暴露 `async def setup(bot, runner, components)`。
 
-### 作为包安装
+详见 [`examples/ebibot/`](examples/ebibot/)，包含提醒、Todoist 看门狗、自动升级和文档同步的完整实例。
 
-如果你已有运行中的 discord.py Bot（Discord 每个 token 只允许一个 Gateway 连接）：
+---
+
+### 最小化 Bot（作为包安装）
 
 ```bash
 uv add git+https://github.com/ebibibi/claude-code-discord-bridge.git
 ```
 
+创建 `bot.py`：
+
 ```python
+import asyncio
+import os
+from dotenv import load_dotenv
+import discord
 from discord.ext import commands
 from claude_discord import ClaudeRunner, setup_bridge
 
-bot = commands.Bot(...)
-runner = ClaudeRunner(command="claude", model="sonnet")
+load_dotenv()
+
+intents = discord.Intents.default()
+intents.message_content = True
+
+bot = commands.Bot(command_prefix="!", intents=intents)
+runner = ClaudeRunner(
+    command="claude",
+    model="sonnet",
+    working_dir="/path/to/your/project",
+)
 
 @bot.event
 async def on_ready():
+    print(f"Logged in as {bot.user}")
     await setup_bridge(
         bot,
         runner,
-        claude_channel_id=YOUR_CHANNEL_ID,
-        allowed_user_ids={YOUR_USER_ID},
+        claude_channel_id=int(os.environ["DISCORD_CHANNEL_ID"]),
+        allowed_user_ids={int(os.environ["DISCORD_OWNER_ID"])},
     )
+
+asyncio.run(bot.start(os.environ["DISCORD_BOT_TOKEN"]))
 ```
 
-`setup_bridge()` 自动连接所有 Cog。ccdb 新增的 Cog 无需修改消费者代码即可自动包含。
-
-更新到最新版本：
+`setup_bridge()` 自动配置所有 Cog。更新到最新版本：
 
 ```bash
 uv lock --upgrade-package claude-code-discord-bridge && uv sync
@@ -303,69 +321,38 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 
 ## 配置
 
-| 变量 | 描述 | 默认值 |
+| 变量 | 说明 | 默认值 |
 |------|------|--------|
 | `DISCORD_BOT_TOKEN` | Discord Bot token | （必填） |
 | `DISCORD_CHANNEL_ID` | Claude 聊天频道 ID | （必填） |
-| `CLAUDE_COMMAND` | Claude Code CLI 路径 | `claude` |
-| `CLAUDE_MODEL` | 使用的模型 | `sonnet` |
-| `CLAUDE_PERMISSION_MODE` | CLI 权限模式 | `acceptEdits` |
-| `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | 跳过所有权限检查（谨慎使用） | `false` |
-| `CLAUDE_WORKING_DIR` | Claude 的工作目录 | 当前目录 |
-| `MAX_CONCURRENT_SESSIONS` | 最大并发 Claude CLI 会话数（适用于所有路径：聊天、技能、调度器、Webhook） | `3` |
-| `SESSION_TIMEOUT_SECONDS` | 会话非活动超时 | `300` |
-| `DISCORD_OWNER_ID` | Claude 需要输入时 @提及的用户 ID | （可选） |
-| `COORDINATION_CHANNEL_ID` | AI Lounge 频道的默认回退频道 ID | （可选） |
-| `WORKTREE_BASE_DIR` | 扫描会话 worktree 的基础目录（启用自动清理） | （可选） |
-| `CLI_SESSIONS_PATH` | CLI 会话发现的路径（`~/.claude/projects`），启用 `/sync-sessions` | （可选） |
-| `MENTION_ONLY_CHANNEL_IDS` | 仅在 @提及时响应的频道 ID（逗号分隔） | （可选） |
-| `INLINE_REPLY_CHANNEL_IDS` | 内联回复的频道 ID（逗号分隔，不创建线程） | （可选） |
-| `CHAT_ONLY_CHANNEL_IDS` | 仅显示 Claude 文本回复的频道 ID（逗号分隔，工具嵌入/thinking/Todo 隐藏） | （可选） |
-| `THREAD_INBOX_ENABLED` | 启用持久线程收件箱（通过 `claude -p` 将会话分类为 `waiting`/`done`/`ambiguous`；显示在线程面板中） | `false` |
-| `THREAD_AUTO_RENAME` | 使用 Claude AI 自动重命名新线程标题 — 通过后台 `claude -p` 调用从首条用户消息生成简短描述性标题（不影响会话启动速度） | `false` |
-| `CCDB_CLI_ENV_FILE` | `KEY=VALUE` 文件路径，每次调用 CLI 子进程时将其变量合并到环境中。无需重启 bot 即可立即生效。适用于临时 API 路由切换（如切换至 Azure Foundry） | （可选） |
-
-### 权限模式 — `-p` 模式下的功能说明
-
-通过 ccdb 使用时，Claude Code CLI 以 **`-p`（非交互式）模式** 运行。在此模式下，CLI **无法请求权限确认** — 需要审批的工具会被立即拒绝。这是 [CLI 的设计约束](https://code.claude.com/docs/en/headless)，而非 ccdb 的限制。
-
-| 模式 | `-p` 模式下的行为 | 推荐 |
-|------|----------------------|----------------|
-| `default` | ❌ **所有工具被拒绝** — 无法使用 | 不要使用 |
-| `acceptEdits` | ⚠️ Edit/Write 自动批准，Bash 被拒绝（Claude 回退到 Write 进行文件操作） | 最低可用选项 |
-| `bypassPermissions` | ✅ 所有工具均被批准 | 可用，但建议使用下方的环境变量 |
-| **`CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`** | ✅ **所有工具均被批准** | **推荐** — ccdb 已通过 `allowed_user_ids` 限制访问 |
-
-**我们的推荐：** 设置 `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true`。由于 ccdb 通过 `allowed_user_ids` 控制与 Claude 的交互，CLI 级别的权限检查只会增加摩擦而没有实质性的安全收益。名称中的「dangerously」体现了 CLI 的通用警告；在 ccdb 已限制访问的上下文中，这是实际可行的选择。
-
-**如需精细控制**，可使用 `CLAUDE_ALLOWED_TOOLS` 允许特定工具，而无需完全绕过权限：
-
-```env
-# 示例：允许文件操作和代码执行，但不允许 Web 访问
-CLAUDE_ALLOWED_TOOLS=Bash,Read,Write,Edit,Glob,Grep
-
-# 示例：只读模式 — Claude 可以探索但不能修改
-CLAUDE_ALLOWED_TOOLS=Read,Glob,Grep
-```
-
-常用工具名称：`Bash`、`Read`、`Write`、`Edit`、`Glob`、`Grep`、`WebFetch`、`WebSearch`、`NotebookEdit`。使用此功能时请将 `CLAUDE_PERMISSION_MODE` 设置为 `default`（其他模式可能会覆盖此设置）。
-
-> **为什么 Discord 中不显示权限按钮？** CLI 的 `-p` 模式不会发出 `permission_request` 事件，因此 ccdb 无内容可显示。您看到的 `AskUserQuestion` 按钮（Claude 的选择提示）是不同的机制，可以正常工作。详细调查请参阅 [#210](https://github.com/ebibibi/claude-code-discord-bridge/issues/210)。
-
----
-
-## Discord Bot 设置
-
-1. 在 [Discord Developer Portal](https://discord.com/developers/applications) 创建新应用
-2. 创建 Bot 并复制 token
-3. 在 Privileged Gateway Intents 中启用 **Message Content Intent**
-4. 使用以下权限邀请 Bot：
-   - Send Messages
-   - Create Public Threads
-   - Send Messages in Threads
-   - Add Reactions
-   - Manage Messages（用于清理反应）
-   - Read Message History
+| `CCDB_BACKEND` | 使用的 CLI 后端：`claude` 或 `codex` | `claude` |
+| `CCDB_COMMAND` | CLI 二进制文件路径或名称（覆盖 `CLAUDE_COMMAND`） | _（自动）_ |
+| `CCDB_MODEL` | 使用的模型（覆盖 `CLAUDE_MODEL`） | `sonnet` |
+| `CCDB_PERMISSION_MODE` | CLI 权限模式（覆盖 `CLAUDE_PERMISSION_MODE`） | `acceptEdits` |
+| `CCDB_DANGEROUSLY_SKIP_PERMISSIONS` | 跳过所有权限检查 | `false` |
+| `CCDB_WORKING_DIR` | CLI 工作目录 | 当前目录 |
+| `CCDB_ALLOWED_TOOLS` | 允许工具的逗号分隔列表 | （可选） |
+| `CCDB_CHANNEL_IDS` | 多频道设置的额外频道 ID | （可选） |
+| `CLAUDE_COMMAND` | Claude CLI 路径（旧名称——推荐 `CCDB_COMMAND`） | `claude` |
+| `CLAUDE_MODEL` | 模型（旧名称——推荐 `CCDB_MODEL`） | `sonnet` |
+| `CLAUDE_PERMISSION_MODE` | 权限模式（旧名称——推荐 `CCDB_PERMISSION_MODE`） | `acceptEdits` |
+| `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | 跳过权限检查（旧名称） | `false` |
+| `CLAUDE_WORKING_DIR` | 工作目录（旧名称） | 当前目录 |
+| `MAX_CONCURRENT_SESSIONS` | 最大并行会话数 | `3` |
+| `SESSION_TIMEOUT_SECONDS` | 会话不活跃超时 | `300` |
+| `DISCORD_OWNER_ID` | 需要输入时 @提及 的用户 ID | （可选） |
+| `COORDINATION_CHANNEL_ID` | AI Lounge 频道的默认回退 | （可选） |
+| `MENTION_ONLY_CHANNEL_IDS` | 仅 @提及 时响应的频道（逗号分隔） | （可选） |
+| `INLINE_REPLY_CHANNEL_IDS` | 内联回复频道（逗号分隔） | （可选） |
+| `CHAT_ONLY_CHANNEL_IDS` | 纯聊天模式频道（逗号分隔） | （可选） |
+| `WORKTREE_BASE_DIR` | 扫描会话 worktree 的基础目录 | （可选） |
+| `CLI_SESSIONS_PATH` | CLI 会话发现路径（`~/.claude/projects`） | （可选） |
+| `CUSTOM_COGS_DIR` | 自定义 Cog 目录 | （可选） |
+| `THREAD_INBOX_ENABLED` | 启用持久线程收件箱 | `false` |
+| `THREAD_AUTO_RENAME` | 使用 Claude 自动重命名线程 | `false` |
+| `CCDB_CLI_ENV_FILE` | 每次 CLI 调用时合并到环境的 `KEY=VALUE` 文件 | （可选） |
+| `API_HOST` | REST API 绑定地址 | `127.0.0.1` |
+| `API_PORT` | REST API 端口（设置后启用） | （可选） |
 
 ---
 
@@ -374,10 +361,10 @@ CLAUDE_ALLOWED_TOOLS=Read,Glob,Grep
 ### 示例：自动文档同步
 
 每次推送到 `main`，Claude Code：
-1. 拉取最新变更并分析差异
+1. 拉取最新更改并分析差异
 2. 更新英文文档
-3. 翻译为日文（或任何目标语言）
-4. 创建含双语摘要的 PR
+3. 翻译为目标语言
+4. 创建带双语摘要的 PR
 5. 启用自动合并——CI 通过后自动合并
 
 **GitHub Actions：**
@@ -399,86 +386,24 @@ jobs:
             -d '{"content": "🔄 docs-sync"}'
 ```
 
-**Bot 配置：**
-
-```python
-from claude_discord import WebhookTriggerCog, WebhookTrigger, ClaudeRunner
-
-runner = ClaudeRunner(command="claude", model="sonnet")
-
-triggers = {
-    "🔄 docs-sync": WebhookTrigger(
-        prompt="分析变更，更新文档，创建含双语摘要的 PR，启用自动合并。",
-        working_dir="/home/user/my-project",
-        timeout=600,
-    ),
-}
-
-await bot.add_cog(WebhookTriggerCog(
-    bot=bot,
-    runner=runner,
-    triggers=triggers,
-    channel_ids={YOUR_CHANNEL_ID},
-))
-```
-
-**安全性：** 提示在服务端定义。Webhook 只负责触发，不能注入任意提示。
-
-### 示例：自动批准所有者 PR
-
-```yaml
-# .github/workflows/auto-approve.yml
-name: Auto Approve Owner PRs
-on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-jobs:
-  auto-approve:
-    if: github.event.pull_request.user.login == 'your-username'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
-    steps:
-      - env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --approve
-          gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --squash
-```
-
 ---
 
-## 计划任务
+## 定时任务
 
-运行时注册定期 Claude Code 任务——无需修改代码，无需重新部署。
-
-在 Discord 会话中，Claude 可以注册任务：
+无需修改代码即可在运行时注册定期 Claude Code 任务。
 
 ```bash
 # Claude 在会话中调用：
 curl -X POST "$CCDB_API_URL/api/tasks" \
   -H "Content-Type: application/json" \
-  -d '{"prompt": "检查过时依赖并在发现时开启 issue", "interval_seconds": 604800}'
+  -d '{"prompt": "检查过期依赖并在发现时开 issue", "interval_seconds": 604800}'
 ```
 
-或从自己的脚本注册：
-
-```bash
-curl -X POST http://localhost:8080/api/tasks \
-  -H "Authorization: Bearer your-secret" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "每周安全扫描", "interval_seconds": 604800}'
-```
-
-30 秒主循环自动检测到期任务并创建 Claude Code 会话。
+30 秒主循环自动检测到期任务并启动 Claude Code 会话。
 
 ---
 
 ## 自动升级
-
-当新版本发布时自动升级 bot：
 
 ```python
 from claude_discord import AutoUpgradeCog, UpgradeConfig
@@ -488,35 +413,20 @@ config = UpgradeConfig(
     trigger_prefix="🔄 bot-upgrade",
     working_dir="/home/user/my-bot",
     restart_command=["sudo", "systemctl", "restart", "my-bot.service"],
-    restart_approval=True,  # 通过 ✅ 反应确认重启
+    restart_approval=True,
+    slash_command_enabled=True,
 )
 
 await bot.add_cog(AutoUpgradeCog(bot, config))
 ```
 
-重启前，`AutoUpgradeCog`：
-
-1. **快照活跃会话** — 收集所有有运行中 Claude 会话的线程（鸭子类型：任何有 `_active_runners` dict 的 Cog 都会被自动发现）。
-2. **排空** — 等待活跃会话自然结束。
-3. **标记恢复** — 将活跃线程 ID 保存到待恢复表。下次启动时，这些会话会以"bot 已重启，请继续"的提示自动恢复。
-4. **重启** — 执行配置的重启命令。
-
-任何有 `active_count` 属性的 Cog 都会被自动发现并排空：
-
-```python
-class MyCog(commands.Cog):
-    @property
-    def active_count(self) -> int:
-        return len(self._running_tasks)
-```
-
-> **覆盖范围：** `AutoUpgradeCog` 覆盖升级触发的重启。对于*所有其他*关闭（`systemctl stop`、`bot.close()`、SIGTERM），`ClaudeChatCog.cog_unload()` 提供第二道自动安全网。
+重启前，`AutoUpgradeCog` 会快照活跃会话、等待其完成、标记恢复并执行重启命令。
 
 ---
 
 ## REST API
 
-可选的 REST API，用于通知和任务管理。需要 aiohttp：
+可选 REST API，用于通知和任务管理。需要 aiohttp：
 
 ```bash
 uv add "claude-code-discord-bridge[api]"
@@ -524,106 +434,58 @@ uv add "claude-code-discord-bridge[api]"
 
 ### 端点
 
-| 方法 | 路径 | 描述 |
+| 方法 | 路径 | 说明 |
 |------|------|------|
 | GET | `/api/health` | 健康检查 |
 | POST | `/api/notify` | 发送即时通知 |
-| POST | `/api/schedule` | 计划通知 |
+| POST | `/api/schedule` | 安排通知 |
 | GET | `/api/scheduled` | 列出待处理通知 |
 | DELETE | `/api/scheduled/{id}` | 取消通知 |
-| POST | `/api/tasks` | 注册计划 Claude Code 任务 |
+| POST | `/api/tasks` | 注册定期 Claude Code 任务 |
 | GET | `/api/tasks` | 列出已注册任务 |
 | DELETE | `/api/tasks/{id}` | 删除任务 |
-| PATCH | `/api/tasks/{id}` | 更新任务（启用/禁用，修改计划） |
+| PATCH | `/api/tasks/{id}` | 更新任务 |
 | POST | `/api/spawn` | 创建新 Discord 线程并启动 Claude Code 会话（非阻塞） |
-| POST | `/api/mark-resume` | 标记线程在下次 bot 启动时自动恢复 |
-| GET | `/api/lounge` | 获取 AI Lounge 的最近消息 |
-| POST | `/api/lounge` | 向 AI Lounge 发布消息（`label` 可选） |
-
-```bash
-# 发送通知
-curl -X POST http://localhost:8080/api/notify \
-  -H "Authorization: Bearer your-secret" \
-  -H "Content-Type: application/json" \
-  -d '{"message": "构建成功！", "title": "CI/CD"}'
-
-# 注册定期任务
-curl -X POST http://localhost:8080/api/tasks \
-  -H "Authorization: Bearer your-secret" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "每日站会摘要", "interval_seconds": 86400}'
-```
+| POST | `/api/mark-resume` | 标记线程在下次 Bot 启动时自动恢复 |
+| GET | `/api/lounge` | 读取最近的 AI Lounge 消息 |
+| POST | `/api/lounge` | 向 AI Lounge 发布消息 |
 
 ---
 
 ## 架构
 
 ```
+claude_code_core/          # 与后端无关的共享核心库
+  backend.py               # SessionBackend 协议 + create_backend() 工厂
+  codex_runner.py          # OpenAI Codex CLI 后端
+  runner.py                # Claude CLI 子进程管理器
+  parser.py                # stream-json 事件解析器
+  types.py                 # SDK 消息类型定义
 claude_discord/
-  main.py                  # 独立入口点（setup_bridge + 自定义 Cog 加载器）
-  cli.py                   # CLI 入口点（ccdb setup/start 命令）
-  setup.py                 # setup_bridge() — 一键 Cog 连接
-  cog_loader.py            # 动态自定义 Cog 加载器（CUSTOM_COGS_DIR）
-  bot.py                   # Discord Bot 类
-  protocols.py             # 共享协议（DrainAware）
-  concurrency.py           # Worktree 指令 + 活跃会话注册表
-  lounge.py                # AI Lounge 提示构建器
-  session_sync.py          # CLI 会话发现和导入
-  worktree.py              # WorktreeManager — 安全 git worktree 生命周期
+  main.py                  # 独立入口
+  cli.py                   # CLI 入口（ccdb setup/start）
+  setup.py                 # setup_bridge()
   cogs/
-    claude_chat.py         # 交互式聊天（线程创建，消息处理）
-    skill_command.py       # /skill 斜杠命令，含自动补全
-    session_manage.py      # /sessions, /sync-sessions, /resume, /resume-info, /sync-settings
-    session_sync.py        # sync-sessions 的线程创建和消息发布逻辑
-    prompt_builder.py      # build_prompt_and_images() — 纯函数，无 Cog/Bot 状态
-    scheduler.py           # 定期 Claude Code 任务执行器
-    webhook_trigger.py     # Webhook → Claude Code 任务（CI/CD）
-    auto_upgrade.py        # Webhook → 包升级 + 感知排空重启
-    event_processor.py     # EventProcessor — stream-json 事件状态机
-    run_config.py          # RunConfig 数据类 — 打包所有 CLI 执行参数
-    _run_helper.py         # 薄编排层（run_claude_with_config + shim）
-  claude/
-    runner.py              # Claude CLI 子进程管理器
-    parser.py              # stream-json 事件解析器
-    types.py               # SDK 消息类型定义
-  database/
-    models.py              # SQLite 模式
-    repository.py          # 会话 CRUD
-    task_repo.py           # 计划任务 CRUD
-    ask_repo.py            # 待处理 AskUserQuestion CRUD
-    notification_repo.py   # 计划通知 CRUD
-    lounge_repo.py         # AI Lounge 消息 CRUD
-    resume_repo.py         # 启动恢复 CRUD（跨 bot 重启的待恢复记录）
-    settings_repo.py       # 每公会设置
-  discord_ui/
-    status.py              # 表情反应管理器（防抖）
-    chunker.py             # 感知代码块和表格的消息分割
-    embeds.py              # Discord embed 构建器
-    views.py               # 停止按钮和共享 UI 组件
-    ask_bus.py             # AskUserQuestion 通信事件总线
-    ask_view.py            # AskUserQuestion 的按钮/下拉菜单
-    ask_handler.py         # collect_ask_answers() — AskUserQuestion UI + DB 生命周期
-    streaming_manager.py   # StreamingMessageManager — 防抖就地消息编辑
-    tool_timer.py          # LiveToolTimer — 长运行工具的耗时计数器
-    thread_dashboard.py    # 显示会话状态的实时置顶 embed
-    plan_view.py           # Plan Mode 批准/取消按钮（ExitPlanMode）
-    permission_view.py     # 工具权限请求允许/拒绝按钮
-    elicitation_view.py    # MCP Elicitation 的 Discord UI（Modal 表单或 URL 按钮）
-    file_sender.py         # 通过 .ccdb-attachments 传送文件
+    claude_chat.py         # 交互式聊天
+    skill_command.py       # /skill 命令
+    session_manage.py      # 会话管理
+    scheduler.py           # 定期任务
+    webhook_trigger.py     # CI/CD 触发器
+    auto_upgrade.py        # 自动升级
   ext/
-    api_server.py          # REST API（可选，需要 aiohttp）
-  utils/
-    logger.py              # 日志设置
+    api_server.py          # REST API（可选）
+examples/
+  ebibot/                  # 真实案例
 ```
 
 ### 设计理念
 
-- **CLI 调用而非 API** — 调用 `claude -p --output-format stream-json`，免费获得完整 Claude Code 功能（CLAUDE.md、技能、工具、内存），无需重新实现
-- **并发优先** — 多个同时会话是预期场景而非边缘情况；每个会话都有 worktree 指令，注册表和 AI Lounge 处理其余部分
-- **Discord 作为粘合剂** — Discord 提供 UI、线程、反应、webhook 和持久通知；无需自定义前端
-- **框架而非应用** — 作为包安装，向现有 bot 添加 Cog，通过代码配置
-- **零代码扩展性** — 无需修改源代码即可添加计划任务和 webhook 触发器
-- **简单即安全** — 约 3000 行可审计的 Python；仅使用 subprocess exec，无 shell 扩展
+- **CLI 生成而非 API** — 获得完整 Claude Code 功能，无需 API 密钥，无按 token 计费
+- **并发优先** — 多个同时会话是预期情况，而非边缘情况
+- **Discord 作为胶水** — Discord 提供 UI、线程、反应、webhook 和持久通知
+- **框架而非应用** — 作为包安装，向现有 Bot 添加 Cog
+- **零代码可扩展性** — 无需修改源代码即可添加定时任务和 webhook 触发器
+- **简单即安全** — 约 8000 行可审计的 Python；仅 subprocess exec，无 shell 扩展
 
 ---
 
@@ -633,37 +495,38 @@ claude_discord/
 uv run pytest tests/ -v --cov=claude_discord
 ```
 
-1050+ 个测试覆盖解析器、分块器、仓库、运行器、流式传输、webhook 触发、自动升级（含 `/upgrade` 斜杠命令、线程调用和批准按钮）、REST API、AskUserQuestion UI、线程面板、计划任务、会话同步、AI Lounge、启动恢复、模型切换、压缩检测、TodoWrite 进度 embed，以及权限/elicitation/plan-mode 事件解析。
+1365+ 个测试覆盖解析器、分块器、仓库、运行器、流式传输、webhook 触发器、自动升级、REST API、AskUserQuestion UI、线程仪表板、定时任务、会话同步、AI Lounge、启动恢复、模型切换、压缩检测、TodoWrite 进度 embed、自定义 Cog 加载器、SessionBackend 协议、CodexRunner 和后端工厂。
 
 ---
 
 ## 本项目的构建方式
 
-**整个代码库由 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)** 编写——Anthropic 的 AI 编程代理。人类作者（[@ebibibi](https://github.com/ebibibi)）以自然语言提供需求和方向，但未手动阅读或编辑源代码。
+**本代码库由 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)**（Anthropic 的 AI 编码代理）在 [@ebibibi](https://github.com/ebibibi) 的指导下开发。人类作者定义需求、审查 PR 并批准所有更改——Claude Code 负责实现。
 
-这意味着：
-
-- **所有代码由 AI 生成** — 架构、实现、测试、文档
-- **人类作者无法保证代码级别的正确性** — 如需确认请查看源代码
-- **欢迎 Bug 报告和 PR** — Claude Code 将用于处理它们
-- **这是 AI 编写的开源软件的真实案例**
-
-本项目始于 2026-02-18，通过与 Claude Code 的迭代对话持续演进。
+项目于 2026-02-18 启动，并通过与 Claude Code 的迭代对话不断演进。
 
 ---
 
 ## 实际案例
 
-**[EbiBot](https://github.com/ebibibi/discord-bot)** — 基于此框架构建的个人 Discord Bot。包括自动文档同步（英文 + 日文）、推送通知、Todoist 看门狗、定期健康检查和 GitHub Actions CI/CD。可作为构建自己 bot 的参考。
+**[`examples/ebibot/`](examples/ebibot/)** — 基于此框架构建的个人 Discord Bot，展示自定义 Cog 加载器：
+
+- **ReminderCog** — `/remind HH:MM "message"` 斜杠命令 + 30 秒发送循环
+- **WatchdogCog** — Todoist 过期任务监控（30 分钟检查，每日去重，按严重程度告警）
+- **AutoUpgradeCog** — 通过 GitHub webhook + systemctl restart 自我更新
+- **DocsSyncCog** — 推送时自动翻译文档
+- **AlertResponderCog** — 通用告警监控 Cog；监视可配置来源并向 Discord 发布带严重程度注释的通知
+
+运行方式：`ccdb start --cogs-dir examples/ebibot/cogs/`
 
 ---
 
-## 灵感来源
+## 致谢
 
-- [OpenClaw](https://github.com/openclaw/openclaw) — 表情状态反应、消息防抖、感知代码块分割
-- [claude-code-discord-bot](https://github.com/timoconnellaus/claude-code-discord-bot) — CLI 调用 + stream-json 方案
+- [OpenClaw](https://github.com/openclaw/openclaw) — 表情状态反应、消息防抖、fence 感知分块
+- [claude-code-discord-bot](https://github.com/timoconnellaus/claude-code-discord-bot) — CLI 生成 + stream-json 方法
 - [claude-code-discord](https://github.com/zebbern/claude-code-discord) — 权限控制模式
-- [claude-sandbox-bot](https://github.com/RhysSullivan/claude-sandbox-bot) — 每对话线程模型
+- [claude-sandbox-bot](https://github.com/RhysSullivan/claude-sandbox-bot) — 每线程对话模型
 
 ---
 


### PR DESCRIPTION
## Summary

- **v3.0.0 title update** — All 6 languages now reflect the new project name "Claude & Codex Discord Bridge" (previously "claude-code-discord-bridge")
- **OpenAI Codex added** — Tagline, description, disclaimer, and subscription info updated to mention both Claude Code and OpenAI Codex across all languages
- **Full rewrites** — zh-CN, ko, es, pt-BR, fr were significantly behind (stuck at v2.2.x); now fully updated to v3.0.1 content
- **Partial update** — ja was mostly current; only header section (title, tagline, description, disclaimer) updated

## Languages Updated

| Language | Change Type |
|----------|-------------|
| 🇯🇵 Japanese (ja) | Header section only (title, tagline, disclaimer) |
| 🇨🇳 Chinese Simplified (zh-CN) | Full rewrite |
| 🇰🇷 Korean (ko) | Full rewrite |
| 🇪🇸 Spanish (es) | Full rewrite |
| 🇧🇷 Portuguese Brazil (pt-BR) | Full rewrite |
| 🇫🇷 French (fr) | Full rewrite |

## Test plan

- [ ] Verify all translation files render correctly as Markdown
- [ ] Verify language navigation links work in each translated file
- [ ] Verify code blocks and badges are preserved intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
