### PR TITLE
fix: pre-start.sh skipped git pull when untracked files were present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ Thumbs.db
 .coverage
 htmlcov/
 .pytest_cache/
+
+# Logs (bot-generated, e.g. the optional rotating file log handler)
+logs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **API provider indicator** — After each session, the statusline footer shows a `🔗 API: <provider>` line indicating which API endpoint the Claude Code CLI is actually using: `Anthropic API (direct)`, `AWS Bedrock`, `Google Vertex AI`, `Azure AI Foundry`, or a custom base URL. The label is derived from the final subprocess environment (`_build_env()`), so CLI env overlays (`CCDB_CLI_ENV_FILE`) and systemd-provided variables are reflected accurately. It is shown even when no `statusLine` is configured, so "which API am I using right now" stays visible after every turn. Adds the `detect_api_provider()` helper (exported from `claude_code_core`) and `SessionBackend.describe_api()` on both `ClaudeRunner` and `CodexRunner`.
 
+### Fixed
+- **`pre-start.sh` skipped `git pull` when untracked files were present** — the local-dev-mode guard treated *any* `git status --porcelain` output as a signal to skip the pull. The bot-generated `logs/` directory (from the optional rotating file log handler) showed up as an untracked entry, so the guard silently skipped every pull and a stale checkout persisted across restarts. The guard now considers only *tracked* changes (`--untracked-files=no`), and `logs/` is gitignored.
+
 ## [3.0.0] - 2026-05-15
 
 ### Added

--- a/scripts/pre-start.sh
+++ b/scripts/pre-start.sh
@@ -38,8 +38,11 @@ send_webhook() {
 
 # ── Step 1: Pull latest code (skip in local dev mode) ──
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
-# Ignore uv.lock changes — uv sync regenerates it on every run.
-LOCAL_CHANGES=$(git status --porcelain 2>/dev/null | grep -v '^ M uv.lock$' | grep -v '^M  uv.lock$' || true)
+# Only *tracked* changes signal local dev mode. Untracked files (e.g. the
+# bot-generated logs/ directory) must never block the pull, otherwise a stale
+# checkout silently persists across every restart. uv.lock is a derived file
+# that uv sync regenerates, so it is filtered out too.
+LOCAL_CHANGES=$(git status --porcelain --untracked-files=no 2>/dev/null | grep -v '^ M uv.lock$' | grep -v '^M  uv.lock$' || true)
 
 if [ "$CURRENT_BRANCH" != "main" ] || [ -n "$LOCAL_CHANGES" ]; then
     echo "[pre-start] Local dev mode (branch: $CURRENT_BRANCH) — skipping git pull" >&2


### PR DESCRIPTION
## Summary

`pre-start.sh` (run as `ExecStartPre` before the bot) silently skipped `git pull` whenever **any** untracked file was present, leaving the bot on a stale checkout across restarts.

### Root cause

The local-dev-mode guard ran `git status --porcelain` (which includes **untracked** files) and skipped the pull when the output was non-empty (after filtering `uv.lock`). The bot-generated `logs/` directory — from the optional rotating file log handler, and not gitignored — showed up as `?? logs/`, so the guard treated the repo as "local dev mode" and skipped the pull on **every** restart.

This bit production: PR #417 was merged to `main` but never reached the running bot until `logs/` was cleared and the pull was run manually. The bot kept running old code no matter how many times it was restarted.

## Fix

- **`--untracked-files=no`** on the guard's `git status` — only *tracked* changes signal local dev mode; untracked artifacts (logs, caches, anything the bot writes) never block the pull again.
- **gitignore `logs/`** so the bot's own log output doesn't pollute `git status` in the first place.

## Test plan

- [x] `bash -n scripts/pre-start.sh` — syntax OK
- [x] Reproduced the fix: with `?? logs/` present, the old guard (`git status --porcelain | grep -v uv.lock`) is non-empty → skip; the new guard (`--untracked-files=no`) is empty → pull proceeds
- [x] Genuine *tracked* local changes still trigger dev mode (intentional); the existing `uv.lock` filter is preserved
- [x] No Python changed — existing pytest/ruff CI is unaffected