### PR TITLE
[docs-sync] Add CCDB_LOG_FILE to configuration tables — rotating file handler

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,11 @@ CLAUDE_WORKING_DIR=
 # without restarting the bot. Useful for temporary API routing (e.g., Azure Foundry).
 # CCDB_CLI_ENV_FILE=/path/to/overlay.env
 
+# Logging (optional)
+# Path to a log file. When set, a rotating file handler (10 MB × 5 backups) is
+# added alongside the default stdout handler. Useful for monitoring and alerting.
+# CCDB_LOG_FILE=/home/you/claude-code-discord-bridge/logs/discord-bot.log
+
 # Limits
 MAX_CONCURRENT_SESSIONS=3
 SESSION_TIMEOUT_SECONDS=300

--- a/README.md
+++ b/README.md
@@ -596,6 +596,7 @@ In chat-only mode, permission requests and `AskUserQuestion` prompts are **alway
 | `THREAD_INBOX_ENABLED` | Enable the persistent thread inbox (classifies sessions as `waiting`/`done`/`ambiguous` via `claude -p`; shown in thread dashboard) | `false` |
 | `THREAD_AUTO_RENAME` | Auto-rename new thread titles using Claude AI — generates a short, descriptive title from the first user message via a background `claude -p` call (never delays session start) | `false` |
 | `CCDB_CLI_ENV_FILE` | Path to a `KEY=VALUE` file whose variables are merged into the CLI subprocess environment on every invocation. Changes take effect immediately without restarting the bot. Useful for temporary API routing (e.g., Azure Foundry) | (optional) |
+| `CCDB_LOG_FILE` | Path to a log file. When set, a rotating file handler (10 MB per file, 5 backups) is added alongside the default stdout handler. Useful for monitoring and alerting. | (optional) |
 | `API_HOST` | REST API bind address | `127.0.0.1` |
 | `API_PORT` | REST API port (enables REST API when set) | (optional) |
 

--- a/claude_discord/utils/logger.py
+++ b/claude_discord/utils/logger.py
@@ -1,7 +1,12 @@
 """Logging configuration."""
 
+from __future__ import annotations
+
 import logging
+import os
 import sys
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
 
 
 def setup_logging(level: int = logging.INFO) -> None:
@@ -17,6 +22,18 @@ def setup_logging(level: int = logging.INFO) -> None:
     root = logging.getLogger()
     root.setLevel(level)
     root.addHandler(handler)
+
+    log_file = os.environ.get("CCDB_LOG_FILE")
+    if log_file:
+        log_path = Path(log_file)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = RotatingFileHandler(
+            log_path,
+            maxBytes=10 * 1024 * 1024,
+            backupCount=5,
+        )
+        file_handler.setFormatter(formatter)
+        root.addHandler(file_handler)
 
     # Quiet down discord.py's verbose logging
     logging.getLogger("discord").setLevel(logging.WARNING)

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -316,6 +316,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `THREAD_INBOX_ENABLED` | Habilitar bandeja de entrada persistente de hilos | `false` |
 | `THREAD_AUTO_RENAME` | Auto-renombrar hilos con título generado por Claude | `false` |
 | `CCDB_CLI_ENV_FILE` | Ruta a archivo `KEY=VALUE` fusionado en entorno del subproceso CLI | (opcional) |
+| `CCDB_LOG_FILE` | Ruta al archivo de log. Si se configura, se añade un manejador de archivo rotativo (10 MB por archivo, 5 copias) junto al handler stdout predeterminado. Útil para monitoreo y alertas | (opcional) |
 | `API_HOST` | Dirección de enlace de REST API | `127.0.0.1` |
 | `API_PORT` | Puerto de REST API (habilita REST API cuando se configura) | (opcional) |
 

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -312,6 +312,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `THREAD_INBOX_ENABLED` | Activer la boîte de réception de fils persistante | `false` |
 | `THREAD_AUTO_RENAME` | Renommer automatiquement les nouveaux fils avec un titre généré par Claude | `false` |
 | `CCDB_CLI_ENV_FILE` | Chemin vers le fichier `KEY=VALUE` fusionné dans l'environnement du sous-processus CLI | (optionnel) |
+| `CCDB_LOG_FILE` | Chemin vers un fichier de log. Si défini, un gestionnaire de fichier rotatif (10 Mo par fichier, 5 sauvegardes) est ajouté en plus du gestionnaire stdout par défaut. Utile pour la surveillance et les alertes | (optionnel) |
 | `API_HOST` | Adresse de liaison de l'API REST | `127.0.0.1` |
 | `API_PORT` | Port de l'API REST (active l'API REST quand configuré) | (optionnel) |
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -599,6 +599,7 @@ CHAT_ONLY_CHANNEL_IDS=444,555
 | `THREAD_INBOX_ENABLED` | 永続スレッドインボックスを有効化（`claude -p` でセッションを `waiting`/`done`/`ambiguous` に分類し、スレッドダッシュボードに表示） | `false` |
 | `THREAD_AUTO_RENAME` | 新しいスレッドのタイトルを Claude AI で自動リネーム — 最初のユーザーメッセージをもとにバックグラウンドの `claude -p` 呼び出しで短く分かりやすいタイトルを生成（セッション開始を遅延させない） | `false` |
 | `CCDB_CLI_ENV_FILE` | CLI サブプロセス起動時に毎回環境変数へマージする `KEY=VALUE` ファイルのパス。Bot を再起動せずに即座に反映される。一時的な API ルーティング（Azure Foundry への切り替えなど）に便利 | （オプション） |
+| `CCDB_LOG_FILE` | ログファイルのパス。設定すると、デフォルトの stdout ハンドラーに加えてローテーティングファイルハンドラー（1ファイル 10 MB、5 世代保持）が追加される。監視・アラートに便利 | （オプション） |
 | `API_HOST` | REST API バインドアドレス | `127.0.0.1` |
 | `API_PORT` | REST API ポート（設定すると REST API が有効になる） | （オプション） |
 

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -328,6 +328,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `THREAD_INBOX_ENABLED` | 지속적인 스레드 수신함 활성화 | `false` |
 | `THREAD_AUTO_RENAME` | Claude AI로 새 스레드 제목 자동 이름 변경 | `false` |
 | `CCDB_CLI_ENV_FILE` | CLI 서브프로세스에 매번 병합할 `KEY=VALUE` 파일 경로 | (선택) |
+| `CCDB_LOG_FILE` | 로그 파일 경로. 설정하면 기본 stdout 핸들러 외에 로테이팅 파일 핸들러(파일당 10 MB, 5개 백업)가 추가된다. 모니터링 및 알림에 유용 | (선택) |
 | `API_HOST` | REST API 바인드 주소 | `127.0.0.1` |
 | `API_PORT` | REST API 포트 (설정 시 활성화) | (선택) |
 

--- a/docs/pt-BR/README.md
+++ b/docs/pt-BR/README.md
@@ -312,6 +312,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `THREAD_INBOX_ENABLED` | Habilitar caixa de entrada de thread persistente | `false` |
 | `THREAD_AUTO_RENAME` | Auto-renomear novas threads com título gerado pelo Claude | `false` |
 | `CCDB_CLI_ENV_FILE` | Caminho para arquivo `KEY=VALUE` mesclado no ambiente do subprocesso CLI | (opcional) |
+| `CCDB_LOG_FILE` | Caminho para um arquivo de log. Quando definido, um handler de arquivo rotativo (10 MB por arquivo, 5 backups) é adicionado ao handler stdout padrão. Útil para monitoramento e alertas | (opcional) |
 | `API_HOST` | Endereço de bind da REST API | `127.0.0.1` |
 | `API_PORT` | Porta da REST API (habilita REST API quando configurada) | (opcional) |
 

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -351,6 +351,7 @@ uv lock --upgrade-package claude-code-discord-bridge && uv sync
 | `THREAD_INBOX_ENABLED` | 启用持久线程收件箱 | `false` |
 | `THREAD_AUTO_RENAME` | 使用 Claude 自动重命名线程 | `false` |
 | `CCDB_CLI_ENV_FILE` | 每次 CLI 调用时合并到环境的 `KEY=VALUE` 文件 | （可选） |
+| `CCDB_LOG_FILE` | 日志文件路径。设置后，在默认 stdout 处理器的基础上额外添加轮转文件处理器（每文件 10 MB，保留 5 个备份）。适用于监控和告警 | （可选） |
 | `API_HOST` | REST API 绑定地址 | `127.0.0.1` |
 | `API_PORT` | REST API 端口（设置后启用） | （可选） |
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,75 @@
+"""Tests for claude_discord.utils.logger.setup_logging()."""
+
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _cleanup_handlers(root: logging.Logger, before: list[logging.Handler]) -> None:
+    for h in list(root.handlers):
+        if h not in before:
+            h.close()
+            root.removeHandler(h)
+
+
+class TestSetupLogging:
+    def setup_method(self) -> None:
+        self._root = logging.getLogger()
+        self._handlers_before = list(self._root.handlers)
+
+    def teardown_method(self) -> None:
+        _cleanup_handlers(self._root, self._handlers_before)
+
+    def test_default_adds_stream_handler(self) -> None:
+        """Without CCDB_LOG_FILE, only a StreamHandler is added."""
+        with patch.dict("os.environ", {}, clear=True):
+            from claude_discord.utils.logger import setup_logging
+
+            setup_logging()
+
+        new_handlers = [h for h in self._root.handlers if h not in self._handlers_before]
+        assert any(isinstance(h, logging.StreamHandler) for h in new_handlers)
+        assert not any(isinstance(h, RotatingFileHandler) for h in new_handlers)
+
+    def test_file_handler_added_when_env_set(self, tmp_path: Path) -> None:
+        """CCDB_LOG_FILE causes a RotatingFileHandler to be added."""
+        log_file = tmp_path / "discord-bot.log"
+
+        with patch.dict("os.environ", {"CCDB_LOG_FILE": str(log_file)}):
+            from claude_discord.utils.logger import setup_logging
+
+            setup_logging()
+
+        new_handlers = [h for h in self._root.handlers if h not in self._handlers_before]
+        file_handlers = [h for h in new_handlers if isinstance(h, RotatingFileHandler)]
+        assert len(file_handlers) == 1
+        assert Path(file_handlers[0].baseFilename) == log_file  # type: ignore[attr-defined]
+
+    def test_log_dir_created_automatically(self, tmp_path: Path) -> None:
+        """Parent directories of CCDB_LOG_FILE are created automatically."""
+        log_file = tmp_path / "logs" / "subdir" / "discord-bot.log"
+        assert not log_file.parent.exists()
+
+        with patch.dict("os.environ", {"CCDB_LOG_FILE": str(log_file)}):
+            from claude_discord.utils.logger import setup_logging
+
+            setup_logging()
+
+        assert log_file.parent.exists()
+
+    def test_file_handler_rotation_config(self, tmp_path: Path) -> None:
+        """RotatingFileHandler is configured with 10MB max and 5 backups."""
+        log_file = tmp_path / "discord-bot.log"
+
+        with patch.dict("os.environ", {"CCDB_LOG_FILE": str(log_file)}):
+            from claude_discord.utils.logger import setup_logging
+
+            setup_logging()
+
+        new_handlers = [h for h in self._root.handlers if h not in self._handlers_before]
+        fh = next(h for h in new_handlers if isinstance(h, RotatingFileHandler))
+        assert fh.maxBytes == 10 * 1024 * 1024
+        assert fh.backupCount == 5

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "3.0.0"
+version = "3.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Added `CCDB_LOG_FILE` environment variable to configuration tables in all language documentation (EN, JA, ES, FR, KO, PT-BR, ZH-CN)
- Documents the rotating file handler feature added in `feat: add optional rotating file log handler and logger tests` (1a58801)

## ドキュメント変更内容 / Doc changes

- `README.md` — Added `CCDB_LOG_FILE` row to Configuration table
- `docs/ja/README.md` — 日本語版に `CCDB_LOG_FILE` 行を追加
- `docs/es/README.md` — Spanish translation added
- `docs/fr/README.md` — French translation added
- `docs/ko/README.md` — Korean translation added
- `docs/pt-BR/README.md` — Portuguese translation added
- `docs/zh-CN/README.md` — Chinese translation added

## Test plan

- [ ] Verify `CCDB_LOG_FILE` row appears correctly in all 7 language README files
- [ ] Verify description matches `.env.example` comment and `logger.py` implementation (10 MB × 5 backups)
