### PR TITLE
feat: add stop hook event handling

### DIFF
--- a/claude_code_core/parser.py
+++ b/claude_code_core/parser.py
@@ -15,6 +15,7 @@ from .types import (
     AskQuestion,
     ContentBlockType,
     ElicitationRequest,
+    HookEvent,
     MessageType,
     PermissionRequest,
     RateLimitInfo,
@@ -60,7 +61,7 @@ def parse_line(line: str) -> StreamEvent | None:
     elif msg_type == MessageType.RESULT:
         _parse_result(data, event)
     elif msg_type == MessageType.PROGRESS:
-        pass  # No additional parsing needed — the event itself resets stall timers
+        _parse_progress(data, event)
     elif msg_type == MessageType.RATE_LIMIT_EVENT:
         _parse_rate_limit_event(data, event)
 
@@ -100,6 +101,26 @@ def _parse_system(data: dict[str, Any], event: StreamEvent) -> None:
             schema=data.get("schema", {}),
         )
         logger.info("MCP elicitation: %s (%s)", data.get("server_name"), data.get("mode"))
+    elif subtype == "stop_hook_summary":
+        event.stop_hook_has_output = bool(data.get("hasOutput", False))
+        logger.info("Stop hook summary (hasOutput=%s)", event.stop_hook_has_output)
+    elif subtype in ("hook_execution_start", "hook_execution_complete"):
+        lifecycle = "start" if subtype == "hook_execution_start" else "complete"
+        num_hooks_str = data.get("num_hooks", "0")
+        duration_str = data.get("total_duration_ms", "0")
+        event.hook_event = HookEvent(
+            hook_event_name=data.get("hook_event", ""),
+            hook_name=data.get("hook_name", ""),
+            lifecycle=lifecycle,
+            num_hooks=int(num_hooks_str) if num_hooks_str.isdigit() else 0,
+            duration_ms=int(duration_str) if duration_str.isdigit() else 0,
+        )
+        logger.info(
+            "Hook %s: %s (%d hooks)",
+            lifecycle,
+            data.get("hook_event"),
+            event.hook_event.num_hooks,
+        )
 
 
 def _parse_assistant(data: dict[str, Any], event: StreamEvent) -> None:
@@ -229,6 +250,20 @@ def _parse_result(data: dict[str, Any], event: StreamEvent) -> None:
         # not a normal session-complete display.
         event.error = result_text
         event.text = ""  # suppress duplicate display via result text path
+
+
+def _parse_progress(data: dict[str, Any], event: StreamEvent) -> None:
+    """Parse progress message — extract hook_progress data if present."""
+    progress_data = data.get("data", {})
+    if not isinstance(progress_data, dict):
+        return
+    if progress_data.get("type") == "hook_progress":
+        event.hook_event = HookEvent(
+            hook_event_name=progress_data.get("hookEvent", ""),
+            hook_name=progress_data.get("hookName", ""),
+            command=progress_data.get("command", ""),
+            status_message=progress_data.get("statusMessage", ""),
+        )
 
 
 def _parse_rate_limit_event(data: dict[str, Any], event: StreamEvent) -> None:

--- a/claude_code_core/runner.py
+++ b/claude_code_core/runner.py
@@ -292,6 +292,8 @@ class ClaudeRunner:
         if self.include_partial_messages:
             args.append("--include-partial-messages")
 
+        args.append("--include-hook-events")
+
         if self.dangerously_skip_permissions and self.permission_mode not in (
             "auto",
             "plan",

--- a/claude_code_core/types.py
+++ b/claude_code_core/types.py
@@ -176,6 +176,19 @@ class ToolUseEvent:
 
 
 @dataclass
+class HookEvent:
+    """Parsed hook lifecycle event from stream-json."""
+
+    hook_event_name: str  # "Stop", "PreToolUse", etc.
+    hook_name: str = ""
+    command: str = ""
+    status_message: str = ""
+    lifecycle: str = ""  # "start", "complete", or "" for progress
+    num_hooks: int = 0
+    duration_ms: int = 0
+
+
+@dataclass
 class StreamEvent:
     """A parsed event from the Claude Code stream-json output."""
 
@@ -207,3 +220,5 @@ class StreamEvent:
     context_window: int | None = None
     error: str | None = None
     rate_limit_info: RateLimitInfo | None = None
+    hook_event: HookEvent | None = None
+    stop_hook_has_output: bool = False

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -266,6 +266,11 @@ class EventProcessor:
             await self._handle_elicitation(event)
             return
 
+        # Hook lifecycle events (--include-hook-events)
+        if event.hook_event is not None:
+            await self._handle_hook_lifecycle(event)
+            return
+
         if not event.session_id:
             return
 
@@ -397,7 +402,10 @@ class EventProcessor:
                 logger.warning("Failed to clear tool in-progress indicator", exc_info=True)
 
     async def _on_progress(self, event: StreamEvent) -> None:
-        """Handle PROGRESS events — reset stall timer (compact in progress)."""
+        """Handle PROGRESS events — reset stall timer, show hook status."""
+        if event.hook_event is not None and self._config.status:
+            await self._config.status.set_hook(event.hook_event.hook_event_name)
+            return
         if self._config.status:
             self._config.status._reset_stall_timer()
 
@@ -681,6 +689,33 @@ class EventProcessor:
             logger.warning(
                 "Failed to post todo embed; will retry on next TodoWrite call", exc_info=True
             )
+
+    async def _handle_hook_lifecycle(self, event: StreamEvent) -> None:
+        """Show hook execution start/complete as Discord subtext."""
+        assert event.hook_event is not None
+        he = event.hook_event
+
+        if self._chat_only:
+            if self._config.status and he.lifecycle == "start":
+                await self._config.status.set_hook(he.hook_event_name)
+            return
+
+        if he.lifecycle == "start":
+            label = f"\U0001fa9d {he.hook_event_name} hooks running ({he.num_hooks})"
+            if self._config.status:
+                await self._config.status.set_hook(he.hook_event_name)
+        elif he.lifecycle == "complete":
+            dur = he.duration_ms
+            label = f"\U0001fa9d {he.hook_event_name} hooks completed"
+            if dur:
+                label += f" ({dur}ms)"
+            if self._config.status:
+                await self._config.status.set_thinking()
+        else:
+            return
+
+        with contextlib.suppress(discord.HTTPException):
+            await self._config.thread.send(f"-# {label}")
 
     async def _bump_stop(self) -> None:
         """Move the Stop button to the bottom of the thread if configured."""

--- a/claude_discord/discord_ui/status.py
+++ b/claude_discord/discord_ui/status.py
@@ -27,6 +27,7 @@ EMOJI_ERROR = "\u274c"  # ❌
 EMOJI_STALL_SOFT = "\u23f3"  # ⏳
 EMOJI_STALL_HARD = "\u26a0\ufe0f"  # ⚠️
 EMOJI_COMPACT = "\U0001f5dc\ufe0f"  # 🗜️
+EMOJI_HOOK = "\U0001fa9d"  # 🪝
 
 # Tool category to emoji
 CATEGORY_EMOJI: dict[ToolCategory, str] = {
@@ -98,6 +99,11 @@ class StatusManager:
         # Hold done emoji briefly, then clean up
         await asyncio.sleep(1.5)
         await self.cleanup()
+
+    async def set_hook(self, hook_event: str = "") -> None:
+        """Set status to hook running."""
+        await self._set_status(EMOJI_HOOK)
+        self._reset_stall_timer()
 
     async def set_compact(self) -> None:
         """Set status to compacting (context compression in progress)."""

--- a/tests/test_hook_events.py
+++ b/tests/test_hook_events.py
@@ -1,0 +1,272 @@
+"""Tests for hook event parsing and processing."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from claude_code_core.parser import parse_line
+from claude_code_core.types import HookEvent, MessageType, StreamEvent
+
+
+class TestHookProgressParsing:
+    """Tests for hook_progress events in progress messages."""
+
+    def test_hook_progress_parsed(self) -> None:
+        line = json.dumps(
+            {
+                "type": "progress",
+                "data": {
+                    "type": "hook_progress",
+                    "hookEvent": "Stop",
+                    "hookName": "Stop:*",
+                    "command": "~/.claude/hooks/check-uncommitted.sh",
+                },
+            }
+        )
+        event = parse_line(line)
+        assert event is not None
+        assert event.message_type == MessageType.PROGRESS
+        assert event.hook_event is not None
+        assert event.hook_event.hook_event_name == "Stop"
+        assert event.hook_event.hook_name == "Stop:*"
+        assert event.hook_event.command == "~/.claude/hooks/check-uncommitted.sh"
+
+    def test_hook_progress_with_status_message(self) -> None:
+        line = json.dumps(
+            {
+                "type": "progress",
+                "data": {
+                    "type": "hook_progress",
+                    "hookEvent": "Stop",
+                    "hookName": "Stop:*",
+                    "command": "evaluate-session.sh",
+                    "statusMessage": "Evaluating session patterns...",
+                },
+            }
+        )
+        event = parse_line(line)
+        assert event is not None
+        assert event.hook_event is not None
+        assert event.hook_event.status_message == "Evaluating session patterns..."
+
+    def test_non_hook_progress_has_no_hook_event(self) -> None:
+        line = json.dumps(
+            {
+                "type": "progress",
+                "data": {"message": {"type": "assistant"}},
+            }
+        )
+        event = parse_line(line)
+        assert event is not None
+        assert event.hook_event is None
+
+    def test_progress_without_data(self) -> None:
+        line = json.dumps({"type": "progress"})
+        event = parse_line(line)
+        assert event is not None
+        assert event.hook_event is None
+
+
+class TestStopHookSummaryParsing:
+    """Tests for stop_hook_summary system events."""
+
+    def test_stop_hook_summary_with_output(self) -> None:
+        line = json.dumps(
+            {
+                "type": "system",
+                "subtype": "stop_hook_summary",
+                "hasOutput": True,
+                "hookEvent": "Stop",
+            }
+        )
+        event = parse_line(line)
+        assert event is not None
+        assert event.message_type == MessageType.SYSTEM
+        assert event.stop_hook_has_output is True
+
+    def test_stop_hook_summary_without_output(self) -> None:
+        line = json.dumps(
+            {
+                "type": "system",
+                "subtype": "stop_hook_summary",
+                "hasOutput": False,
+                "hookEvent": "Stop",
+            }
+        )
+        event = parse_line(line)
+        assert event is not None
+        assert event.stop_hook_has_output is False
+
+    def test_stop_hook_summary_default_no_output(self) -> None:
+        line = json.dumps(
+            {
+                "type": "system",
+                "subtype": "stop_hook_summary",
+            }
+        )
+        event = parse_line(line)
+        assert event is not None
+        assert event.stop_hook_has_output is False
+
+
+class TestHookLifecycleParsing:
+    """Tests for hook_execution_start and hook_execution_complete system events."""
+
+    def test_hook_execution_start(self) -> None:
+        line = json.dumps(
+            {
+                "type": "system",
+                "subtype": "hook_execution_start",
+                "hook_event": "Stop",
+                "hook_name": "Stop",
+                "num_hooks": "4",
+            }
+        )
+        event = parse_line(line)
+        assert event is not None
+        assert event.message_type == MessageType.SYSTEM
+        assert event.hook_event is not None
+        assert event.hook_event.hook_event_name == "Stop"
+        assert event.hook_event.lifecycle == "start"
+        assert event.hook_event.num_hooks == 4
+
+    def test_hook_execution_complete(self) -> None:
+        line = json.dumps(
+            {
+                "type": "system",
+                "subtype": "hook_execution_complete",
+                "hook_event": "Stop",
+                "hook_name": "Stop",
+                "num_hooks": "4",
+                "num_success": "3",
+                "num_blocking": "0",
+                "total_duration_ms": "1234",
+            }
+        )
+        event = parse_line(line)
+        assert event is not None
+        assert event.hook_event is not None
+        assert event.hook_event.lifecycle == "complete"
+        assert event.hook_event.num_hooks == 4
+        assert event.hook_event.duration_ms == 1234
+
+
+class TestRunnerIncludeHookEvents:
+    """Tests for --include-hook-events flag in runner."""
+
+    def test_include_hook_events_in_args(self) -> None:
+        from claude_code_core.runner import ClaudeRunner
+
+        runner = ClaudeRunner()
+        args = runner._build_args("hello", None)
+        assert "--include-hook-events" in args
+
+    def test_include_hook_events_with_session_resume(self) -> None:
+        from claude_code_core.runner import ClaudeRunner
+
+        runner = ClaudeRunner()
+        args = runner._build_args("hello", "abc-123")
+        assert "--include-hook-events" in args
+
+    def test_clone_preserves_include_hook_events(self) -> None:
+        from claude_code_core.runner import ClaudeRunner
+
+        runner = ClaudeRunner()
+        cloned = runner.clone()
+        args = cloned._build_args("hello", None)
+        assert "--include-hook-events" in args
+
+
+def _make_config(thread: MagicMock, runner: MagicMock, **kwargs):
+    from claude_discord.cogs.run_config import RunConfig
+
+    return RunConfig(thread=thread, runner=runner, prompt="test", **kwargs)
+
+
+class TestEventProcessorHookEvents:
+    """Tests for EventProcessor handling of hook events."""
+
+    @pytest.mark.asyncio
+    async def test_hook_progress_sets_status(self, thread: MagicMock, runner: MagicMock) -> None:
+        from claude_discord.cogs.event_processor import EventProcessor
+
+        status = MagicMock()
+        status.set_hook = AsyncMock()
+        config = _make_config(thread, runner, status=status)
+        proc = EventProcessor(config)
+
+        event = StreamEvent(
+            message_type=MessageType.PROGRESS,
+            hook_event=HookEvent(
+                hook_event_name="Stop",
+                hook_name="Stop:*",
+                command="check-uncommitted.sh",
+            ),
+        )
+        await proc.process(event)
+        status.set_hook.assert_awaited_once_with("Stop")
+
+    @pytest.mark.asyncio
+    async def test_hook_progress_without_status_is_noop(
+        self, thread: MagicMock, runner: MagicMock
+    ) -> None:
+        from claude_discord.cogs.event_processor import EventProcessor
+
+        config = _make_config(thread, runner)
+        proc = EventProcessor(config)
+
+        event = StreamEvent(
+            message_type=MessageType.PROGRESS,
+            hook_event=HookEvent(
+                hook_event_name="Stop",
+                hook_name="Stop:*",
+                command="check-uncommitted.sh",
+            ),
+        )
+        await proc.process(event)
+
+    @pytest.mark.asyncio
+    async def test_hook_lifecycle_start_sends_message(
+        self, thread: MagicMock, runner: MagicMock
+    ) -> None:
+        from claude_discord.cogs.event_processor import EventProcessor
+
+        config = _make_config(thread, runner)
+        proc = EventProcessor(config)
+
+        event = StreamEvent(
+            message_type=MessageType.SYSTEM,
+            hook_event=HookEvent(
+                hook_event_name="Stop",
+                lifecycle="start",
+                num_hooks=4,
+            ),
+        )
+        await proc.process(event)
+        thread.send.assert_awaited()
+        sent_text = thread.send.call_args[0][0]
+        assert "Stop" in sent_text
+        assert "4" in sent_text
+
+    @pytest.mark.asyncio
+    async def test_hook_lifecycle_start_skipped_in_chat_only(
+        self, thread: MagicMock, runner: MagicMock
+    ) -> None:
+        from claude_discord.cogs.event_processor import EventProcessor
+
+        config = _make_config(thread, runner, chat_only=True)
+        proc = EventProcessor(config)
+
+        event = StreamEvent(
+            message_type=MessageType.SYSTEM,
+            hook_event=HookEvent(
+                hook_event_name="Stop",
+                lifecycle="start",
+                num_hooks=4,
+            ),
+        )
+        await proc.process(event)
+        thread.send.assert_not_awaited()


### PR DESCRIPTION
## Summary

- ccdbがClaude CLIの`--include-hook-events`フラグを渡すようになり、Stop hookの実行状況がDiscordに可視化される
- hook実行中は🪝ステータス絵文字が表示され、サブテキストで開始・完了が通知される
- `HookEvent`データクラスと`hook_progress`/`stop_hook_summary`/`hook_execution_start`/`hook_execution_complete`のパース対応

## 背景

Stop hookが実行されている間（`check-uncommitted.sh`、`daily-note-session-summary.sh`、`evaluate-session.sh`等）、ユーザーにはステータス更新がなく、セッションがフリーズしたように見えていた。特に`evaluate-session.sh`がcontinuationをトリガーすると、予期しない遅延が発生していた。

## Test plan

- [x] パーサーテスト（hook_progress、stop_hook_summary、hook_execution_start/complete）
- [x] ランナーテスト（--include-hook-events フラグ）
- [x] EventProcessorテスト（ステータス更新、サブテキスト送信、chat_onlyモード）
- [x] 既存142テスト全通過
- [x] ruff lint/format 通過