### PR TITLE
fix: make Codex backend actually usable end-to-end (argv, model leak, statusLine)

### DIFF
--- a/claude_code_core/codex_runner.py
+++ b/claude_code_core/codex_runner.py
@@ -241,13 +241,23 @@ class CodexRunner:
         logger.debug("inject_tool_result called on CodexRunner (no-op): %s", request_id)
 
     def _build_args(self, prompt: str, session_id: str | None) -> list[str]:
-        """Build command-line arguments for codex CLI."""
+        """Build command-line arguments for codex CLI.
+
+        Codex CLI structure (verified against v0.124):
+            codex exec [OPTIONS] [PROMPT]
+            codex exec resume [OPTIONS] [SESSION_ID] [PROMPT]
+
+        Both subcommands accept --json and --model. The resume positional
+        args come AFTER any flags, with SESSION_ID before PROMPT.
+        """
+        # Always under the `exec` subcommand. `resume` is its sub-subcommand.
+        args = [self.command, "exec"]
         if session_id:
             if not re.match(r"^[a-f0-9\-]+$", session_id):
                 raise ValueError(f"Invalid session_id format: {session_id!r}")
-            args = [self.command, "resume", session_id, "--json", "--model", self.model]
-        else:
-            args = [self.command, "exec", "--json", "--model", self.model]
+            args.append("resume")
+
+        args.extend(["--json", "--model", self.model])
 
         if self.dangerously_skip_permissions:
             args.append("--dangerously-bypass-approvals-and-sandbox")
@@ -257,6 +267,9 @@ class CodexRunner:
         if self.working_dir:
             args.extend(["--cd", self.working_dir])
 
+        # Positional args come last. For resume: SESSION_ID then PROMPT.
+        if session_id:
+            args.append(session_id)
         args.append(prompt)
         return args
 

--- a/claude_discord/backend_settings.py
+++ b/claude_discord/backend_settings.py
@@ -60,6 +60,25 @@ class BackendSettings:
             return v
         return self._env_backend
 
+    async def explicit_model(self, backend: str, thread_id: int | None = None) -> str | None:
+        """Return only the EXPLICITLY-stored model — env fallback is NOT consulted.
+
+        Use this when callers want to distinguish 'user explicitly set a
+        per-backend model via /model' from 'we fell back to whatever was
+        in .env'. ``current_model()`` mixes those two together; this
+        method keeps them apart.
+
+        Resolution: thread > global > None.
+        """
+        if backend not in ALL_BACKENDS:
+            return None
+        if thread_id is not None:
+            v = await self.repo.get(f"{MODEL_THREAD_PREFIX}{thread_id}.{backend}")
+            if v:
+                return v
+        v = await self.repo.get(f"{MODEL_GLOBAL_PREFIX}{backend}")
+        return v if v else None
+
     async def current_model(self, backend: str, thread_id: int | None = None) -> str | None:
         """Return the model for the given backend, or None if no override.
 

--- a/claude_discord/cogs/backend_command.py
+++ b/claude_discord/cogs/backend_command.py
@@ -137,8 +137,32 @@ class BackendCommandCog(commands.Cog):
             )
             return
 
-        # Persist
+        # Persist the new backend. Capture the previous one first so we can
+        # detect a real change (and decide whether to wipe the thread's
+        # stored session ID, which is not interoperable across backends).
+        prev_backend = await self._settings.current_backend(target_thread_id)
         await self._settings.set_backend(name, thread_id=target_thread_id)
+
+        # When the EFFECTIVE backend actually changed, drop any stored
+        # session ID so the next message starts a fresh session in the new
+        # backend. Codex and Claude session stores are not interoperable
+        # (passing a Claude session UUID to `codex exec resume` -- or vice
+        # versa -- fails at the CLI level).
+        if prev_backend != name and target_thread_id is not None:
+            try:
+                deleted = await self._chat_cog.repo.delete(target_thread_id)
+                if deleted:
+                    logger.info(
+                        "Cleared stored session for thread %d on backend switch %s -> %s",
+                        target_thread_id,
+                        prev_backend,
+                        name,
+                    )
+            except Exception:
+                logger.exception(
+                    "Failed to clear thread %d session on backend change",
+                    target_thread_id,
+                )
 
         # If global change, also swap the shared default runner so the next
         # ClaudeChatCog session inherits it (thread overrides will be honoured

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -300,9 +300,26 @@ class ClaudeChatCog(commands.Cog):
             )
 
         backend = await self._backend_settings.current_backend(thread_id)
-        if model_override:
-            model: str | None = model_override
+
+        # Model resolution order:
+        # 1. Explicit /model command value for THIS backend (thread > global).
+        #    Env fallback is NOT considered yet — see step 3.
+        # 2. Legacy /model-set value (passed in as ``model_override``).
+        #    Honoured only when the current backend is claude. Passing a
+        #    Claude model id to Codex would cause `codex exec` to fail
+        #    with an unknown model error.
+        # 3. Env-derived per-backend default, then the factory's hard-coded
+        #    default (sonnet for claude, gpt-5.4 for codex). Returned as
+        #    None here so factory.build() picks the right one.
+        explicit_model = await self._backend_settings.explicit_model(backend, thread_id)
+        model: str | None
+        if explicit_model:
+            model = explicit_model
+        elif model_override and backend == "claude":
+            model = model_override
         else:
+            # Fall back to env-set default (current_model() exposes it),
+            # or None for the factory to choose.
             model = await self._backend_settings.current_model(backend, thread_id)
 
         runner = self._factory.build(

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -481,20 +481,24 @@ class EventProcessor:
                 if self._config.status:
                     await self._config.status.set_done()
 
-                # Post the user's configured statusLine as Discord subtext.
-                # Runs only when statusLine.command is set in ~/.claude/settings.json.
-                asyncio.create_task(
-                    _post_statusline_footer(
-                        thread=self._config.thread,
-                        working_dir=self._config.runner.working_dir,
-                        model=self._config.runner.model,
-                        context_window=event.context_window,
-                        input_tokens=event.input_tokens,
-                        cache_creation_tokens=event.cache_creation_tokens,
-                        cache_read_tokens=event.cache_read_tokens,
-                    ),
-                    name=f"statusline-{self._config.thread.id}",
-                )
+                # Post the configured statusLine as Discord subtext. Only
+                # meaningful for the Claude backend — the statusLine command
+                # reads ~/.claude/settings.json and surfaces Anthropic-specific
+                # quota windows (5h, 7d) that have no Codex equivalent. Skip
+                # for non-claude backends entirely.
+                if _backend_name_from_runner(self._config.runner) == "claude":
+                    asyncio.create_task(
+                        _post_statusline_footer(
+                            thread=self._config.thread,
+                            working_dir=self._config.runner.working_dir,
+                            model=self._config.runner.model,
+                            context_window=event.context_window,
+                            input_tokens=event.input_tokens,
+                            cache_creation_tokens=event.cache_creation_tokens,
+                            cache_read_tokens=event.cache_read_tokens,
+                        ),
+                        name=f"statusline-{self._config.thread.id}",
+                    )
 
                 # Schedule inbox classification as a background task (non-blocking).
                 # Only runs when inbox_repo is wired in (THREAD_INBOX_ENABLED=true).

--- a/tests/test_backend_command_session_clear.py
+++ b/tests/test_backend_command_session_clear.py
@@ -1,0 +1,138 @@
+"""Tests for BackendCommandCog clear-thread-session-on-backend-change."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import aiosqlite
+import discord
+
+from claude_discord.backend_factory import BackendFactory
+from claude_discord.backend_settings import BackendSettings
+from claude_discord.cogs.backend_command import BackendCommandCog
+from claude_discord.database.settings_repo import SettingsRepository
+
+
+async def _new_settings_repo() -> SettingsRepository:
+    tmp = Path(tempfile.mkdtemp()) / "settings.db"
+    async with aiosqlite.connect(str(tmp)) as db:
+        await db.execute("CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+        await db.commit()
+    return SettingsRepository(str(tmp))
+
+
+def _make_cog(settings: BackendSettings) -> BackendCommandCog:
+    bot = MagicMock()
+    factory = BackendFactory(
+        claude_command="claude",
+        codex_command="codex",
+        permission_mode="acceptEdits",
+        working_dir=None,
+        timeout_seconds=300,
+        dangerously_skip_permissions=False,
+        allowed_tools=None,
+        append_system_prompt=None,
+        effort=None,
+    )
+    chat_cog = MagicMock()
+    chat_cog.runner = MagicMock()
+    chat_cog.runner.model = "sonnet"
+    chat_cog.repo = MagicMock()
+    chat_cog.repo.delete = AsyncMock(return_value=True)
+    cog = BackendCommandCog(bot, settings=settings, factory=factory, chat_cog=chat_cog)
+    return cog
+
+
+def _make_thread_interaction(thread_id: int) -> MagicMock:
+    interaction = MagicMock()
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = thread_id
+    interaction.channel = thread
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+class TestBackendCommandClearsSession:
+    """When /backend changes a thread's effective backend, the stored session
+    must be cleared so Codex doesn't try to resume a Claude session id (or
+    vice versa)."""
+
+    async def test_clears_session_on_thread_backend_change(self) -> None:
+        repo = await _new_settings_repo()
+        settings = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+        )
+        cog = _make_cog(settings)
+        interaction = _make_thread_interaction(thread_id=42)
+
+        # Run /backend codex scope:thread on a thread defaulting to claude.
+        await cog.backend_command.callback(cog, interaction, name="codex", scope="thread")
+
+        # The session for thread 42 should have been wiped.
+        cog._chat_cog.repo.delete.assert_awaited_once_with(42)
+
+    async def test_no_clear_when_backend_is_same(self) -> None:
+        repo = await _new_settings_repo()
+        settings = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+        )
+        # Thread is already on claude.
+        await settings.set_backend("claude", thread_id=42)
+        cog = _make_cog(settings)
+        interaction = _make_thread_interaction(thread_id=42)
+
+        # Setting it to claude again should not wipe the session.
+        await cog.backend_command.callback(cog, interaction, name="claude", scope="thread")
+
+        cog._chat_cog.repo.delete.assert_not_awaited()
+
+    async def test_clears_session_when_switching_back(self) -> None:
+        repo = await _new_settings_repo()
+        settings = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+        )
+        await settings.set_backend("codex", thread_id=42)
+        cog = _make_cog(settings)
+        interaction = _make_thread_interaction(thread_id=42)
+
+        # Now switching back to claude should also wipe.
+        await cog.backend_command.callback(cog, interaction, name="claude", scope="thread")
+
+        cog._chat_cog.repo.delete.assert_awaited_once_with(42)
+
+    async def test_global_change_does_not_clear_any_thread_session(self) -> None:
+        """A global /backend change must not wipe individual threads' sessions
+        (they may have explicit thread overrides). It only swaps the default
+        runner that fresh threads inherit."""
+        repo = await _new_settings_repo()
+        settings = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+        )
+        cog = _make_cog(settings)
+        # No thread in the interaction (global scope by definition).
+        interaction = MagicMock()
+        interaction.channel = MagicMock()  # NOT a discord.Thread
+        # Force not-a-thread by spec-less mock + isinstance check returning False.
+        # Easiest: skip channel handling and call with explicit scope.
+        interaction.response = MagicMock()
+        interaction.response.send_message = AsyncMock()
+
+        await cog.backend_command.callback(cog, interaction, name="codex", scope="global")
+
+        # Global change → no thread session deletes.
+        cog._chat_cog.repo.delete.assert_not_awaited()

--- a/tests/test_build_runner_for_thread.py
+++ b/tests/test_build_runner_for_thread.py
@@ -1,0 +1,300 @@
+"""Tests for ClaudeChatCog._build_runner_for_thread.
+
+Verifies backend-aware resolution, model precedence rules, fallback to
+legacy clone() when factory/settings are missing, and that overrides
+do not leak between backends (e.g. Claude model "opus" should not be
+passed through to a Codex spawn).
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import aiosqlite
+
+from claude_code_core.codex_runner import CodexRunner
+from claude_code_core.runner import ClaudeRunner
+from claude_discord.backend_factory import BackendFactory
+from claude_discord.backend_settings import BackendSettings
+from claude_discord.database.settings_repo import SettingsRepository
+
+
+async def _new_settings_repo() -> SettingsRepository:
+    tmp = Path(tempfile.mkdtemp()) / "settings.db"
+    async with aiosqlite.connect(str(tmp)) as db:
+        await db.execute("CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+        await db.commit()
+    return SettingsRepository(str(tmp))
+
+
+def _factory() -> BackendFactory:
+    return BackendFactory(
+        claude_command="claude",
+        codex_command="codex",
+        permission_mode="acceptEdits",
+        working_dir=None,
+        timeout_seconds=300,
+        dangerously_skip_permissions=False,
+        allowed_tools=None,
+        append_system_prompt=None,
+        effort=None,
+    )
+
+
+def _cog(*, factory: BackendFactory | None, settings: BackendSettings | None):
+    """Minimal stand-in for ClaudeChatCog that exposes _build_runner_for_thread."""
+    from claude_discord.cogs.claude_chat import ClaudeChatCog
+
+    # Skip the real __init__ — we only need the method bound to a mock self.
+    cog = ClaudeChatCog.__new__(ClaudeChatCog)
+    cog._factory = factory  # type: ignore[attr-defined]
+    cog._backend_settings = settings  # type: ignore[attr-defined]
+    # Provide a runner so the legacy fallback path is exercisable.
+    cog.runner = ClaudeRunner(command="claude", model="sonnet")  # type: ignore[attr-defined]
+    return cog
+
+
+class TestBuildRunnerLegacyFallback:
+    """Without factory + settings, must call self.runner.clone()."""
+
+    async def test_legacy_clone_called(self) -> None:
+        cog = _cog(factory=None, settings=None)
+        # Replace .runner with a magic mock so we can capture the clone call.
+        cog.runner = MagicMock()
+        cog.runner.clone.return_value = "CLONED"
+        result = await cog._build_runner_for_thread(
+            thread_id=42,
+            model_override=None,
+            tools_override=None,
+            fork_session=False,
+            working_dir_override=None,
+            effort_override=None,
+        )
+        assert result == "CLONED"
+        cog.runner.clone.assert_called_once()
+
+
+class TestBuildRunnerBackendResolution:
+    async def test_global_claude_default(self) -> None:
+        repo = await _new_settings_repo()
+        settings = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+        )
+        cog = _cog(factory=_factory(), settings=settings)
+        runner = await cog._build_runner_for_thread(
+            thread_id=1,
+            model_override=None,
+            tools_override=None,
+            fork_session=False,
+            working_dir_override=None,
+            effort_override=None,
+        )
+        assert isinstance(runner, ClaudeRunner)
+        assert runner.model == "sonnet"
+
+    async def test_thread_override_codex_returns_codex_runner(self) -> None:
+        repo = await _new_settings_repo()
+        settings = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+        )
+        await settings.set_backend("codex", thread_id=99)
+        cog = _cog(factory=_factory(), settings=settings)
+        runner = await cog._build_runner_for_thread(
+            thread_id=99,
+            model_override=None,
+            tools_override=None,
+            fork_session=False,
+            working_dir_override=None,
+            effort_override=None,
+        )
+        # The thread override pins backend=codex, so we should get a CodexRunner.
+        assert isinstance(runner, CodexRunner)
+        # No stored model for codex → factory default "gpt-5.4"
+        assert runner.model == "gpt-5.4"
+
+    async def test_other_thread_keeps_global(self) -> None:
+        repo = await _new_settings_repo()
+        settings = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+        )
+        await settings.set_backend("codex", thread_id=99)  # thread 99 only
+        cog = _cog(factory=_factory(), settings=settings)
+        # Thread 1 should still use global default (claude).
+        runner = await cog._build_runner_for_thread(
+            thread_id=1,
+            model_override=None,
+            tools_override=None,
+            fork_session=False,
+            working_dir_override=None,
+            effort_override=None,
+        )
+        assert isinstance(runner, ClaudeRunner)
+
+    async def test_global_codex_then_thread_keeps_codex(self) -> None:
+        repo = await _new_settings_repo()
+        settings = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+        )
+        await settings.set_backend("codex")  # global
+        cog = _cog(factory=_factory(), settings=settings)
+        runner = await cog._build_runner_for_thread(
+            thread_id=123,
+            model_override=None,
+            tools_override=None,
+            fork_session=False,
+            working_dir_override=None,
+            effort_override=None,
+        )
+        assert isinstance(runner, CodexRunner)
+
+
+class TestBuildRunnerModelResolution:
+    """The key regression: a stale Claude /model-set value MUST NOT leak
+    through to a Codex spawn, or codex CLI rejects the model name."""
+
+    async def test_legacy_model_override_does_not_leak_to_codex(self) -> None:
+        repo = await _new_settings_repo()
+        settings = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+        )
+        await settings.set_backend("codex", thread_id=7)
+        cog = _cog(factory=_factory(), settings=settings)
+        # User previously did /model-set opus while on claude. That value is
+        # passed as `model_override`. When the thread's backend is codex we
+        # must IGNORE it and fall back to the factory default.
+        runner = await cog._build_runner_for_thread(
+            thread_id=7,
+            model_override="opus",
+            tools_override=None,
+            fork_session=False,
+            working_dir_override=None,
+            effort_override=None,
+        )
+        assert isinstance(runner, CodexRunner)
+        assert runner.model == "gpt-5.4", (
+            "Claude model 'opus' must not leak through to a Codex spawn"
+        )
+
+    async def test_legacy_model_override_is_used_for_claude(self) -> None:
+        repo = await _new_settings_repo()
+        settings = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+        )
+        cog = _cog(factory=_factory(), settings=settings)
+        runner = await cog._build_runner_for_thread(
+            thread_id=1,
+            model_override="opus",
+            tools_override=None,
+            fork_session=False,
+            working_dir_override=None,
+            effort_override=None,
+        )
+        assert isinstance(runner, ClaudeRunner)
+        assert runner.model == "opus"
+
+    async def test_per_backend_stored_model_takes_priority(self) -> None:
+        repo = await _new_settings_repo()
+        settings = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+        )
+        await settings.set_backend("codex", thread_id=5)
+        # User explicitly set codex model via /model command for this thread.
+        await settings.set_model("codex", "o4-mini", thread_id=5)
+        cog = _cog(factory=_factory(), settings=settings)
+        runner = await cog._build_runner_for_thread(
+            thread_id=5,
+            model_override="opus",  # legacy /model-set leftover — should be ignored
+            tools_override=None,
+            fork_session=False,
+            working_dir_override=None,
+            effort_override=None,
+        )
+        assert isinstance(runner, CodexRunner)
+        assert runner.model == "o4-mini"
+
+
+class TestBuildRunnerPerCallOverrides:
+    async def test_allowed_tools_applied(self) -> None:
+        repo = await _new_settings_repo()
+        settings = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+        )
+        cog = _cog(factory=_factory(), settings=settings)
+        runner = await cog._build_runner_for_thread(
+            thread_id=1,
+            model_override=None,
+            tools_override=["Read", "Glob"],
+            fork_session=False,
+            working_dir_override=None,
+            effort_override=None,
+        )
+        assert runner.allowed_tools == ["Read", "Glob"]
+
+    async def test_working_dir_applied(self) -> None:
+        repo = await _new_settings_repo()
+        settings = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+        )
+        cog = _cog(factory=_factory(), settings=settings)
+        runner = await cog._build_runner_for_thread(
+            thread_id=1,
+            model_override=None,
+            tools_override=None,
+            fork_session=False,
+            working_dir_override="/work",
+            effort_override=None,
+        )
+        assert runner.working_dir == "/work"
+
+    async def test_effort_only_on_claude(self) -> None:
+        """Codex doesn't expose .effort; the helper must not set it."""
+        repo = await _new_settings_repo()
+        settings = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+        )
+        await settings.set_backend("codex", thread_id=11)
+        cog = _cog(factory=_factory(), settings=settings)
+        runner = await cog._build_runner_for_thread(
+            thread_id=11,
+            model_override=None,
+            tools_override=None,
+            fork_session=False,
+            working_dir_override=None,
+            effort_override="high",
+        )
+        # CodexRunner does not have an effort attribute — must not raise,
+        # and the attribute must not be set (or be None) on a fresh codex runner.
+        assert isinstance(runner, CodexRunner)
+        assert not hasattr(runner, "effort") or getattr(runner, "effort", None) is None

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -204,3 +204,100 @@ class TestParseCodexLine:
         assert event is not None
         assert event.error is not None
         assert event.is_complete is True
+
+
+class TestCodexRunnerArgvStructure:
+    """Strict structural tests — verify args match codex CLI's actual grammar.
+
+    Codex CLI v0.124 grammar (verified against ``codex exec --help`` /
+    ``codex exec resume --help``):
+
+        codex exec [OPTIONS] [PROMPT]
+        codex exec resume [OPTIONS] [SESSION_ID] [PROMPT]
+
+    Both subcommands accept ``--json``, ``--model``, ``--ask-for-approval``,
+    ``--dangerously-bypass-approvals-and-sandbox``, ``--cd``. The resume
+    positional args come AFTER all flags, with SESSION_ID before PROMPT.
+
+    These tests guard against regressions like the one that shipped briefly
+    in 3.0.0 where resume was invoked as ``codex resume <id> --json …`` —
+    a structure codex rejects with ``error: unexpected argument '--json'
+    found``.
+    """
+
+    def test_new_session_starts_with_exec(self) -> None:
+        runner = CodexRunner(command="codex", model="gpt-5.4")
+        args = runner._build_args("prompt", session_id=None)
+        # First positional must be the command, second must be 'exec',
+        # and 'resume' must NOT appear when starting a new session.
+        assert args[0] == "codex"
+        assert args[1] == "exec"
+        assert "resume" not in args
+
+    def test_resume_starts_with_exec_resume(self) -> None:
+        sid = "019e29a0-d5b0-71f0-bdc0-46f09a06fdaf"
+        runner = CodexRunner(command="codex", model="gpt-5.4")
+        args = runner._build_args("prompt", session_id=sid)
+        # The first three tokens must be exactly: codex exec resume
+        assert args[:3] == ["codex", "exec", "resume"], (
+            f"Codex resume must be invoked as `codex exec resume`, got: {args[:3]!r}"
+        )
+
+    def test_resume_flags_precede_session_id(self) -> None:
+        sid = "019e29a0-d5b0-71f0-bdc0-46f09a06fdaf"
+        runner = CodexRunner(
+            command="codex",
+            model="gpt-5.4",
+            permission_mode="acceptEdits",
+            working_dir="/work",
+        )
+        args = runner._build_args("hello", session_id=sid)
+        sid_idx = args.index(sid)
+        # --json, --model, --ask-for-approval, --cd must all come before SESSION_ID.
+        for flag in ("--json", "--model", "--ask-for-approval", "--cd"):
+            assert flag in args, f"{flag} missing from resume args"
+            assert args.index(flag) < sid_idx, (
+                f"{flag} should appear before SESSION_ID in codex exec resume"
+            )
+
+    def test_resume_session_id_before_prompt(self) -> None:
+        sid = "019e29a0-d5b0-71f0-bdc0-46f09a06fdaf"
+        runner = CodexRunner(command="codex", model="gpt-5.4")
+        args = runner._build_args("hello-prompt", session_id=sid)
+        # SESSION_ID must come BEFORE PROMPT in `codex exec resume`.
+        assert args.index(sid) < args.index("hello-prompt"), (
+            "SESSION_ID must precede PROMPT in codex exec resume"
+        )
+
+    def test_prompt_is_always_last(self) -> None:
+        runner = CodexRunner(command="codex", model="gpt-5.4")
+        # New session
+        args = runner._build_args("the-prompt", session_id=None)
+        assert args[-1] == "the-prompt"
+        # Resume
+        args = runner._build_args("the-prompt", session_id="019e29a0-d5b0-71f0-bdc0-46f09a06fdaf")
+        assert args[-1] == "the-prompt"
+
+    def test_dangerously_bypass_flag_for_resume(self) -> None:
+        sid = "019e29a0-d5b0-71f0-bdc0-46f09a06fdaf"
+        runner = CodexRunner(
+            command="codex",
+            model="gpt-5.4",
+            dangerously_skip_permissions=True,
+        )
+        args = runner._build_args("hi", session_id=sid)
+        assert "--dangerously-bypass-approvals-and-sandbox" in args
+        # Must precede SESSION_ID like the other flags
+        assert args.index("--dangerously-bypass-approvals-and-sandbox") < args.index(sid)
+
+    def test_no_lingering_resume_top_level_form(self) -> None:
+        """`codex resume` (without `exec`) is NOT a valid codex CLI form."""
+        sid = "019e29a0-d5b0-71f0-bdc0-46f09a06fdaf"
+        runner = CodexRunner(command="codex", model="gpt-5.4")
+        args = runner._build_args("hi", session_id=sid)
+        # If 'resume' appears at index 1, that means we built `codex resume <id>`
+        # which is rejected by codex. Must be at index 2 (after `exec`).
+        if "resume" in args:
+            assert args.index("resume") == 2, (
+                f"resume must follow exec at index 2, got index {args.index('resume')}"
+            )


### PR DESCRIPTION
## Summary

The Codex backend looked done in 3.0.0 but the **basic `/backend codex` → send a message → get a Codex reply** flow was broken. This PR fixes the three real bugs and — importantly — adds the test coverage that should have caught them.

> Context: a user switched a thread to Codex and the bot replied `❌ Error / CLI exited with code 2`. Root cause below.

## Bugs fixed

### 1. CodexRunner resume argv was invalid
- Was: `codex resume <id> --json --model <m> <prompt>`
- codex rejects it: `error: unexpected argument '--json' found`
- `resume` is a sub-subcommand of `exec`. Correct grammar (verified against codex v0.124): `codex exec resume [OPTIONS] <SESSION_ID> <PROMPT>`.
- `_build_args` now always emits `codex exec`, appends `resume` when a session id is present, places all flags before the positional `SESSION_ID`, and `PROMPT` last.

### 2. Claude model leaked into Codex spawns
- After `/backend codex`, a stale `/model-set opus` value was passed straight to codex → unknown-model failure.
- `ClaudeChatCog._build_runner_for_thread` now resolves model as: explicit per-backend `/model` value → legacy `/model-set` (claude only) → env default → factory default. The legacy override is ignored for non-claude backends.
- New `BackendSettings.explicit_model()` returns only the explicitly-stored model (no env fallback), so the helper can distinguish "user chose this" from ".env default".

### 3. Claude statusLine shown for Codex sessions
- The post-completion subtext (📁/💪/🧠 with Anthropic 5h/7d quota windows) is read from `~/.claude/settings.json` and is meaningless for Codex.
- `event_processor` now only schedules `_post_statusline_footer` when the runner is the claude backend.

## Session handling

`BackendCommandCog` clears the thread's stored session id when `/backend` changes the effective backend for that thread. Codex and Claude session stores are not interoperable — resuming a Claude session id under `codex exec resume` (or vice versa) fails. After a switch, the next message starts a fresh session.

## Tests added (22 new, all CI-safe — no codex CLI needed)

- **`test_codex_runner.py`** — +7 strict argv-structure tests (`TestCodexRunnerArgvStructure`). These fail on the old `codex resume …` form, so the regression cannot silently come back. The pre-existing argv tests were too loose (`"resume" in args`) and passed even with the broken command.
- **`test_build_runner_for_thread.py`** — 11 tests: backend resolution (thread/global/env), model precedence, the **legacy-override-must-not-leak-to-codex** regression, per-call overrides, and the legacy `clone()` fallback path.
- **`test_backend_command_session_clear.py`** — 4 tests for clear-session-on-backend-change.

## Verification

- [x] `pyright` / `ruff format` / `ruff check` — clean
- [x] `pytest --ignore=tests/integration` — **1395 passed** (+22)
- [x] Standalone E2E on moviegen — `codex exec` (new) and `codex exec resume <id>` both stream events and complete without error
- [x] Live on moviegen via dev-worktree — `/backend codex` in a thread → OpenAI-teal "🌀 OpenAI Codex session started" embed → Codex reply; no Claude statusLine subtext posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
