### PR TITLE
[docs-sync] Update BackendFactory docs for api_port/api_secret (#410 follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Concrete example:
 
 Behind the scenes:
 
-- `BackendFactory` — captures the static configuration at boot (per-backend command path, permission mode, working dir, allowed tools, timeout, append-system-prompt, effort) and builds a fresh `ClaudeRunner` or `CodexRunner` on demand.
+- `BackendFactory` — captures the static configuration at boot (per-backend command path, permission mode, working dir, allowed tools, timeout, append-system-prompt, effort, api_port, api_secret) and builds a fresh `ClaudeRunner` or `CodexRunner` on demand. `api_port` is wired automatically by `setup_bridge` after the REST API server starts, so factory-built runners always have `CCDB_API_URL` injected into their subprocess environment.
 - `BackendSettings` — thin wrapper over `SettingsRepository` that resolves the active backend with **thread > global > env** precedence and persists writes from the slash commands.
 - `SessionBackend` Protocol — the abstract interface that both runners satisfy. Internal plumbing (cogs, embeds, views, scheduler, webhook trigger) takes a `SessionBackend`, never one concrete runner class.
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -172,7 +172,7 @@ ccdb 3.0 では、Bot を再起動せずにどの AI が次のセッションを
 
 内部の仕組み:
 
-- `BackendFactory` — 起動時に静的な設定（バックエンドごとのコマンドパス、パーミッションモード、作業ディレクトリ、許可ツール、タイムアウト、append-system-prompt、effort）を取り込み、必要に応じて `ClaudeRunner` または `CodexRunner` を新規生成。
+- `BackendFactory` — 起動時に静的な設定（バックエンドごとのコマンドパス、パーミッションモード、作業ディレクトリ、許可ツール、タイムアウト、append-system-prompt、effort、api_port、api_secret）を取り込み、必要に応じて `ClaudeRunner` または `CodexRunner` を新規生成。`api_port` は REST API サーバー起動後に `setup_bridge` が自動で設定するため、Factory 経由で生成されたランナーは常に `CCDB_API_URL` がサブプロセス環境に注入される。
 - `BackendSettings` — **スレッド > グローバル > 環境変数**の優先順位でアクティブなバックエンドを解決し、スラッシュコマンドからの書き込みを永続化する `SettingsRepository` の薄いラッパー。
 - `SessionBackend` プロトコル — 両方のランナーが満たす抽象インターフェース。内部配管（Cog、embed、ビュー、スケジューラー、Webhook トリガー）は `SessionBackend` を受け取り、具体的なランナークラスには依存しない。
 


### PR DESCRIPTION
## Summary

- `BackendFactory` の説明を更新（英語 README）: `api_port` / `api_secret` パラメータを列挙し、`setup_bridge` による自動配線の挙動を明記
- 日本語 README (`docs/ja/README.md`) を同様に更新

## Motivation

PR #410 で `BackendFactory` に `api_port` / `api_secret` の伝播が実装されたが、英語・日本語ドキュメントのクラス説明がその変更を反映していなかった。

## Test plan

- [ ] `README.md` の `BackendFactory` 説明に `api_port`, `api_secret` が含まれている
- [ ] `docs/ja/README.md` の同箇所が日本語で正確に翻訳されている
- [ ] マークダウンの整形に問題がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
