### PR TITLE
[docs-sync] Update documentation and translations for interactive input mention feature (#419)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,10 +199,10 @@ Behind the scenes:
 - **Thread dashboard** — Live pinned embed showing which threads are active vs. waiting; owner @-mentioned when input is needed
 
 #### 🤝 Human-in-the-Loop
-- **Interactive questions** — `AskUserQuestion` renders as Discord Buttons or Select Menu; session resumes with your answer; buttons survive bot restarts
-- **Plan Mode** — When Claude calls `ExitPlanMode`, a Discord embed shows the full plan with Approve/Cancel buttons; Claude proceeds only after approval; auto-cancel on 5-minute timeout
-- **Tool permission requests** — When Claude needs permission to execute a tool, Discord shows Allow/Deny buttons with the tool name and input; auto-deny after 2 minutes
-- **MCP Elicitation** — MCP servers can request user input via Discord (form-mode: up to 5 Modal fields from JSON schema; url-mode: URL button + Done confirmation); 5-minute timeout
+- **Interactive questions** — `AskUserQuestion` renders as Discord Buttons or Select Menu; session resumes with your answer; buttons survive bot restarts; requester is @mentioned when input is needed
+- **Plan Mode** — When Claude calls `ExitPlanMode`, a Discord embed shows the full plan with Approve/Cancel buttons; Claude proceeds only after approval; requester @mentioned on prompt; auto-cancel on 5-minute timeout
+- **Tool permission requests** — When Claude needs permission to execute a tool, Discord shows Allow/Deny buttons with the tool name and input; requester @mentioned; auto-deny after 2 minutes
+- **MCP Elicitation** — MCP servers can request user input via Discord (form-mode: up to 5 Modal fields from JSON schema; url-mode: URL button + Done confirmation); requester @mentioned; 5-minute timeout
 - **Live TodoWrite progress** — When Claude calls `TodoWrite`, a single Discord embed is posted and edited in-place on each update; shows ✅ completed, 🔄 active (with `activeForm` label), ⬜ pending items
 
 #### 📊 Observability
@@ -922,6 +922,7 @@ claude_discord/
     chunker.py             # Fence- and table-aware message splitting
     embeds.py              # Discord embed builders
     views.py               # Stop button and shared UI components
+    mentions.py            # user_mention_kwargs() — notify requester when Claude pauses for input
     ask_bus.py             # Event bus for AskUserQuestion communication
     ask_view.py            # Buttons/Select Menus for AskUserQuestion
     ask_handler.py         # collect_ask_answers() — AskUserQuestion UI + DB lifecycle

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -110,10 +110,10 @@ Un canal compartido "sala de descanso" donde todas las sesiones concurrentes se 
 - **Panel de hilos** — Embed fijado en vivo mostrando qué hilos están activos vs. esperando
 
 #### 🤝 Human-in-the-Loop
-- **Preguntas interactivas** — `AskUserQuestion` se renderiza como botones o menú de selección de Discord
-- **Modo Plan** — `ExitPlanMode` muestra embed de Discord con botones Aprobar/Cancelar; 5 minutos de timeout
-- **Solicitudes de permisos de herramientas** — Botones Permitir/Denegar; auto-rechazo después de 2 minutos
-- **MCP Elicitation** — Los servidores MCP pueden solicitar entrada del usuario a través de Discord; 5 minutos de timeout
+- **Preguntas interactivas** — `AskUserQuestion` se renderiza como botones o menú de selección de Discord; se @menciona al solicitante cuando se necesita entrada
+- **Modo Plan** — `ExitPlanMode` muestra embed de Discord con botones Aprobar/Cancelar; se @menciona al solicitante en el prompt; 5 minutos de timeout
+- **Solicitudes de permisos de herramientas** — Botones Permitir/Denegar; se @menciona al solicitante; auto-rechazo después de 2 minutos
+- **MCP Elicitation** — Los servidores MCP pueden solicitar entrada del usuario a través de Discord; se @menciona al solicitante; 5 minutos de timeout
 - **Progreso TodoWrite en vivo** — Embed único de Discord actualizado en su lugar
 
 #### 📊 Observabilidad

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -106,10 +106,10 @@ Vous utilisez déjà Claude Code CLI directement ? Synchronisez vos sessions de 
 - **Tableau de bord des fils** — Embed épinglé en direct montrant les fils actifs vs. en attente
 
 #### 🤝 Human-in-the-Loop
-- **Questions interactives** — `AskUserQuestion` rendu comme boutons ou menu de sélection Discord
-- **Mode Plan** — `ExitPlanMode` affiche un embed Discord avec boutons Approuver/Annuler ; timeout 5 minutes
-- **Demandes de permission d'outil** — Boutons Autoriser/Refuser ; refus automatique après 2 minutes
-- **MCP Elicitation** — Les serveurs MCP peuvent demander des saisies utilisateur via Discord ; timeout 5 minutes
+- **Questions interactives** — `AskUserQuestion` rendu comme boutons ou menu de sélection Discord ; le demandeur est @mentionné quand une saisie est nécessaire
+- **Mode Plan** — `ExitPlanMode` affiche un embed Discord avec boutons Approuver/Annuler ; le demandeur est @mentionné à la demande d'approbation ; timeout 5 minutes
+- **Demandes de permission d'outil** — Boutons Autoriser/Refuser ; le demandeur est @mentionné ; refus automatique après 2 minutes
+- **MCP Elicitation** — Les serveurs MCP peuvent demander des saisies utilisateur via Discord ; le demandeur est @mentionné ; timeout 5 minutes
 - **Progression TodoWrite en direct** — Embed Discord unique édité sur place
 
 #### 📊 Observabilité

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -202,10 +202,10 @@ ccdb 3.0 では、Bot を再起動せずにどの AI が次のセッションを
 - **スレッドダッシュボード** — アクティブ/待機スレッドを表示するライブピン embed。入力が必要なときはオーナーを @mention
 
 #### 🤝 ヒューマンインザループ
-- **インタラクティブな質問** — `AskUserQuestion` を Discord ボタンまたは Select Menu でレンダリング。回答でセッション再開。ボタンは Bot 再起動後も有効
-- **Plan Mode** — Claude が `ExitPlanMode` を呼び出すと、プラン全文と Approve/Cancel ボタンを含む Discord embed を表示；承認後にのみ実行を開始；5 分でタイムアウト（自動キャンセル）
-- **ツール実行許可リクエスト** — Claude がツールを実行するために許可が必要な場合、ツール名と入力内容を示した Allow/Deny ボタンを Discord に表示；2 分間応答なしで自動拒否
-- **MCP Elicitation** — MCP サーバーが Discord 経由でユーザー入力を要求（form-mode: JSON スキーマから最大 5 フィールドの Modal；url-mode: URL ボタン + Done 確認）；5 分でタイムアウト
+- **インタラクティブな質問** — `AskUserQuestion` を Discord ボタンまたは Select Menu でレンダリング。回答でセッション再開。ボタンは Bot 再起動後も有効；入力が必要なときはリクエスターを @mention
+- **Plan Mode** — Claude が `ExitPlanMode` を呼び出すと、プラン全文と Approve/Cancel ボタンを含む Discord embed を表示；承認後にのみ実行を開始；承認を求める際はリクエスターを @mention；5 分でタイムアウト（自動キャンセル）
+- **ツール実行許可リクエスト** — Claude がツールを実行するために許可が必要な場合、ツール名と入力内容を示した Allow/Deny ボタンを Discord に表示；リクエスターを @mention；2 分間応答なしで自動拒否
+- **MCP Elicitation** — MCP サーバーが Discord 経由でユーザー入力を要求（form-mode: JSON スキーマから最大 5 フィールドの Modal；url-mode: URL ボタン + Done 確認）；リクエスターを @mention；5 分でタイムアウト
 - **TodoWrite ライブ進捗** — Claude が `TodoWrite` を呼び出すと Discord embed を一度投稿し、以降の更新はその embed をインプレースで編集；✅ 完了、🔄 実行中（`activeForm` ラベル付き）、⬜ 保留中の各状態を表示
 
 #### 📊 オブザーバビリティ
@@ -924,6 +924,7 @@ claude_discord/
     chunker.py             # フェンス・テーブル対応メッセージ分割
     embeds.py              # Discord embed ビルダー
     views.py               # 停止ボタンと共有 UI コンポーネント
+    mentions.py            # user_mention_kwargs() — Claude が入力待ちのときリクエスターに通知
     ask_bus.py             # AskUserQuestion 通信用イベントバス
     ask_view.py            # AskUserQuestion 用 Discord ボタン / Select Menu
     ask_handler.py         # collect_ask_answers() — AskUserQuestion UI + DB ライフサイクル

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -122,10 +122,10 @@ curl -X POST "$CCDB_API_URL/api/spawn" \
 - **스레드 대시보드** — 활성 vs. 대기 스레드 표시하는 라이브 고정 embed
 
 #### 🤝 Human-in-the-Loop
-- **인터랙티브 질문** — `AskUserQuestion`을 Discord 버튼 또는 선택 메뉴로 렌더링; 봇 재시작 후에도 버튼 유효
-- **계획 모드** — `ExitPlanMode` 호출 시 Discord embed에 전체 계획과 승인/취소 버튼 표시; 5분 타임아웃
-- **도구 권한 요청** — 허용/거부 버튼; 2분 무응답 시 자동 거부
-- **MCP Elicitation** — MCP 서버가 Discord를 통해 사용자 입력 요청; 5분 타임아웃
+- **인터랙티브 질문** — `AskUserQuestion`을 Discord 버튼 또는 선택 메뉴로 렌더링; 봇 재시작 후에도 버튼 유효; 입력이 필요할 때 요청자를 @mention
+- **계획 모드** — `ExitPlanMode` 호출 시 Discord embed에 전체 계획과 승인/취소 버튼 표시; 승인 요청 시 요청자를 @mention; 5분 타임아웃
+- **도구 권한 요청** — 허용/거부 버튼; 요청자를 @mention; 2분 무응답 시 자동 거부
+- **MCP Elicitation** — MCP 서버가 Discord를 통해 사용자 입력 요청; 요청자를 @mention; 5분 타임아웃
 - **TodoWrite 실시간 진행** — 단일 Discord embed 인플레이스 업데이트; ✅ 완료, 🔄 진행 중, ⬜ 대기 표시
 
 #### 📊 관찰 가능성

--- a/docs/pt-BR/README.md
+++ b/docs/pt-BR/README.md
@@ -106,10 +106,10 @@ Já usa Claude Code CLI diretamente? Sincronize suas sessões de terminal existe
 - **Dashboard de thread** — Embed fixado ao vivo mostrando quais threads estão ativas vs. aguardando
 
 #### 🤝 Human-in-the-Loop
-- **Perguntas interativas** — `AskUserQuestion` renderizado como Botões ou Menu de Seleção do Discord
-- **Modo Plan** — `ExitPlanMode` mostra embed com botões Aprovar/Cancelar; 5 minutos de timeout
-- **Solicitações de permissão de ferramenta** — Botões Permitir/Negar; auto-negação após 2 minutos
-- **MCP Elicitation** — Servidores MCP podem solicitar entrada do usuário via Discord; 5 minutos de timeout
+- **Perguntas interativas** — `AskUserQuestion` renderizado como Botões ou Menu de Seleção do Discord; solicitante @mencionado quando input é necessário
+- **Modo Plan** — `ExitPlanMode` mostra embed com botões Aprovar/Cancelar; solicitante @mencionado no prompt; 5 minutos de timeout
+- **Solicitações de permissão de ferramenta** — Botões Permitir/Negar; solicitante @mencionado; auto-negação após 2 minutos
+- **MCP Elicitation** — Servidores MCP podem solicitar entrada do usuário via Discord; solicitante @mencionado; 5 minutos de timeout
 - **Progresso TodoWrite ao vivo** — Embed único do Discord editado no lugar; mostra ✅ concluído, 🔄 ativo, ⬜ pendente
 
 #### 📊 Observabilidade

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -144,10 +144,10 @@ curl -X POST "$CCDB_API_URL/api/spawn" \
 - **线程仪表板** — 实时固定 embed 显示活跃/等待线程状态
 
 #### 🤝 人机协作
-- **交互式问题** — `AskUserQuestion` 渲染为 Discord 按钮或下拉菜单
-- **计划模式** — `ExitPlanMode` 触发带批准/取消按钮的 Discord embed；5 分钟超时
-- **工具权限请求** — 允许/拒绝按钮；2 分钟无响应自动拒绝
-- **MCP Elicitation** — MCP 服务器通过 Discord 请求用户输入；5 分钟超时
+- **交互式问题** — `AskUserQuestion` 渲染为 Discord 按钮或下拉菜单；需要输入时 @mention 请求者
+- **计划模式** — `ExitPlanMode` 触发带批准/取消按钮的 Discord embed；提示时 @mention 请求者；5 分钟超时
+- **工具权限请求** — 允许/拒绝按钮；@mention 请求者；2 分钟无响应自动拒绝
+- **MCP Elicitation** — MCP 服务器通过 Discord 请求用户输入；@mention 请求者；5 分钟超时
 - **TodoWrite 实时进度** — 单个 Discord embed 原地更新；显示 ✅ 已完成、🔄 进行中、⬜ 待处理
 
 #### 📊 可观测性


### PR DESCRIPTION
## Summary

- **Interactive input prompt mention** — Updated English README and all 6 translated READMEs (ja, zh-CN, ko, es, pt-BR, fr) to document that plan approval, permission requests, MCP elicitation, and AskUserQuestion messages now @mention the session requester (#419)
- **Architecture section** — Added `mentions.py` to the `discord_ui/` file listing in the English and Japanese READMEs

## Changes

| File | Change |
|------|--------|
| `README.md` | Updated Human-in-the-Loop bullets; added `mentions.py` to architecture |
| `docs/ja/README.md` | Same updates in Japanese |
| `docs/zh-CN/README.md` | Updated Human-in-the-Loop bullets in Chinese |
| `docs/ko/README.md` | Updated Human-in-the-Loop bullets in Korean |
| `docs/es/README.md` | Updated Human-in-the-Loop bullets in Spanish |
| `docs/pt-BR/README.md` | Updated Human-in-the-Loop bullets in Portuguese |
| `docs/fr/README.md` | Updated Human-in-the-Loop bullets in French |

## Test plan

- [ ] Verify that the @mention behavior described matches the implementation in `claude_discord/discord_ui/mentions.py`
- [ ] Verify that `mentions.py` entry appears correctly in the architecture section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
