### PR TITLE
feat: add working_dir support to spawn_session and POST /api/spawn

### DIFF
--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -708,6 +708,7 @@ class ClaudeChatCog(commands.Cog):
         session_id: str | None = None,
         fork: bool = False,
         auto_start: bool = True,
+        working_dir: str | None = None,
     ) -> discord.Thread:
         """Create a new thread and optionally start a Claude Code session.
 
@@ -746,7 +747,11 @@ class ClaudeChatCog(commands.Cog):
             # Run Claude in the background so /api/spawn returns immediately.
             # The caller gets the thread reference without waiting for Claude to finish.
             asyncio.create_task(
-                self._run_claude(seed_message, thread, prompt, session_id=session_id, fork=fork)
+                self._run_claude(
+                    seed_message, thread, prompt,
+                    session_id=session_id, fork=fork,
+                    working_dir_override=working_dir,
+                )
             )
         return thread
 

--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -633,6 +633,7 @@ class ApiServer:
 
         thread_name: str | None = data.get("thread_name") or None
         auto_start: bool = data.get("auto_start", True)
+        working_dir: str | None = data.get("working_dir") or None
 
         try:
             thread = await cog.spawn_session(
@@ -640,6 +641,7 @@ class ApiServer:
                 prompt,
                 thread_name=thread_name,
                 auto_start=auto_start,
+                working_dir=working_dir,
             )
         except Exception as exc:
             logger.error("spawn_session failed: %s", exc, exc_info=True)

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -638,6 +638,25 @@ class TestSpawn:
         )
         assert resp.status == 400
 
+    @pytest.mark.asyncio
+    async def test_spawn_passes_working_dir_to_cog(
+        self, spawn_client: TestClient, mock_cog: MagicMock
+    ) -> None:
+        await spawn_client.post(
+            "/api/spawn",
+            json={"prompt": "Audit SEO", "working_dir": "/Users/jeb/jebos/shopify/fumetsu"},
+        )
+        kwargs = mock_cog.spawn_session.call_args.kwargs
+        assert kwargs.get("working_dir") == "/Users/jeb/jebos/shopify/fumetsu"
+
+    @pytest.mark.asyncio
+    async def test_spawn_working_dir_defaults_to_none(
+        self, spawn_client: TestClient, mock_cog: MagicMock
+    ) -> None:
+        await spawn_client.post("/api/spawn", json={"prompt": "Do something"})
+        kwargs = mock_cog.spawn_session.call_args.kwargs
+        assert kwargs.get("working_dir") is None
+
 
 class TestMarkResume:
     """Tests for POST /api/mark-resume endpoint."""

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -463,6 +463,53 @@ class TestSpawnSession:
         thread.send.assert_called_once_with("Hello")
         mock_run.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_spawn_passes_working_dir_to_run_claude(self) -> None:
+        """spawn_session passes working_dir through to _run_claude as working_dir_override."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import discord
+
+        thread = MagicMock(spec=discord.Thread)
+        seed_msg = MagicMock()
+        thread.send = AsyncMock(return_value=seed_msg)
+
+        channel = MagicMock()
+        channel.create_thread = AsyncMock(return_value=thread)
+
+        bot = MagicMock()
+        cog = ClaudeChatCog(bot=bot, repo=MagicMock(), runner=MagicMock())
+
+        mock_run = AsyncMock()
+        with patch.object(cog, "_run_claude", new=mock_run):
+            await cog.spawn_session(channel, "Do work", working_dir="/Users/jeb/jebos/shopify/fumetsu")
+
+        mock_run.assert_called_once()
+        assert mock_run.call_args.kwargs.get("working_dir_override") == "/Users/jeb/jebos/shopify/fumetsu"
+
+    @pytest.mark.asyncio
+    async def test_spawn_working_dir_none_by_default(self) -> None:
+        """spawn_session passes working_dir_override=None when working_dir not given."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import discord
+
+        thread = MagicMock(spec=discord.Thread)
+        thread.send = AsyncMock()
+
+        channel = MagicMock()
+        channel.create_thread = AsyncMock(return_value=thread)
+
+        bot = MagicMock()
+        cog = ClaudeChatCog(bot=bot, repo=MagicMock(), runner=MagicMock())
+
+        mock_run = AsyncMock()
+        with patch.object(cog, "_run_claude", new=mock_run):
+            await cog.spawn_session(channel, "Do work")
+
+        mock_run.assert_called_once()
+        assert mock_run.call_args.kwargs.get("working_dir_override") is None
+
 
 class TestFetchSeedContext:
     """Tests for ClaudeChatCog._fetch_seed_context()."""


### PR DESCRIPTION
## Summary

- Adds `working_dir: str | None = None` parameter to `ClaudeChatCog.spawn_session()`
- Forwards it as `working_dir_override` to `_run_claude()` so Claude Code actually runs in the specified directory
- Extracts `working_dir` from `POST /api/spawn` request body and passes it to the cog

Without this, all programmatically spawned sessions (e.g. via a dashboard dispatch UI) run in the bot's cwd regardless of which working directory is requested in the payload.

## Test plan

- [ ] `test_spawn_passes_working_dir_to_run_claude` — verifies `working_dir_override` is forwarded
- [ ] `test_spawn_working_dir_none_by_default` — verifies no regression when omitted
- [ ] `test_spawn_passes_working_dir_to_cog` — verifies API endpoint extracts and passes the param
- [ ] `test_spawn_working_dir_defaults_to_none` — verifies no regression when omitted from request

All existing spawn tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)