### PR TITLE
fix: load .env from CWD and honor --env flag (#398)

### DIFF
--- a/claude_discord/cli.py
+++ b/claude_discord/cli.py
@@ -342,7 +342,10 @@ async def _run_start(env_path: Path) -> None:
         print("    Run 'ccdb setup' first to create it.", file=sys.stderr)
         sys.exit(1)
 
-    # Import and run the existing main() from claude_discord.main
+    from dotenv import load_dotenv
+
+    load_dotenv(env_path)
+
     from claude_discord.main import main as bot_main
 
     await bot_main()

--- a/claude_discord/main.py
+++ b/claude_discord/main.py
@@ -14,7 +14,7 @@ import signal
 import sys
 from pathlib import Path
 
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 
 from claude_code_core.backend import create_backend
 
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 def load_config() -> dict[str, str]:
     """Load and validate configuration from environment."""
-    load_dotenv()
+    load_dotenv(find_dotenv(usecwd=True))
 
     token = os.getenv("DISCORD_BOT_TOKEN", "")
     if not token:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -292,3 +292,62 @@ class TestMain:
             main()
             assert "CUSTOM_COGS_DIR" not in os.environ or os.environ["CUSTOM_COGS_DIR"] == ""
             mock_start.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _run_start — .env loading (Issue #398)
+# ---------------------------------------------------------------------------
+
+
+class TestRunStartEnvLoading:
+    """Regression tests for Issue #398: .env not loaded from --env path."""
+
+    @pytest.mark.asyncio
+    async def test_run_start_loads_dotenv_from_explicit_path(self, tmp_path: Path) -> None:
+        """_run_start must call load_dotenv(env_path) so vars are available to main."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("DISCORD_BOT_TOKEN=test-token-123\nDISCORD_CHANNEL_ID=999\n")
+
+        with (
+            patch("dotenv.load_dotenv") as mock_load_dotenv,
+            patch("claude_discord.main.main", new_callable=AsyncMock) as mock_main,
+        ):
+            from claude_discord.cli import _run_start
+
+            await _run_start(env_file)
+            mock_load_dotenv.assert_any_call(env_file)
+            mock_main.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_run_start_exits_when_env_missing(self, tmp_path: Path) -> None:
+        """_run_start must exit with error when .env does not exist."""
+        from claude_discord.cli import _run_start
+
+        missing = tmp_path / "nonexistent.env"
+        with pytest.raises(SystemExit):
+            await _run_start(missing)
+
+
+# ---------------------------------------------------------------------------
+# load_config — .env discovery from CWD (Issue #398)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfigCwd:
+    """Regression tests for Issue #398: load_config must find .env in CWD."""
+
+    def test_load_config_uses_usecwd(self) -> None:
+        """load_config must pass usecwd=True so .env is found relative to CWD."""
+        with patch("claude_discord.main.load_dotenv") as mock_ld:
+            mock_ld.return_value = True
+            with (
+                patch.dict(
+                    "os.environ",
+                    {"DISCORD_BOT_TOKEN": "tok", "DISCORD_CHANNEL_ID": "123"},
+                ),
+            ):
+                from claude_discord.main import load_config
+
+                load_config()
+            args, kwargs = mock_ld.call_args
+            assert kwargs.get("usecwd") is True or (args and args[0] is not None)


### PR DESCRIPTION
## Summary

Fixes #398 — `ccdb start` fails with `DISCORD_BOT_TOKEN is required` even when a valid `.env` exists in the current working directory. The `--env PATH` flag was also silently ignored.

### Root cause

- `load_dotenv()` without args calls `find_dotenv(usecwd=False)`, which searches upward from `__file__` (inside `site-packages/claude_discord/`), not from the user's CWD
- `_run_start(env_path)` checked if the env file exists but never passed the path to `load_dotenv()`

### Fix

- **`cli.py`**: Call `load_dotenv(env_path)` in `_run_start()` before importing `main`, so `--env PATH` actually takes effect
- **`main.py`**: Pass `usecwd=True` via `find_dotenv()` so standalone `python -m claude_discord.main` also finds `.env` in CWD

Since `python-dotenv` doesn't override existing vars by default, the two calls compose safely.

### Credit

Root cause analysis and suggested fix by @bomber555 in #398.

## Test plan

- [x] 3 regression tests added (RED→GREEN verified)
- [x] All 19 CLI tests pass
- [x] ruff check + format clean
- [ ] CI passes on all Python versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)