### PR TITLE
fix: propagate api_port through BackendFactory to spawned runners

### DIFF
--- a/claude_discord/backend_factory.py
+++ b/claude_discord/backend_factory.py
@@ -40,6 +40,8 @@ class BackendFactory:
         allowed_tools: list[str] | None,
         append_system_prompt: str | None,
         effort: str | None,
+        api_port: int | None = None,
+        api_secret: str | None = None,
     ) -> None:
         self.claude_command = claude_command or DEFAULT_COMMAND["claude"]
         self.codex_command = codex_command or DEFAULT_COMMAND["codex"]
@@ -50,6 +52,8 @@ class BackendFactory:
         self.allowed_tools = allowed_tools
         self.append_system_prompt = append_system_prompt
         self.effort = effort
+        self.api_port = api_port
+        self.api_secret = api_secret
 
     def command_for(self, backend: str) -> str:
         if backend == "claude":
@@ -87,6 +91,10 @@ class BackendFactory:
             kwargs["append_system_prompt"] = self.append_system_prompt
         if self.effort is not None:
             kwargs["effort"] = self.effort
+        if self.api_port is not None:
+            kwargs["api_port"] = self.api_port
+        if self.api_secret is not None:
+            kwargs["api_secret"] = self.api_secret
         runner = create_backend(backend=backend, model=chosen_model, **kwargs)
         logger.debug("Built %s runner (model=%s, thread_id=%s)", backend, chosen_model, thread_id)
         return runner

--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -371,6 +371,8 @@ async def setup_bridge(
         components.apply_to_api_server(api_server)
         if runner.api_port is None:
             runner.api_port = api_server.port
+        if backend_factory is not None and backend_factory.api_port is None:
+            backend_factory.api_port = api_server.port
         logger.info("Auto-wired repos to ApiServer (port=%d)", api_server.port)
 
     return components

--- a/tests/test_backend_factory_api_port.py
+++ b/tests/test_backend_factory_api_port.py
@@ -1,0 +1,71 @@
+"""Tests for BackendFactory api_port / api_secret propagation.
+
+Verifies that factory-built runners inherit api_port and api_secret so
+CCDB_API_URL is injected into the subprocess environment.
+"""
+
+from __future__ import annotations
+
+from claude_code_core.runner import ClaudeRunner
+from claude_discord.backend_factory import BackendFactory
+
+
+def _factory(**overrides: object) -> BackendFactory:
+    defaults: dict[str, object] = {
+        "claude_command": "claude",
+        "codex_command": "codex",
+        "permission_mode": "acceptEdits",
+        "working_dir": None,
+        "timeout_seconds": 300,
+        "dangerously_skip_permissions": False,
+        "allowed_tools": None,
+        "append_system_prompt": None,
+        "effort": None,
+    }
+    defaults.update(overrides)
+    return BackendFactory(**defaults)  # type: ignore[arg-type]
+
+
+class TestFactoryApiPort:
+    def test_build_passes_api_port_to_runner(self) -> None:
+        factory = _factory(api_port=8099)
+        runner = factory.build(backend="claude")
+        assert runner.api_port == 8099
+
+    def test_build_passes_api_secret_to_runner(self) -> None:
+        factory = _factory(api_port=8099, api_secret="s3cret")
+        runner = factory.build(backend="claude")
+        assert isinstance(runner, ClaudeRunner)
+        assert runner.api_secret == "s3cret"
+
+    def test_build_without_api_port_leaves_none(self) -> None:
+        factory = _factory()
+        runner = factory.build(backend="claude")
+        assert runner.api_port is None
+
+    def test_api_port_in_env(self) -> None:
+        factory = _factory(api_port=8099)
+        runner = factory.build(backend="claude")
+        env = runner._build_env()
+        assert env["CCDB_API_URL"] == "http://127.0.0.1:8099"
+
+    def test_no_api_port_means_no_env_var(self) -> None:
+        factory = _factory()
+        runner = factory.build(backend="claude")
+        env = runner._build_env()
+        assert "CCDB_API_URL" not in env
+
+    def test_api_port_set_after_init(self) -> None:
+        """setup_bridge sets factory.api_port after construction."""
+        factory = _factory()
+        assert factory.api_port is None
+        factory.api_port = 9090
+        runner = factory.build(backend="claude")
+        assert runner.api_port == 9090
+
+    def test_codex_backend_also_gets_api_port(self) -> None:
+        factory = _factory(api_port=8099)
+        runner = factory.build(backend="codex")
+        assert runner.api_port == 8099
+        env = runner._build_env()
+        assert env["CCDB_API_URL"] == "http://127.0.0.1:8099"

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -288,6 +288,74 @@ async def test_setup_bridge_preserves_existing_runner_api_port(tmp_path: object)
 
 
 @pytest.mark.asyncio
+async def test_setup_bridge_sets_factory_api_port(tmp_path: object) -> None:
+    """setup_bridge(api_server=...) should also set backend_factory.api_port."""
+    from claude_discord.backend_factory import BackendFactory
+
+    bot = _make_bot()
+    runner = _make_runner()
+    runner.api_port = None
+    api_server = _make_api_server()
+    factory = BackendFactory(
+        claude_command="claude",
+        codex_command="codex",
+        permission_mode="acceptEdits",
+        working_dir=None,
+        timeout_seconds=300,
+        dangerously_skip_permissions=False,
+        allowed_tools=None,
+        append_system_prompt=None,
+        effort=None,
+    )
+
+    await setup_bridge(
+        bot,
+        runner,
+        api_server=api_server,
+        backend_factory=factory,
+        session_db_path=str(tmp_path / "sessions.db"),  # type: ignore[operator]
+        enable_scheduler=False,
+    )
+
+    assert factory.api_port == api_server.port
+
+
+@pytest.mark.asyncio
+async def test_setup_bridge_preserves_existing_factory_api_port(tmp_path: object) -> None:
+    """setup_bridge should not overwrite factory.api_port if already set."""
+    from claude_discord.backend_factory import BackendFactory
+
+    bot = _make_bot()
+    runner = _make_runner()
+    runner.api_port = None
+    api_server = _make_api_server()
+    api_server.port = 8099
+    factory = BackendFactory(
+        claude_command="claude",
+        codex_command="codex",
+        permission_mode="acceptEdits",
+        working_dir=None,
+        timeout_seconds=300,
+        dangerously_skip_permissions=False,
+        allowed_tools=None,
+        append_system_prompt=None,
+        effort=None,
+        api_port=7777,
+    )
+
+    await setup_bridge(
+        bot,
+        runner,
+        api_server=api_server,
+        backend_factory=factory,
+        session_db_path=str(tmp_path / "sessions.db"),  # type: ignore[operator]
+        enable_scheduler=False,
+    )
+
+    assert factory.api_port == 7777
+
+
+@pytest.mark.asyncio
 async def test_setup_bridge_passes_max_concurrent_to_chat_cog(tmp_path: object) -> None:
     """max_concurrent parameter should be forwarded to ClaudeChatCog."""
     from claude_discord.cogs.claude_chat import ClaudeChatCog


### PR DESCRIPTION
## Summary
- `BackendFactory.build()` が `api_port` を渡さずにrunnerを生成していたため、全セッションで `CCDB_API_URL` が空になりラウンジ投稿や `curl $CCDB_API_URL` が全て失敗していた
- `BackendFactory` に `api_port` / `api_secret` フィールドを追加し、`build()` 時にrunnerへ伝播するよう修正
- `setup_bridge()` で `backend_factory.api_port` も自動セットするよう追加

## Test plan
- [x] 新規テスト7件追加（`test_backend_factory_api_port.py`）: factory経由のrunnerに api_port が渡ること、`_build_env()` で `CCDB_API_URL` が生成されること、Codexバックエンドでも動作すること
- [x] `test_setup.py` に2件追加: `setup_bridge` がfactoryにもapi_portをセットすること、既存値を上書きしないこと
- [x] 既存テスト114件の回帰なし確認済み
- [x] ruff check / ruff format パス
- [ ] dev-onでEbiBot動作確認 → ラウンジ投稿が成功すること