### PR TITLE
[codex] Fix thread dashboard shutdown resilience

### DIFF
--- a/claude_discord/discord_ui/thread_dashboard.py
+++ b/claude_discord/discord_ui/thread_dashboard.py
@@ -202,9 +202,9 @@ class ThreadStatusDashboard:
             logger.debug("Dashboard message was deleted; re-posting")
             try:
                 self._dashboard_message = await self._channel.send(embed=embed)
-            except discord.HTTPException:
+            except (discord.HTTPException, RuntimeError):
                 logger.warning("Failed to re-post dashboard message", exc_info=True)
-        except discord.HTTPException:
+        except (discord.HTTPException, RuntimeError):
             logger.debug("Failed to edit dashboard message", exc_info=True)
 
     def _prune_stale(self) -> None:

--- a/tests/test_thread_dashboard.py
+++ b/tests/test_thread_dashboard.py
@@ -217,6 +217,40 @@ class TestRemove:
 
 
 # ---------------------------------------------------------------------------
+# Shutdown resilience
+# ---------------------------------------------------------------------------
+
+
+class TestShutdownResilience:
+    @pytest.mark.asyncio
+    async def test_refresh_survives_session_closed_runtime_error(self) -> None:
+        """RuntimeError('Session is closed') during bot shutdown must not propagate.
+
+        When aiohttp closes its HTTP session during shutdown, message.edit() raises
+        RuntimeError instead of discord.HTTPException. The dashboard must swallow it.
+        """
+        dashboard, channel = _make_dashboard()
+        await dashboard.initialize()
+        msg = channel.send.return_value
+        msg.edit.side_effect = RuntimeError("Session is closed")
+
+        # Should not raise
+        await dashboard.set_state(1, ThreadState.PROCESSING, "work", thread=_make_thread(1))
+
+    @pytest.mark.asyncio
+    async def test_remove_survives_session_closed_runtime_error(self) -> None:
+        """remove() must also survive RuntimeError during shutdown."""
+        dashboard, channel = _make_dashboard()
+        await dashboard.initialize()
+        msg = channel.send.return_value
+        msg.edit.side_effect = RuntimeError("Session is closed")
+        await dashboard.set_state(1, ThreadState.PROCESSING, "work")
+
+        # Should not raise
+        await dashboard.remove(1)
+
+
+# ---------------------------------------------------------------------------
 # Embed building
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- catch `RuntimeError("Session is closed")` alongside `discord.HTTPException` when refreshing the thread dashboard during shutdown
- add regression coverage for both refresh and remove paths while the aiohttp session is already closed

## Why
During shutdown, `message.edit()` can fail with `RuntimeError` before Discord wraps it as an HTTP exception. That made dashboard cleanup noisy and brittle even though the bot was already stopping.

## Validation
- `uv run pytest tests/test_thread_dashboard.py -v`
