### PR TITLE
fix: per-thread /backend override actually switches runner + README rewrite for dual-backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,12 @@
+# ── Backend selection (3.0+) ─────────────────────────────────────
+# Which AI CLI handles new sessions by default. Override per-thread
+# at runtime with /backend, or override globally with /backend.
+CCDB_BACKEND=claude
+# Optional explicit CLI paths. Required for codex under systemd
+# because the default service PATH does not include ~/.npm-global/bin.
+# CCDB_CLAUDE_COMMAND=/home/you/.local/bin/claude
+# CCDB_CODEX_COMMAND=/home/you/.npm-global/bin/codex
+
 # Discord Bot Configuration
 DISCORD_BOT_TOKEN=your-bot-token-here
 DISCORD_CHANNEL_ID=your-channel-id-here

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Open Claude Code or OpenAI Codex from your smartphone's Discord app, spin up mul
 
 ## The Big Idea: Parallel Sessions Without Fear
 
-When you send tasks to Claude Code in separate Discord threads, the bridge does four things automatically:
+When you send tasks to Claude Code or OpenAI Codex in separate Discord threads, the bridge does four things automatically — regardless of which backend you picked:
 
 1. **Concurrency notice injection** — Every session's system prompt includes mandatory instructions: create a git worktree, work only inside it, never touch the main working directory directly.
 
@@ -31,15 +31,17 @@ When you send tasks to Claude Code in separate Discord threads, the bridge does 
 
 3. **AI Lounge** — A session-to-session "breakroom" injected into every prompt. Before starting, each session reads recent lounge messages to see what other sessions are doing. Before disruptive operations (force push, bot restart, DB drop), sessions check the lounge first so they don't stomp on each other's work.
 
+4. **Backend-agnostic surface** — The same Discord UI, slash commands, scheduler, API, and Lounge work the same way whether a thread runs Claude or Codex. Mix backends across threads if you want — e.g. Claude for refactors, Codex for code review — using `/backend` per thread.
+
 ```
-Thread A (feature)   ──→  Claude Code (worktree-A)  ─┐
-Thread B (PR review) ──→  Claude Code (worktree-B)   ├─→  #ai-lounge
-Thread C (docs)      ──→  Claude Code (worktree-C)  ─┘    "A: auth refactor in progress"
-                                                           "B: PR #42 review done"
-                                                           "C: updating README"
+Thread A (feature)    ──→  Claude Code  (worktree-A)  ─┐
+Thread B (PR review)  ──→  OpenAI Codex (worktree-B)   ├─→  #ai-lounge
+Thread C (docs)       ──→  Claude Code  (worktree-C)  ─┘    "A: auth refactor in progress"
+                                                             "B: PR #42 review done (codex)"
+                                                             "C: updating README"
 ```
 
-No race conditions. No lost work. No merge surprises.
+No race conditions. No lost work. No merge surprises. No backend lock-in.
 
 ---
 
@@ -47,15 +49,16 @@ No race conditions. No lost work. No merge surprises.
 
 ### Interactive Chat (Mobile / Desktop)
 
-Use Claude Code from anywhere Discord runs — phone, tablet, or desktop. Each message creates or continues a thread, mapping 1:1 to a persistent Claude Code session.
+Use Claude Code _or_ OpenAI Codex from anywhere Discord runs — phone, tablet, or desktop. Each message creates or continues a thread that maps 1:1 to a persistent AI session. Switch backend at any time with `/backend claude` or `/backend codex` — per thread, or globally as the new default.
 
 ### Parallel Development
 
-Open multiple threads simultaneously. Each is an independent Claude Code session with its own context, working directory, and git worktree. Useful patterns:
+Open multiple threads simultaneously. Each is an independent AI session — Claude Code or Codex — with its own context, working directory, and git worktree. Useful patterns:
 
-- **Feature + review in parallel**: Start a feature in one thread while Claude reviews a PR in another.
-- **Multiple contributors**: Different team members each get their own thread; sessions stay aware of each other via the AI Lounge.
+- **Feature + review in parallel**: Start a feature with Claude in one thread while Codex reviews the PR in another.
+- **Multiple contributors**: Different team members each get their own thread (and their preferred backend); sessions stay aware of each other via the AI Lounge.
 - **Experiment safely**: Try an approach in thread A while keeping thread B on stable code.
+- **A/B the same prompt on both AIs**: Spawn two threads with the same task, one on `/backend claude` and one on `/backend codex`, then compare the diffs side-by-side.
 
 ### Scheduled Tasks (SchedulerCog)
 
@@ -137,6 +140,40 @@ If the bot restarts mid-session, interrupted Claude sessions are automatically r
 - **Automatic (upgrade restart)** — `AutoUpgradeCog` snapshots all active sessions just before a package upgrade restart and marks them automatically.
 - **Automatic (any shutdown)** — `ClaudeChatCog.cog_unload()` marks all mid-run sessions whenever the bot shuts down via any mechanism (`systemctl stop`, `bot.close()`, SIGTERM, etc.).
 - **Manual** — Any session can call `POST /api/mark-resume` directly.
+
+### Backend Switching — Claude / Codex on Demand
+
+ccdb 3.0 introduces two slash commands that change which AI handles the next session, with no bot restart:
+
+- `/backend [name] [scope]` — show or switch backend. `name` is `claude` or `codex`. `scope` is `thread` (this thread only) or `global` (server-wide default). When you omit `scope`, the command auto-resolves: in a thread it scopes to that thread, otherwise it sets the global default.
+- `/model [name] [scope]` — show or switch the model used by the **current** backend. Each backend remembers its own model preference, so flipping backend back and forth keeps your favoured models intact.
+
+Both commands persist to SQLite via `SettingsRepository`, so the choice survives bot restarts. Calling `/backend` with no arguments prints the current global default plus any thread override.
+
+Visual cues so you never forget which one you're talking to:
+
+- **Claude sessions** open with a blurple embed titled "🤖 Claude Code session started".
+- **Codex sessions** open with an OpenAI-teal embed titled "🌀 OpenAI Codex session started".
+- The completion embed prepends a `🧠 Claude · sonnet` / `🧠 Codex · gpt-5.4` chip alongside the usual duration / cost / token / context metrics.
+
+Concrete example:
+
+```text
+/backend codex                        # global → codex (next new sessions use codex)
+/model gpt-5-codex                    # global → codex uses gpt-5-codex
+                                       # …open a thread, send a message…
+/backend claude scope:thread          # this thread only → switch back to claude
+/model opus scope:thread              # this thread only → claude/opus
+                                       # other threads keep the global codex+gpt-5-codex default
+```
+
+Behind the scenes:
+
+- `BackendFactory` — captures the static configuration at boot (per-backend command path, permission mode, working dir, allowed tools, timeout, append-system-prompt, effort) and builds a fresh `ClaudeRunner` or `CodexRunner` on demand.
+- `BackendSettings` — thin wrapper over `SettingsRepository` that resolves the active backend with **thread > global > env** precedence and persists writes from the slash commands.
+- `SessionBackend` Protocol — the abstract interface that both runners satisfy. Internal plumbing (cogs, embeds, views, scheduler, webhook trigger) takes a `SessionBackend`, never one concrete runner class.
+
+**Where does each backend authenticate?** Claude Code uses your existing Claude Pro/Max subscription via the `claude` CLI's `claude login`. Codex uses your existing ChatGPT Plus/Pro/Business subscription via the `codex` CLI's `codex login`. ccdb never sees raw API keys — it just shells out to whichever CLI is selected.
 
 ---
 
@@ -233,9 +270,15 @@ If the bot restarts mid-session, interrupted Claude sessions are automatically r
 
 ---
 
-## Quick Start — Claude in Discord in 5 Minutes
+## Quick Start — Claude or Codex in Discord in 5 Minutes
 
-**Prerequisites:** Python 3.10+, [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated.
+**Prerequisites:**
+
+- Python 3.10+
+- At least one of:
+  - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) — installed and authenticated (`claude login`). Recommended for Anthropic Pro/Max subscribers.
+  - [OpenAI Codex CLI](https://github.com/openai/codex) — `npm install -g @openai/codex` then `codex login`. Uses your existing ChatGPT Plus/Pro/Business subscription.
+- You can install both. Switch between them at runtime with `/backend` (see [Backend Switching](#backend-switching--claude--codex-on-demand)).
 
 **Platform support:** Primarily developed and tested on **Linux**. macOS and Windows are supported and pass CI, but receive less real-world testing — bug reports welcome.
 
@@ -524,7 +567,9 @@ In chat-only mode, permission requests and `AskUserQuestion` prompts are **alway
 | `DISCORD_BOT_TOKEN` | Your Discord bot token | (required) |
 | `DISCORD_CHANNEL_ID` | Channel ID for Claude chat | (required) |
 | `CCDB_BACKEND` | CLI backend to use: `claude` (Claude Code CLI) or `codex` (OpenAI Codex CLI) | `claude` |
-| `CCDB_COMMAND` | Path or name of the CLI binary (overrides `CLAUDE_COMMAND`). Useful to pin a specific version. | _(auto: `claude` or `codex`)_ |
+| `CCDB_COMMAND` | Path or name of the CLI binary (overrides `CLAUDE_COMMAND`). Used by the initial runner picked from `CCDB_BACKEND`; superseded by the two per-backend variables below when `/backend` switches at runtime. | _(auto: `claude` or `codex`)_ |
+| `CCDB_CLAUDE_COMMAND` | Explicit path to the Claude CLI binary. Used by `BackendFactory` whenever `/backend claude` is active, regardless of the initial `CCDB_BACKEND`. Falls back to `CLAUDE_COMMAND`, then `claude` (PATH). | (optional) |
+| `CCDB_CODEX_COMMAND` | Explicit path to the OpenAI Codex CLI binary. Required when running the bot under systemd (default service PATH does not include `~/.npm-global/bin`). Falls back to `codex` (PATH). | (optional) |
 | `CCDB_MODEL` | Model to use (overrides `CLAUDE_MODEL`) | `sonnet` |
 | `CCDB_PERMISSION_MODE` | Permission mode for CLI (overrides `CLAUDE_PERMISSION_MODE`) | `acceptEdits` |
 | `CCDB_DANGEROUSLY_SKIP_PERMISSIONS` | Skip all permission checks — overrides `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | `false` |

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -23,6 +23,8 @@ from discord.ext import commands
 
 from claude_code_core.backend import SessionBackend
 
+from ..backend_factory import BackendFactory
+from ..backend_settings import BackendSettings
 from ..claude.rewind import find_session_jsonl, parse_user_turns
 from ..claude.types import ImageData
 from ..concurrency import SessionRegistry
@@ -110,10 +112,17 @@ class ClaudeChatCog(commands.Cog):
         chat_only_channel_ids: set[int] | None = None,
         auto_rename_threads: bool = False,
         monitor_all_channels: bool = False,
+        factory: BackendFactory | None = None,
+        backend_settings: BackendSettings | None = None,
     ) -> None:
         self.bot = bot
         self.repo = repo
         self.runner = runner
+        # Optional backend factory + settings: when both are present,
+        # session spawns consult them to honour per-thread /backend overrides.
+        # When either is None, we fall back to self.runner.clone() (legacy).
+        self._factory = factory
+        self._backend_settings = backend_settings
         self._max_concurrent = max_concurrent
         self._allowed_user_ids = allowed_user_ids
         # When True, skip channel-ID filtering and accept all guild channels.
@@ -257,6 +266,64 @@ class ClaudeChatCog(commands.Cog):
         # Check if message is in a thread under one of the configured channels
         if is_target_thread:
             await self._handle_thread_reply(message)
+
+    async def _build_runner_for_thread(
+        self,
+        *,
+        thread_id: int,
+        model_override: str | None,
+        tools_override: list[str] | None,
+        fork_session: bool,
+        working_dir_override: str | None,
+        effort_override: str | None,
+    ) -> SessionBackend:
+        """Build a runner for a session, honouring per-thread backend/model overrides.
+
+        When the cog has a BackendFactory + BackendSettings (the 3.x path), the
+        backend and model are resolved from BackendSettings — thread > global >
+        env. Per-call overrides (model_override, tools_override, ...) still win
+        over stored settings.
+
+        When either dependency is missing (legacy embedded setups, tests), we
+        fall back to ``self.runner.clone()`` so existing behaviour is preserved.
+        """
+        from ..claude.runner import _UNSET
+
+        if self._factory is None or self._backend_settings is None:
+            return self.runner.clone(
+                thread_id=thread_id,
+                model=model_override,
+                allowed_tools=tools_override if tools_override is not None else _UNSET,
+                fork_session=fork_session,
+                working_dir=working_dir_override if working_dir_override is not None else _UNSET,
+                effort=effort_override if effort_override is not None else _UNSET,
+            )
+
+        backend = await self._backend_settings.current_backend(thread_id)
+        if model_override:
+            model: str | None = model_override
+        else:
+            model = await self._backend_settings.current_model(backend, thread_id)
+
+        runner = self._factory.build(
+            backend=backend,
+            model=model,
+            thread_id=thread_id,
+        )
+
+        # Apply per-call overrides that the factory does not know about.
+        # Both ClaudeRunner and CodexRunner allow attribute assignment for
+        # these fields; effort/fork are Claude-specific and gated by hasattr.
+        if tools_override is not None:
+            runner.allowed_tools = tools_override
+        if working_dir_override is not None:
+            runner.working_dir = working_dir_override
+        if effort_override is not None and hasattr(runner, "effort"):
+            runner.effort = effort_override  # type: ignore[attr-defined]
+        if fork_session and hasattr(runner, "fork_session"):
+            runner.fork_session = True  # type: ignore[attr-defined]
+
+        return runner
 
     @app_commands.command(name="help", description="Show available commands and how to use the bot")
     async def help_command(self, interaction: discord.Interaction) -> None:
@@ -951,15 +1018,14 @@ class ClaudeChatCog(commands.Cog):
 
         tools_override = await self._get_allowed_tools()
         effort_override = await self._get_current_effort()
-        from ..claude.runner import _UNSET
 
-        runner = self.runner.clone(
+        runner = await self._build_runner_for_thread(
             thread_id=thread.id,
-            model=model_override,
-            allowed_tools=tools_override if tools_override is not None else _UNSET,
+            model_override=model_override,
+            tools_override=tools_override,
             fork_session=fork,
-            working_dir=working_dir_override if working_dir_override is not None else _UNSET,
-            effort=effort_override if effort_override is not None else _UNSET,
+            working_dir_override=working_dir_override,
+            effort_override=effort_override,
         )
         self._active_runners[thread.id] = runner
 

--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -254,10 +254,26 @@ async def setup_bridge(
         logger.info("Thread inbox enabled")
 
     # --- ClaudeChatCog ---
+    # Build BackendSettings up front so we can also pass it into
+    # ClaudeChatCog (so per-thread /backend overrides take effect on spawn).
+    _backend_settings_for_chat = None
+    if backend_factory is not None:
+        from .backend_settings import BackendSettings
+
+        _runner_class = runner.__class__.__name__
+        _backend_settings_for_chat = BackendSettings(
+            settings_repo,
+            env_backend=_runner_class.replace("Runner", "").lower(),
+            env_model_for_claude=(runner.model if _runner_class == "ClaudeRunner" else ""),
+            env_model_for_codex=(runner.model if _runner_class == "CodexRunner" else ""),
+        )
+
     chat_cog = ClaudeChatCog(
         bot,  # type: ignore[arg-type]  # consumers pass their own Bot subclass
         repo=session_repo,
         runner=runner,
+        factory=backend_factory,
+        backend_settings=_backend_settings_for_chat,
         max_concurrent=max_concurrent,
         allowed_user_ids=allowed_user_ids,
         ask_repo=ask_repo,


### PR DESCRIPTION
## Summary

Two things bundled:

1. **Bug fix** — `/backend codex scope:thread` (and per-thread `/model`) now actually changes the runner for that thread's next session. Previously the override was persisted to `SettingsRepository` but `ClaudeChatCog` kept spawning the boot-time runner via `self.runner.clone()`, so the user saw "Backend set to codex" but the next message still ran on Claude.

2. **README rewrite** — replaces single-backend phrasing throughout, adds a new "Backend Switching — Claude / Codex on Demand" section that documents `/backend`, `/model`, persistence, and the visual cues. Quick Start prerequisites now list Claude Code CLI and OpenAI Codex CLI side by side (install either or both). The Configuration table gains `CCDB_CLAUDE_COMMAND` and `CCDB_CODEX_COMMAND` rows.

## How the fix works

`ClaudeChatCog` learns two optional dependencies — `BackendFactory` and `BackendSettings` — and a new helper `_build_runner_for_thread()`. On every spawn it now:

1. Reads `current_backend(thread_id)` from settings (thread > global > env)
2. Reads `current_model(backend, thread_id)` from settings (same precedence)
3. Calls `factory.build(backend=..., model=..., thread_id=...)` to construct a fresh `ClaudeRunner` or `CodexRunner`
4. Layers per-call overrides (model_override, allowed_tools, working_dir, effort, fork_session) on top of the new runner

When either dependency is missing (embedded consumers, tests, very small deployments) the cog falls back to the legacy `self.runner.clone()` so existing behaviour is preserved.

`setup_bridge` constructs `BackendSettings` once and passes it both into `ClaudeChatCog` (for spawn-time resolution) and into `BackendCommandCog` (for `/backend` / `/model` writes).

## Test plan

- [x] `pyright claude_discord/ claude_code_core/` — 0 errors
- [x] `ruff format` / `ruff check` — clean
- [x] `pytest --ignore=tests/integration` — 1373 passed
- [ ] After merge: bot auto-pulls + I restart on moviegen. From a thread, run `/backend codex scope:thread`, then send "say hi in one word" — embed should be OpenAI-teal "🌀 OpenAI Codex session started"; reply should be a Codex completion. From a different thread, the global Claude default still applies.

## Files

- `claude_discord/cogs/claude_chat.py` — `__init__` adds factory + backend_settings kwargs, new `_build_runner_for_thread` helper, spawn call site updated.
- `claude_discord/setup.py` — builds `BackendSettings` and passes it into `ClaudeChatCog`.
- `README.md` — dual-backend phrasing, new "Backend Switching" section, prerequisites + config table additions.
- `.env.example` — new top section with `CCDB_BACKEND`, `CCDB_CLAUDE_COMMAND`, `CCDB_CODEX_COMMAND`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
