### PR TITLE
fix: mention requester for interactive prompts [release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **API provider indicator** — After each session, the statusline footer shows a `🔗 API: <provider>` line indicating which API endpoint the Claude Code CLI is actually using: `Anthropic API (direct)`, `AWS Bedrock`, `Google Vertex AI`, `Azure AI Foundry`, or a custom base URL. The label is derived from the final subprocess environment (`_build_env()`), so CLI env overlays (`CCDB_CLI_ENV_FILE`) and systemd-provided variables are reflected accurately. It is shown even when no `statusLine` is configured, so "which API am I using right now" stays visible after every turn. Adds the `detect_api_provider()` helper (exported from `claude_code_core`) and `SessionBackend.describe_api()` on both `ClaudeRunner` and `CodexRunner`.
 
 ### Fixed
+- **Interactive input prompts now mention the requester** — Plan approval, permission
+  requests, MCP elicitation, and AskUserQuestion messages mention the user who started
+  the session, making it clear that Claude is waiting for button/form input instead of
+  still running. Passive controls such as Stop and tool-result expand buttons remain
+  silent. Mentions use a restricted `allowed_mentions` payload so only the target user
+  can be notified (#419).
 - **`pre-start.sh` skipped `git pull` when untracked files were present** — the local-dev-mode guard treated *any* `git status --porcelain` output as a signal to skip the pull. The bot-generated `logs/` directory (from the optional rotating file log handler) showed up as an untracked entry, so the guard silently skipped every pull and a stale checkout persisted across restarts. The guard now considers only *tracked* changes (`--untracked-files=no`), and `logs/` is gitignored.
 
 ## [3.0.0] - 2026-05-15

--- a/claude_discord/cogs/_run_helper.py
+++ b/claude_discord/cogs/_run_helper.py
@@ -281,6 +281,7 @@ async def run_claude_with_config(config: RunConfig) -> str | None:
             processor.pending_ask,
             processor.session_id,
             ask_repo=config.ask_repo,
+            notify_user_id=config.notify_user_id,
         )
         if answer_prompt:
             logger.info(

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -1073,6 +1073,7 @@ class ClaudeChatCog(commands.Cog):
                     inbox_dashboard=dashboard,
                     claude_command=runner.command,
                     chat_only=chat_only,
+                    notify_user_id=user_message.author.id,
                 )
             )
         finally:

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -32,6 +32,7 @@ from ..discord_ui.embeds import (
     tool_use_embed,
 )
 from ..discord_ui.file_sender import send_files
+from ..discord_ui.mentions import user_mention_kwargs
 from ..discord_ui.permission_view import PermissionView
 from ..discord_ui.plan_view import PlanApprovalView
 from ..discord_ui.streaming_manager import StreamingMessageManager
@@ -611,7 +612,11 @@ class EventProcessor:
         # we use the session_id as a stable identifier for the inject payload.
         request_id = self._state.session_id or "plan"
         view = PlanApprovalView(self._config.runner, request_id)
-        await self._config.thread.send(embed=embed, view=view)
+        await self._config.thread.send(
+            embed=embed,
+            view=view,
+            **user_mention_kwargs(self._config.notify_user_id),
+        )
         logger.info("Plan approval prompt posted (session=%s)", request_id)
 
     async def _handle_permission_request(self, event: StreamEvent) -> None:
@@ -641,7 +646,11 @@ class EventProcessor:
 
         embed = permission_embed(event.permission_request)
         view = PermissionView(self._config.runner, event.permission_request)
-        await self._config.thread.send(embed=embed, view=view)
+        await self._config.thread.send(
+            embed=embed,
+            view=view,
+            **user_mention_kwargs(self._config.notify_user_id),
+        )
         logger.info(
             "Permission request posted: %s (request_id=%s)",
             event.permission_request.tool_name,
@@ -657,7 +666,11 @@ class EventProcessor:
             view = ElicitationUrlView(self._config.runner, req)
         else:
             view = ElicitationFormView(self._config.runner, req)
-        await self._config.thread.send(embed=embed, view=view)
+        await self._config.thread.send(
+            embed=embed,
+            view=view,
+            **user_mention_kwargs(self._config.notify_user_id),
+        )
         logger.info(
             "Elicitation posted: %s (%s, request_id=%s)",
             req.server_name,

--- a/claude_discord/cogs/run_config.py
+++ b/claude_discord/cogs/run_config.py
@@ -86,6 +86,8 @@ class RunConfig:
     # blocks, session start/complete embeds, and other technical details are hidden.
     # Useful for public channels where non-technical users are watching.
     chat_only: bool = False
+    # Discord user to mention when Claude pauses for an explicit button/form action.
+    notify_user_id: int | None = None
 
     # Prevent accidental field mutation — RunConfig is a value object.
     # Use dataclasses.replace() to create modified copies.

--- a/claude_discord/cogs/skill_command.py
+++ b/claude_discord/cogs/skill_command.py
@@ -273,6 +273,7 @@ class SkillCommandCog(commands.Cog):
                     session_id=session_id,
                     registry=self._registry,
                     worktree_manager=getattr(self.bot, "worktree_manager", None),
+                    notify_user_id=interaction.user.id,
                 )
             )
             return
@@ -308,5 +309,6 @@ class SkillCommandCog(commands.Cog):
                 session_id=None,
                 registry=self._registry,
                 worktree_manager=getattr(self.bot, "worktree_manager", None),
+                notify_user_id=interaction.user.id,
             )
         )

--- a/claude_discord/discord_ui/ask_handler.py
+++ b/claude_discord/discord_ui/ask_handler.py
@@ -20,6 +20,7 @@ from ..database.ask_repo import PendingAskRepository
 from .ask_bus import ask_bus as _ask_bus
 from .ask_view import AskView
 from .embeds import ask_embed
+from .mentions import user_mention_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +34,7 @@ async def collect_ask_answers(
     questions: list[AskQuestion],
     session_id: str,
     ask_repo: PendingAskRepository | None = None,
+    notify_user_id: int | None = None,
 ) -> str | None:
     """Show Discord UI for each question and return the formatted answer string.
 
@@ -72,7 +74,11 @@ async def collect_ask_answers(
         answer_queue = _ask_bus.register(thread.id)
 
         view = AskView(q, thread_id=thread.id, q_idx=q_idx, ask_repo=ask_repo)
-        msg = await thread.send(embed=ask_embed(q.question, q.header), view=view)
+        msg = await thread.send(
+            embed=ask_embed(q.question, q.header),
+            view=view,
+            **user_mention_kwargs(notify_user_id),
+        )
 
         try:
             selected = await asyncio.wait_for(answer_queue.get(), timeout=ASK_ANSWER_TIMEOUT)

--- a/claude_discord/discord_ui/mentions.py
+++ b/claude_discord/discord_ui/mentions.py
@@ -1,0 +1,21 @@
+"""Helpers for Discord mention payloads."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import discord
+
+
+def user_mention_kwargs(user_id: int | None) -> dict[str, Any]:
+    """Return send() kwargs that notify a specific user, or no kwargs if unset."""
+    if user_id is None:
+        return {}
+    return {
+        "content": f"<@{user_id}>",
+        "allowed_mentions": discord.AllowedMentions(
+            users=True,
+            roles=False,
+            everyone=False,
+        ),
+    }

--- a/tests/test_ask_feature.py
+++ b/tests/test_ask_feature.py
@@ -320,6 +320,38 @@ class TestCollectAskAnswersTimeout:
         assert result is None  # timeout → no answer → returns None
 
 
+class TestCollectAskAnswersMention:
+    """AskUserQuestion messages mention the requester when configured."""
+
+    @pytest.mark.asyncio
+    async def test_collect_ask_answers_mentions_notify_user(self) -> None:
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock
+
+        from claude_discord.claude.types import AskOption, AskQuestion
+        from claude_discord.discord_ui.ask_bus import ask_bus
+        from claude_discord.discord_ui.ask_handler import collect_ask_answers
+
+        q = AskQuestion(
+            question="Which option?",
+            options=[AskOption(label="A"), AskOption(label="B")],
+        )
+        thread = MagicMock()
+        thread.id = 12345
+        thread.send = AsyncMock(return_value=MagicMock())
+
+        async def answer() -> None:
+            await asyncio.sleep(0)
+            ask_bus.post_answer(thread.id, ["A"])
+
+        answer_task = asyncio.create_task(answer())
+        await collect_ask_answers(thread, [q], session_id="abc123", notify_user_id=42)
+        await answer_task
+
+        thread.send.assert_called_once()
+        assert thread.send.call_args.kwargs["content"] == "<@42>"
+
+
 # ---------------------------------------------------------------------------
 # AskView._other_callback — visual feedback after modal submission
 # ---------------------------------------------------------------------------

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -1454,3 +1454,72 @@ class TestPermissionAutoApprove:
         runner.inject_tool_result.assert_not_called()
         # Discord embed + view posted
         thread.send.assert_called_once()
+
+
+class TestUserActionMentions:
+    """Messages that pause Claude for button input mention the requester."""
+
+    @pytest.mark.asyncio
+    async def test_plan_approval_mentions_notify_user(
+        self, thread: MagicMock, runner: MagicMock
+    ) -> None:
+        config = _make_config(thread, runner, notify_user_id=42)
+        p = EventProcessor(config)
+
+        await p.process(
+            StreamEvent(
+                message_type=MessageType.ASSISTANT,
+                text="Implementation plan",
+                is_plan_approval=True,
+            )
+        )
+
+        assert thread.send.call_args.kwargs["content"] == "<@42>"
+
+    @pytest.mark.asyncio
+    async def test_permission_request_mentions_notify_user(
+        self, thread: MagicMock, runner: MagicMock
+    ) -> None:
+        from claude_discord.claude.types import PermissionRequest
+
+        runner.dangerously_skip_permissions = False
+        config = _make_config(thread, runner, notify_user_id=42)
+        p = EventProcessor(config)
+
+        await p.process(
+            StreamEvent(
+                message_type=MessageType.SYSTEM,
+                permission_request=PermissionRequest(
+                    request_id="req-normal-1",
+                    tool_name="Edit",
+                    tool_input={"file_path": "/home/user/.bashrc"},
+                ),
+            )
+        )
+
+        thread.send.assert_called_once()
+        assert thread.send.call_args.kwargs["content"] == "<@42>"
+
+    @pytest.mark.asyncio
+    async def test_elicitation_mentions_notify_user(
+        self, thread: MagicMock, runner: MagicMock
+    ) -> None:
+        from claude_discord.claude.types import ElicitationRequest
+
+        config = _make_config(thread, runner, notify_user_id=42)
+        p = EventProcessor(config)
+
+        await p.process(
+            StreamEvent(
+                message_type=MessageType.SYSTEM,
+                elicitation=ElicitationRequest(
+                    request_id="elicit-1",
+                    server_name="example",
+                    mode="form-mode",
+                    message="Need input",
+                ),
+            )
+        )
+
+        thread.send.assert_called_once()
+        assert thread.send.call_args.kwargs["content"] == "<@42>"

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "3.0.7"
+version = "3.0.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- mention the session requester when Claude pauses for Plan approval, permission requests, MCP elicitation, or AskUserQuestion
- keep passive controls silent, including Stop and tool-result expand buttons
- restrict allowed_mentions so only the target user can be notified

## Tests
- uv run ruff check claude_discord tests/test_event_processor.py tests/test_ask_feature.py
- uv run pytest tests/ -q

Closes #419