### PR TITLE
feat: show active API provider in the statusline footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **API provider indicator** — After each session, the statusline footer shows a `🔗 API: <provider>` line indicating which API endpoint the Claude Code CLI is actually using: `Anthropic API (direct)`, `AWS Bedrock`, `Google Vertex AI`, `Azure AI Foundry`, or a custom base URL. The label is derived from the final subprocess environment (`_build_env()`), so CLI env overlays (`CCDB_CLI_ENV_FILE`) and systemd-provided variables are reflected accurately. It is shown even when no `statusLine` is configured, so "which API am I using right now" stays visible after every turn. Adds the `detect_api_provider()` helper (exported from `claude_code_core`) and `SessionBackend.describe_api()` on both `ClaudeRunner` and `CodexRunner`.
+
 ## [3.0.0] - 2026-05-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Behind the scenes:
 - **Hard stall notification** — Thread message after no activity (extended thinking or context compression); resets automatically when Claude resumes. Thresholds are model-aware: 30 s for standard models, 120 s for Opus (which has longer thinking pauses)
 - **Timeout notifications** — Embed with elapsed time and resume guidance on timeout
 - **StatusLine display** — When Claude configures a `statusLine` (via `/statusline-setup`), the current status is shown in Discord after each session as a concise, always-visible indicator
+- **API provider indicator** — After each session, a `🔗 API: <provider>` line shows which endpoint the CLI is actually using (`Anthropic API (direct)`, `AWS Bedrock`, `Google Vertex AI`, `Azure AI Foundry`, or a custom base URL), derived from the real subprocess environment so CLI env overlays are reflected. Always shown — even without a configured `statusLine`.
 - **Thread inbox** — When `THREAD_INBOX_ENABLED=true`, the dashboard shows a persistent 📬 inbox section: after each session ends, Claude classifies the final message (`waiting` / `done` / `ambiguous`) via a lightweight `claude -p` call; threads awaiting your reply survive bot restarts and are surfaced until you respond
 
 #### 🔌 Input & Skills

--- a/claude_code_core/__init__.py
+++ b/claude_code_core/__init__.py
@@ -24,6 +24,9 @@ Usage::
 
 from __future__ import annotations
 
+# API provider detection
+from .api_provider import detect_api_provider
+
 # Backend
 from .backend import SessionBackend, create_backend
 from .codex_runner import CodexRunner, parse_codex_line
@@ -76,6 +79,8 @@ __all__ = [
     "ToolUseEvent",
     # Parser
     "parse_line",
+    # API provider
+    "detect_api_provider",
     # Backend
     "CodexRunner",
     "SessionBackend",

--- a/claude_code_core/api_provider.py
+++ b/claude_code_core/api_provider.py
@@ -1,0 +1,58 @@
+"""Detect which Claude API endpoint a CLI subprocess will talk to.
+
+The Claude Code CLI selects its API endpoint purely from environment
+variables. :func:`detect_api_provider` maps the *final* subprocess
+environment (as produced by ``ClaudeRunner._build_env()``) to a short,
+human-readable label, so the bridge can surface "which API am I using right
+now" in Discord after every session.
+
+Resolution order mirrors the Claude Code CLI's own precedence: the Bedrock
+and Vertex flags win over a custom base URL, which in turn wins over the
+default direct Anthropic API.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from urllib.parse import urlparse
+
+# Values Claude Code treats as "enabled" for its boolean backend flags.
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _is_enabled(env: Mapping[str, str], key: str) -> bool:
+    """Return True when *env[key]* is a recognised truthy flag value."""
+    return env.get(key, "").strip().lower() in _TRUTHY
+
+
+def detect_api_provider(env: Mapping[str, str]) -> str:
+    """Return a short label for the Claude API endpoint *env* selects.
+
+    Args:
+        env: The subprocess environment the CLI will run with. Pass the
+            output of ``ClaudeRunner._build_env()`` so CLI env overlays and
+            systemd-provided variables are reflected accurately.
+
+    Returns:
+        A concise label such as ``"Anthropic API (direct)"``,
+        ``"AWS Bedrock (us-east-1)"``, or ``"Azure AI Foundry (resource)"``.
+    """
+    if _is_enabled(env, "CLAUDE_CODE_USE_BEDROCK"):
+        region = (env.get("AWS_REGION") or env.get("AWS_DEFAULT_REGION") or "").strip()
+        return f"AWS Bedrock ({region})" if region else "AWS Bedrock"
+
+    if _is_enabled(env, "CLAUDE_CODE_USE_VERTEX"):
+        region = (env.get("CLOUD_ML_REGION") or "").strip()
+        return f"Google Vertex AI ({region})" if region else "Google Vertex AI"
+
+    # Azure AI Foundry serves Claude models in some deployments.
+    if _is_enabled(env, "CLAUDE_CODE_USE_FOUNDRY"):
+        resource = (env.get("ANTHROPIC_FOUNDRY_RESOURCE") or "").strip()
+        return f"Azure AI Foundry ({resource})" if resource else "Azure AI Foundry"
+
+    base_url = (env.get("ANTHROPIC_BASE_URL") or "").strip()
+    if base_url:
+        host = urlparse(base_url).hostname or base_url
+        return f"Custom endpoint ({host})"
+
+    return "Anthropic API (direct)"

--- a/claude_code_core/backend.py
+++ b/claude_code_core/backend.py
@@ -43,6 +43,8 @@ class SessionBackend(Protocol):
 
     def _build_env(self) -> dict[str, str]: ...
 
+    def describe_api(self) -> str: ...
+
 
 def create_backend(
     *,

--- a/claude_code_core/codex_runner.py
+++ b/claude_code_core/codex_runner.py
@@ -13,6 +13,7 @@ import os
 import re
 import signal
 from collections.abc import AsyncGenerator
+from urllib.parse import urlparse
 
 from .types import (
     ImageData,
@@ -292,6 +293,15 @@ class CodexRunner:
         if self.thread_id is not None:
             env["DISCORD_THREAD_ID"] = str(self.thread_id)
         return env
+
+    def describe_api(self) -> str:
+        """Return a short label for the API endpoint this runner targets."""
+        env = self._build_env()
+        base_url = (env.get("OPENAI_BASE_URL") or "").strip()
+        if base_url:
+            host = urlparse(base_url).hostname or base_url
+            return f"Custom endpoint ({host})"
+        return "OpenAI API (direct)"
 
     async def _read_stream(self) -> AsyncGenerator[StreamEvent, None]:
         """Read and parse stdout line by line."""

--- a/claude_code_core/runner.py
+++ b/claude_code_core/runner.py
@@ -20,6 +20,7 @@ import sys
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
+from .api_provider import detect_api_provider
 from .parser import parse_line
 from .types import ImageData, MessageType, StreamEvent
 
@@ -359,6 +360,14 @@ class ClaudeRunner:
             env["DISCORD_THREAD_ID"] = str(self.thread_id)
         env["CLAUDE_CODE_DISABLE_BACKGROUND_TASKS"] = "1"
         return env
+
+    def describe_api(self) -> str:
+        """Return a short label for the API endpoint this runner targets.
+
+        Derived from the final subprocess environment so CLI env overlays
+        (e.g. an Azure Foundry switch) are reflected accurately.
+        """
+        return detect_api_provider(self._build_env())
 
     async def _read_stream(self) -> AsyncGenerator[StreamEvent, None]:
         """Read and parse stdout line by line."""

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -504,6 +504,7 @@ class EventProcessor:
                             input_tokens=event.input_tokens,
                             cache_creation_tokens=event.cache_creation_tokens,
                             cache_read_tokens=event.cache_read_tokens,
+                            api_label=self._config.runner.describe_api(),
                         ),
                         name=f"statusline-{self._config.thread.id}",
                     )
@@ -761,13 +762,15 @@ async def _post_statusline_footer(
     input_tokens: int | None,
     cache_creation_tokens: int | None,
     cache_read_tokens: int | None,
+    api_label: str | None = None,
 ) -> None:
-    """Run the configured statusLine.command and post the result to *thread*.
+    """Post the current API provider line and the configured statusLine.
 
-    Reads ``statusLine.command`` from ``~/.claude/settings.json``.  Does
-    nothing (silently) when the setting is absent or the command fails.
-    The output is posted as Discord subtext (``-#`` prefix per line) so it
-    appears visually distinct from the main conversation.
+    ``api_label`` (e.g. ``"Anthropic API (direct)"``) is always shown when
+    provided, so "which API am I using right now" stays visible after every
+    session — even when no ``statusLine`` is configured. The statusLine output
+    (read from ``~/.claude/settings.json``) is appended below it when present.
+    Posts nothing when neither is available.
     """
     import os
 
@@ -777,32 +780,37 @@ async def _post_statusline_footer(
         render_statusline,
     )
 
+    statusline_text: str | None = None
     command = read_statusline_command()
-    if not command:
+    if command:
+        cwd = working_dir or os.path.expanduser("~")
+        json_input = build_statusline_json(
+            cwd=cwd,
+            model_id=model,
+            model_display_name=model,
+            context_size=context_window or 200000,
+            input_tokens=input_tokens or 0,
+            cache_creation_tokens=cache_creation_tokens or 0,
+            cache_read_tokens=cache_read_tokens or 0,
+        )
+        result = await render_statusline(command, json_input)
+        if result:
+            lines = [line for line in result.splitlines() if line.strip()]
+            if lines:
+                statusline_text = "\n".join(lines[:3])
+
+    parts: list[str] = []
+    if api_label:
+        parts.append(f"\U0001f517 API: {api_label}")
+    if statusline_text:
+        parts.append(statusline_text)
+
+    if not parts:
         return
 
-    cwd = working_dir or os.path.expanduser("~")
-    json_input = build_statusline_json(
-        cwd=cwd,
-        model_id=model,
-        model_display_name=model,
-        context_size=context_window or 200000,
-        input_tokens=input_tokens or 0,
-        cache_creation_tokens=cache_creation_tokens or 0,
-        cache_read_tokens=cache_read_tokens or 0,
-    )
-
-    result = await render_statusline(command, json_input)
-    if not result:
-        return
-
-    lines = [line for line in result.splitlines() if line.strip()]
-    if not lines:
-        return
-
-    text = "\n".join(lines[:3])
+    body = "\n".join(parts)
     with contextlib.suppress(Exception):
-        await thread.send(f"```\n{text}\n```")  # type: ignore[union-attr]
+        await thread.send(f"```\n{body}\n```")  # type: ignore[union-attr]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api_provider.py
+++ b/tests/test_api_provider.py
@@ -1,0 +1,78 @@
+"""Tests for detect_api_provider — maps subprocess env to an API label.
+
+Pure-logic module: aim for full branch coverage with plain dict inputs,
+no Discord or subprocess mocking required.
+"""
+
+from __future__ import annotations
+
+from claude_code_core.api_provider import detect_api_provider
+
+
+def test_direct_anthropic_when_no_flags() -> None:
+    assert detect_api_provider({}) == "Anthropic API (direct)"
+
+
+def test_ignores_irrelevant_vars() -> None:
+    env = {"PATH": "/usr/bin", "HOME": "/home/x"}
+    assert detect_api_provider(env) == "Anthropic API (direct)"
+
+
+def test_bedrock() -> None:
+    assert detect_api_provider({"CLAUDE_CODE_USE_BEDROCK": "1"}) == "AWS Bedrock"
+
+
+def test_bedrock_with_region() -> None:
+    env = {"CLAUDE_CODE_USE_BEDROCK": "1", "AWS_REGION": "us-east-1"}
+    assert detect_api_provider(env) == "AWS Bedrock (us-east-1)"
+
+
+def test_bedrock_with_default_region_fallback() -> None:
+    env = {"CLAUDE_CODE_USE_BEDROCK": "true", "AWS_DEFAULT_REGION": "eu-west-1"}
+    assert detect_api_provider(env) == "AWS Bedrock (eu-west-1)"
+
+
+def test_vertex() -> None:
+    assert detect_api_provider({"CLAUDE_CODE_USE_VERTEX": "1"}) == "Google Vertex AI"
+
+
+def test_vertex_with_region() -> None:
+    env = {"CLAUDE_CODE_USE_VERTEX": "1", "CLOUD_ML_REGION": "us-central1"}
+    assert detect_api_provider(env) == "Google Vertex AI (us-central1)"
+
+
+def test_foundry() -> None:
+    assert detect_api_provider({"CLAUDE_CODE_USE_FOUNDRY": "1"}) == "Azure AI Foundry"
+
+
+def test_foundry_with_resource() -> None:
+    env = {
+        "CLAUDE_CODE_USE_FOUNDRY": "1",
+        "ANTHROPIC_FOUNDRY_RESOURCE": "jbs-llm-platform",
+    }
+    assert detect_api_provider(env) == "Azure AI Foundry (jbs-llm-platform)"
+
+
+def test_custom_base_url_uses_host() -> None:
+    env = {"ANTHROPIC_BASE_URL": "https://apim.example.com/v1/anthropic"}
+    assert detect_api_provider(env) == "Custom endpoint (apim.example.com)"
+
+
+def test_custom_base_url_non_url_falls_back_gracefully() -> None:
+    env = {"ANTHROPIC_BASE_URL": "localhost:4000"}
+    assert detect_api_provider(env).startswith("Custom endpoint")
+
+
+def test_bedrock_precedence_over_base_url() -> None:
+    env = {"CLAUDE_CODE_USE_BEDROCK": "1", "ANTHROPIC_BASE_URL": "https://x.com"}
+    assert detect_api_provider(env) == "AWS Bedrock"
+
+
+def test_truthy_variations() -> None:
+    for val in ("1", "true", "TRUE", "yes", "on", " On "):
+        assert detect_api_provider({"CLAUDE_CODE_USE_BEDROCK": val}) == "AWS Bedrock"
+
+
+def test_falsy_flag_is_direct() -> None:
+    for val in ("0", "false", "", "no"):
+        assert detect_api_provider({"CLAUDE_CODE_USE_BEDROCK": val}) == ("Anthropic API (direct)")

--- a/tests/test_describe_api.py
+++ b/tests/test_describe_api.py
@@ -1,0 +1,85 @@
+"""Tests for SessionBackend.describe_api() across the Claude and Codex runners.
+
+describe_api() must derive its label from the *final* subprocess environment
+(``_build_env()``), so CLI env overlays are reflected accurately.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from claude_code_core.codex_runner import CodexRunner
+from claude_code_core.runner import ClaudeRunner
+
+# Env keys that influence provider detection; cleared so the host process
+# environment cannot leak into assertions.
+_FLAG_KEYS = (
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+    "CLAUDE_CODE_USE_FOUNDRY",
+    "ANTHROPIC_FOUNDRY_RESOURCE",
+    "ANTHROPIC_BASE_URL",
+    "CCDB_CLI_ENV_FILE",
+    "OPENAI_BASE_URL",
+)
+
+
+def _clear() -> dict[str, str | None]:
+    return {k: os.environ.pop(k, None) for k in _FLAG_KEYS}
+
+
+def _restore(saved: dict[str, str | None]) -> None:
+    for key, value in saved.items():
+        if value is not None:
+            os.environ[key] = value
+        else:
+            os.environ.pop(key, None)
+
+
+class TestClaudeDescribeApi:
+    def test_direct_by_default(self) -> None:
+        saved = _clear()
+        try:
+            assert ClaudeRunner().describe_api() == "Anthropic API (direct)"
+        finally:
+            _restore(saved)
+
+    def test_reflects_bedrock_env(self) -> None:
+        saved = _clear()
+        os.environ["CLAUDE_CODE_USE_BEDROCK"] = "1"
+        try:
+            assert ClaudeRunner().describe_api() == "AWS Bedrock"
+        finally:
+            _restore(saved)
+
+    def test_reflects_cli_env_overlay(self, tmp_path: Path) -> None:
+        # Real-world Azure Foundry case: provider must reflect overlay vars.
+        saved = _clear()
+        overlay = tmp_path / "overlay.env"
+        overlay.write_text(
+            "CLAUDE_CODE_USE_FOUNDRY=1\nANTHROPIC_FOUNDRY_RESOURCE=jbs-llm-platform\n"
+        )
+        os.environ["CCDB_CLI_ENV_FILE"] = str(overlay)
+        try:
+            assert ClaudeRunner().describe_api() == "Azure AI Foundry (jbs-llm-platform)"
+        finally:
+            _restore(saved)
+
+
+class TestCodexDescribeApi:
+    def test_direct_openai_by_default(self) -> None:
+        saved = _clear()
+        try:
+            assert CodexRunner(model="o4-mini").describe_api() == "OpenAI API (direct)"
+        finally:
+            _restore(saved)
+
+    def test_custom_openai_base_url(self) -> None:
+        saved = _clear()
+        os.environ["OPENAI_BASE_URL"] = "https://azure-openai.example.com/v1"
+        try:
+            label = CodexRunner(model="o4-mini").describe_api()
+            assert label.startswith("Custom endpoint")
+        finally:
+            _restore(saved)

--- a/tests/test_statusline_footer.py
+++ b/tests/test_statusline_footer.py
@@ -1,0 +1,74 @@
+"""Tests for _post_statusline_footer.
+
+The footer now always surfaces the current API provider line (when known),
+even if no ``statusLine`` is configured, and appends the statusLine output
+below it when present.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from claude_discord.cogs.event_processor import _post_statusline_footer
+
+_STATUSLINE_MOD = "claude_discord.discord_ui.statusline"
+
+
+async def test_posts_api_line_when_no_statusline_configured() -> None:
+    thread = AsyncMock()
+    with patch(f"{_STATUSLINE_MOD}.read_statusline_command", return_value=None):
+        await _post_statusline_footer(
+            thread=thread,
+            working_dir=None,
+            model="opus",
+            context_window=None,
+            input_tokens=None,
+            cache_creation_tokens=None,
+            cache_read_tokens=None,
+            api_label="Anthropic API (direct)",
+        )
+    thread.send.assert_awaited_once()
+    body = thread.send.await_args.args[0]
+    assert "API: Anthropic API (direct)" in body
+
+
+async def test_no_post_when_neither_api_label_nor_statusline() -> None:
+    thread = AsyncMock()
+    with patch(f"{_STATUSLINE_MOD}.read_statusline_command", return_value=None):
+        await _post_statusline_footer(
+            thread=thread,
+            working_dir=None,
+            model="opus",
+            context_window=None,
+            input_tokens=None,
+            cache_creation_tokens=None,
+            cache_read_tokens=None,
+            api_label=None,
+        )
+    thread.send.assert_not_awaited()
+
+
+async def test_combines_api_line_and_statusline_output() -> None:
+    thread = AsyncMock()
+    with (
+        patch(f"{_STATUSLINE_MOD}.read_statusline_command", return_value="cmd"),
+        patch(
+            f"{_STATUSLINE_MOD}.render_statusline",
+            new=AsyncMock(return_value="Ctx 45% | quota OK"),
+        ),
+    ):
+        await _post_statusline_footer(
+            thread=thread,
+            working_dir=None,
+            model="opus",
+            context_window=200000,
+            input_tokens=1000,
+            cache_creation_tokens=0,
+            cache_read_tokens=0,
+            api_label="Azure AI Foundry (jbs-llm-platform)",
+        )
+    body = thread.send.await_args.args[0]
+    assert "API: Azure AI Foundry (jbs-llm-platform)" in body
+    assert "Ctx 45%" in body
+    # The API line should appear above the statusline output.
+    assert body.index("API:") < body.index("Ctx 45%")


### PR DESCRIPTION
## Summary

After each session, the statusline footer now prepends a `🔗 API: <provider>` line showing **which API endpoint the Claude Code CLI is actually talking to**:

- `Anthropic API (direct)`
- `AWS Bedrock (<region>)`
- `Google Vertex AI (<region>)`
- `Azure AI Foundry (<resource>)`
- `Custom endpoint (<host>)` — for any `ANTHROPIC_BASE_URL`

The label is derived from the **final subprocess environment** (`ClaudeRunner._build_env()`), so CLI env overlays (`CCDB_CLI_ENV_FILE`) and systemd-provided variables are reflected accurately. It is shown **even when no `statusLine` is configured**, so "which API am I using right now" stays visible after every turn.

### Motivation

From Discord alone it was hard to tell whether a session was hitting Anthropic directly or being routed through Azure Foundry / Bedrock / a proxy. This surfaces it where you already look after every turn.

## Changes

- **New** `claude_code_core/api_provider.py` — `detect_api_provider(env)` pure function (exported from `claude_code_core`). Resolution precedence mirrors the CLI's own: Bedrock → Vertex → Foundry → custom base URL → direct.
- **`SessionBackend.describe_api()`** added to the protocol and implemented on both `ClaudeRunner` (delegates to `detect_api_provider`) and `CodexRunner` (OpenAI direct / custom base URL).
- **`_post_statusline_footer`** now takes an `api_label` and always emits the API line; the configured statusLine output (if any) is appended below it.

## Security

- `detect_api_provider` reads **only non-secret keys** (`CLAUDE_CODE_USE_*`, `AWS_REGION`, `CLOUD_ML_REGION`, `ANTHROPIC_FOUNDRY_RESOURCE`, `ANTHROPIC_BASE_URL`). It never reads API keys or tokens.
- For a custom base URL, only `urlparse(...).hostname` is shown, so credentials embedded as `user:pass@host` are never leaked.

## Test plan

- [x] `tests/test_api_provider.py` — 14 cases (each backend, region/resource suffixes, truthy/falsy flags, precedence, custom-URL host extraction)
- [x] `tests/test_describe_api.py` — `describe_api()` for Claude & Codex, including **CLI env overlay → Azure Foundry** reflection
- [x] `tests/test_statusline_footer.py` — API line shown without a statusLine; combined with statusLine output; nothing posted when neither is present
- [x] `ruff check` / `ruff format` clean
- [x] Full suite green: **1397 passed**. `test_run_helper.py` was excluded *locally only* because it shells out to a real configured `statusLine` in my dev environment and hangs there. This is pre-existing and unrelated to this change — verified by reproducing the same hang on pristine `origin/main` (stashed my diff). It passes in CI, where no `statusLine` is configured.