### PR TITLE
[codex] Surface Codex usage and fix resume flags

### DIFF
--- a/claude_code_core/codex_runner.py
+++ b/claude_code_core/codex_runner.py
@@ -248,12 +248,15 @@ class CodexRunner:
             codex exec [OPTIONS] [PROMPT]
             codex exec resume [OPTIONS] [SESSION_ID] [PROMPT]
 
-        Both subcommands accept --json and --model. The resume positional
-        args come AFTER any flags, with SESSION_ID before PROMPT.
+        Both subcommands accept --json and --model. Resume supports a smaller
+        flag surface than fresh exec runs: notably, it does not accept
+        --ask-for-approval or --cd. The resume positional args come AFTER any
+        supported flags, with SESSION_ID before PROMPT.
         """
         # Always under the `exec` subcommand. `resume` is its sub-subcommand.
         args = [self.command, "exec"]
-        if session_id:
+        is_resume = session_id is not None
+        if is_resume:
             if not re.match(r"^[a-f0-9\-]+$", session_id):
                 raise ValueError(f"Invalid session_id format: {session_id!r}")
             args.append("resume")
@@ -262,10 +265,10 @@ class CodexRunner:
 
         if self.dangerously_skip_permissions:
             args.append("--dangerously-bypass-approvals-and-sandbox")
-        elif self.permission_mode in _APPROVAL_MODE_MAP:
+        elif not is_resume and self.permission_mode in _APPROVAL_MODE_MAP:
             args.extend(["--ask-for-approval", _APPROVAL_MODE_MAP[self.permission_mode]])
 
-        if self.working_dir:
+        if not is_resume and self.working_dir:
             args.extend(["--cd", self.working_dir])
 
         # Positional args come last. For resume: SESSION_ID then PROMPT.

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -490,25 +490,21 @@ class EventProcessor:
                 if self._config.status:
                     await self._config.status.set_done()
 
-                # Post the configured statusLine as Discord subtext. Only
-                # meaningful for the Claude backend — the statusLine command
-                # reads ~/.claude/settings.json and surfaces Anthropic-specific
-                # quota windows (5h, 7d) that have no Codex equivalent. Skip
-                # for non-claude backends entirely.
-                if _backend_name_from_runner(self._config.runner) == "claude":
-                    asyncio.create_task(
-                        _post_statusline_footer(
-                            thread=self._config.thread,
-                            working_dir=self._config.runner.working_dir,
-                            model=self._config.runner.model,
-                            context_window=event.context_window,
-                            input_tokens=event.input_tokens,
-                            cache_creation_tokens=event.cache_creation_tokens,
-                            cache_read_tokens=event.cache_read_tokens,
-                            api_label=self._config.runner.describe_api(),
-                        ),
-                        name=f"statusline-{self._config.thread.id}",
-                    )
+                asyncio.create_task(
+                    _post_statusline_footer(
+                        thread=self._config.thread,
+                        working_dir=self._config.runner.working_dir,
+                        model=self._config.runner.model,
+                        context_window=event.context_window,
+                        input_tokens=event.input_tokens,
+                        cache_creation_tokens=event.cache_creation_tokens,
+                        cache_read_tokens=event.cache_read_tokens,
+                        api_label=self._config.runner.describe_api(),
+                        backend=_backend_name_from_runner(self._config.runner),
+                        command=self._config.runner.command,
+                    ),
+                    name=f"statusline-{self._config.thread.id}",
+                )
 
                 # Schedule inbox classification as a background task (non-blocking).
                 # Only runs when inbox_repo is wired in (THREAD_INBOX_ENABLED=true).
@@ -776,6 +772,8 @@ async def _post_statusline_footer(
     cache_creation_tokens: int | None,
     cache_read_tokens: int | None,
     api_label: str | None = None,
+    backend: str = "claude",
+    command: str = "claude",
 ) -> None:
     """Post the current API provider line and the configured statusLine.
 
@@ -785,8 +783,7 @@ async def _post_statusline_footer(
     (read from ``~/.claude/settings.json``) is appended below it when present.
     Posts nothing when neither is available.
     """
-    import os
-
+    from ..discord_ui.codex_usage import build_codex_usage_lines, fetch_codex_rate_limits
     from ..discord_ui.statusline import (
         build_statusline_json,
         read_statusline_command,
@@ -794,9 +791,9 @@ async def _post_statusline_footer(
     )
 
     statusline_text: str | None = None
-    command = read_statusline_command()
-    if command:
-        cwd = working_dir or os.path.expanduser("~")
+    statusline_command = read_statusline_command() if backend == "claude" else None
+    if statusline_command:
+        cwd = working_dir or str(Path.home())
         json_input = build_statusline_json(
             cwd=cwd,
             model_id=model,
@@ -806,11 +803,16 @@ async def _post_statusline_footer(
             cache_creation_tokens=cache_creation_tokens or 0,
             cache_read_tokens=cache_read_tokens or 0,
         )
-        result = await render_statusline(command, json_input)
+        result = await render_statusline(statusline_command, json_input)
         if result:
             lines = [line for line in result.splitlines() if line.strip()]
             if lines:
                 statusline_text = "\n".join(lines[:3])
+    elif backend == "codex":
+        payload = await fetch_codex_rate_limits(command)
+        lines = build_codex_usage_lines(payload) if payload else []
+        if lines:
+            statusline_text = "\n".join(lines[:3])
 
     parts: list[str] = []
     if api_label:

--- a/claude_discord/cogs/session_manage.py
+++ b/claude_discord/cogs/session_manage.py
@@ -9,6 +9,7 @@ Provides slash commands for viewing and managing Claude Code sessions:
 
 from __future__ import annotations
 
+import inspect
 import logging
 import time
 from typing import TYPE_CHECKING
@@ -17,8 +18,10 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from ..backend_factory import DEFAULT_COMMAND
 from ..database.repository import SessionRepository, UsageStatsRepository
 from ..database.settings_repo import SettingsRepository
+from ..discord_ui.codex_usage import build_codex_usage_lines, fetch_codex_rate_limits
 from ..discord_ui.embeds import COLOR_ERROR, COLOR_INFO, COLOR_SUCCESS, COLOR_TOOL
 from ..discord_ui.views import ResumeSelectView, ToolSelectView
 from ..worktree import WorktreeManager
@@ -178,6 +181,34 @@ class SessionManageCog(commands.Cog):
         if runner is not None and hasattr(runner, "model"):
             return runner.model  # type: ignore[return-value]
         return "sonnet"
+
+    async def _get_current_backend(self, interaction: discord.Interaction) -> str:
+        """Return the effective backend for the current thread/channel."""
+        chat_cog = self.bot.get_cog("ClaudeChatCog")
+        backend_settings = getattr(chat_cog, "_backend_settings", None)
+        if backend_settings is None:
+            return "claude"
+        thread_id = None
+        if isinstance(interaction.channel, discord.Thread):
+            thread_id = interaction.channel.id
+        getter = getattr(backend_settings, "current_backend", None)
+        if getter is None:
+            return "claude"
+        value = getter(thread_id)
+        if inspect.isawaitable(value):
+            value = await value
+        return value if value in {"claude", "codex"} else "claude"
+
+    def _get_command_for_backend(self, backend: str) -> str:
+        """Resolve the configured CLI command for a backend."""
+        chat_cog = self.bot.get_cog("ClaudeChatCog")
+        factory = getattr(chat_cog, "_factory", None)
+        if factory is not None:
+            return factory.command_for(backend)
+        runner = self._get_runner()
+        if runner is not None and getattr(runner, "command", None) and backend == "claude":
+            return runner.command
+        return DEFAULT_COMMAND.get(backend, backend)
 
     # ── Model commands ────────────────────────────────────────────────────────
 
@@ -948,10 +979,28 @@ class SessionManageCog(commands.Cog):
 
     @app_commands.command(
         name="usage",
-        description="Show Claude Code rate limit usage and weekly activity",
+        description="Show current backend rate limit usage and weekly activity",
     )
     async def usage_show(self, interaction: discord.Interaction) -> None:
         """Display rate limit utilization (5-hour / 7-day) with reset countdown."""
+        backend = await self._get_current_backend(interaction)
+        if backend == "codex":
+            payload = await fetch_codex_rate_limits(self._get_command_for_backend("codex"))
+            if not payload:
+                await interaction.response.send_message(
+                    "ℹ️ No Codex usage data yet — try again after starting a Codex session.",
+                    ephemeral=True,
+                )
+                return
+
+            embed = discord.Embed(
+                title="📊 Codex Usage",
+                description="\n".join(build_codex_usage_lines(payload)),
+                color=COLOR_INFO,
+            )
+            await interaction.response.send_message(embed=embed)
+            return
+
         if self.usage_repo is None:
             await interaction.response.send_message(
                 "ℹ️ Usage tracking is not enabled for this bot instance.", ephemeral=True

--- a/claude_discord/cogs/session_manage.py
+++ b/claude_discord/cogs/session_manage.py
@@ -206,8 +206,9 @@ class SessionManageCog(commands.Cog):
         if factory is not None:
             return factory.command_for(backend)
         runner = self._get_runner()
-        if runner is not None and getattr(runner, "command", None) and backend == "claude":
-            return runner.command
+        command = getattr(runner, "command", None)
+        if isinstance(command, str) and backend == "claude":
+            return command
         return DEFAULT_COMMAND.get(backend, backend)
 
     # ── Model commands ────────────────────────────────────────────────────────

--- a/claude_discord/discord_ui/codex_usage.py
+++ b/claude_discord/discord_ui/codex_usage.py
@@ -1,0 +1,162 @@
+"""Helpers for fetching and formatting Codex rate-limit usage."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT_SECONDS = 10.0
+_CACHE_MAX_AGE_SECONDS = 60
+_CACHE_PATH = Path("/tmp/codex/statusline-usage-cache.json")
+
+
+def _progress_bar(percent: int, width: int = 10) -> str:
+    filled = round((max(0, min(100, percent)) / 100) * width)
+    return "█" * filled + "░" * (width - filled)
+
+
+def _format_countdown(resets_at: int | None, now: int | None = None) -> str:
+    if resets_at is None:
+        return "reset unknown"
+    current = int(time.time()) if now is None else now
+    remaining = resets_at - current
+    if remaining <= 0:
+        return "resetting now"
+    hours, rem = divmod(remaining, 3600)
+    minutes = rem // 60
+    if hours > 0:
+        return f"resets in {hours}h {minutes}m"
+    return f"resets in {minutes}m"
+
+
+def _window_label(window: dict[str, Any], fallback: str) -> str:
+    mins = window.get("windowDurationMins")
+    if mins == 300:
+        return "⏱ 5h"
+    if mins == 10080:
+        return "📅 7d"
+    return fallback
+
+
+def build_codex_usage_lines(payload: dict[str, Any], now: int | None = None) -> list[str]:
+    """Render Codex usage payload into Discord-friendly text lines."""
+    snapshot = payload.get("rateLimits") or {}
+    lines: list[str] = []
+    for key, fallback in (("primary", "⏱ primary"), ("secondary", "📅 secondary")):
+        window = snapshot.get(key)
+        if not isinstance(window, dict):
+            continue
+        used = int(window.get("usedPercent", 0))
+        label = _window_label(window, fallback)
+        countdown = _format_countdown(window.get("resetsAt"), now=now)
+        lines.append(f"{label} `{_progress_bar(used)}` **{used}%** — {countdown}")
+    return lines
+
+
+def _load_cache(max_age_seconds: int) -> dict[str, Any] | None:
+    try:
+        raw = json.loads(_CACHE_PATH.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return None
+    fetched_at = raw.get("fetched_at")
+    data = raw.get("data")
+    if not isinstance(fetched_at, (int, float)) or not isinstance(data, dict):
+        return None
+    if time.time() - fetched_at > max_age_seconds:
+        return None
+    return data
+
+
+def _write_cache(data: dict[str, Any]) -> None:
+    try:
+        _CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _CACHE_PATH.write_text(
+            json.dumps({"fetched_at": time.time(), "data": data}),
+            encoding="utf-8",
+        )
+    except OSError:
+        logger.debug("Failed to write Codex usage cache", exc_info=True)
+
+
+async def fetch_codex_rate_limits(
+    command: str = "codex",
+    *,
+    timeout: float = _TIMEOUT_SECONDS,
+    use_cache: bool = True,
+    cache_max_age_seconds: int = _CACHE_MAX_AGE_SECONDS,
+) -> dict[str, Any] | None:
+    """Fetch Codex account rate limits via the app-server stdio RPC."""
+    if use_cache:
+        cached = _load_cache(cache_max_age_seconds)
+        if cached is not None:
+            return cached
+
+    process = await asyncio.create_subprocess_exec(
+        command,
+        "app-server",
+        "--listen",
+        "stdio://",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+
+    async def _send(payload: dict[str, Any]) -> None:
+        if process.stdin is None:
+            raise RuntimeError("Codex app-server stdin unavailable")
+        process.stdin.write((json.dumps(payload) + "\n").encode("utf-8"))
+        await process.stdin.drain()
+
+    result: dict[str, Any] | None = None
+    deadline = time.monotonic() + timeout
+    try:
+        await _send(
+            {
+                "id": 1,
+                "method": "initialize",
+                "params": {"clientInfo": {"name": "ccdb", "version": "1.0"}},
+            }
+        )
+        await _send({"id": 2, "method": "account/rateLimits/read", "params": None})
+
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("Timed out waiting for Codex rate limits")
+            if process.stdout is None:
+                break
+            line = await asyncio.wait_for(process.stdout.readline(), timeout=remaining)
+            if not line:
+                break
+            try:
+                message = json.loads(line.decode("utf-8"))
+            except json.JSONDecodeError:
+                continue
+            if message.get("id") == 2 and isinstance(message.get("result"), dict):
+                result = message["result"]
+                break
+    except (TimeoutError, OSError, RuntimeError):
+        logger.debug("Failed to fetch Codex rate limits", exc_info=True)
+        result = None
+    finally:
+        if process.stdin is not None:
+            process.stdin.close()
+        if process.returncode is None:
+            process.terminate()
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(process.wait(), timeout=1.0)
+        if process.returncode is None:
+            process.kill()
+            with contextlib.suppress(Exception):
+                await process.wait()
+
+    if result is not None and use_cache:
+        _write_cache(result)
+    return result

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -53,6 +53,26 @@ class TestCodexRunnerBuildArgs:
         assert "--cd" in args or "-C" in args
         assert "/tmp/work" in args
 
+    def test_resume_omits_working_dir_flag(self) -> None:
+        runner = CodexRunner(
+            command="codex",
+            model="o4-mini",
+            working_dir="/tmp/work",
+        )
+        args = runner._build_args("hello", session_id="0199a213-81c0-7800-8aa1-bbab2a035a53")
+        assert "--cd" not in args
+        assert "-C" not in args
+
+    def test_resume_omits_approval_flag(self) -> None:
+        runner = CodexRunner(
+            command="codex",
+            model="o4-mini",
+            permission_mode="acceptEdits",
+        )
+        args = runner._build_args("hello", session_id="0199a213-81c0-7800-8aa1-bbab2a035a53")
+        assert "--ask-for-approval" not in args
+        assert "-a" not in args
+
     def test_prompt_is_last_arg(self) -> None:
         runner = CodexRunner(command="codex", model="o4-mini")
         args = runner._build_args("hello world", session_id=None)
@@ -215,9 +235,10 @@ class TestCodexRunnerArgvStructure:
         codex exec [OPTIONS] [PROMPT]
         codex exec resume [OPTIONS] [SESSION_ID] [PROMPT]
 
-    Both subcommands accept ``--json``, ``--model``, ``--ask-for-approval``,
-    ``--dangerously-bypass-approvals-and-sandbox``, ``--cd``. The resume
-    positional args come AFTER all flags, with SESSION_ID before PROMPT.
+    Both subcommands accept ``--json`` and ``--model``. Resume also accepts
+    ``--dangerously-bypass-approvals-and-sandbox``, but does NOT accept
+    ``--ask-for-approval`` or ``--cd``. The resume positional args come
+    AFTER all supported flags, with SESSION_ID before PROMPT.
 
     These tests guard against regressions like the one that shipped briefly
     in 3.0.0 where resume was invoked as ``codex resume <id> --json …`` —
@@ -253,12 +274,26 @@ class TestCodexRunnerArgvStructure:
         )
         args = runner._build_args("hello", session_id=sid)
         sid_idx = args.index(sid)
-        # --json, --model, --ask-for-approval, --cd must all come before SESSION_ID.
-        for flag in ("--json", "--model", "--ask-for-approval", "--cd"):
+        # Supported resume flags must come before SESSION_ID.
+        for flag in ("--json", "--model"):
             assert flag in args, f"{flag} missing from resume args"
             assert args.index(flag) < sid_idx, (
                 f"{flag} should appear before SESSION_ID in codex exec resume"
             )
+
+    def test_resume_does_not_include_unsupported_flags(self) -> None:
+        sid = "019e29a0-d5b0-71f0-bdc0-46f09a06fdaf"
+        runner = CodexRunner(
+            command="codex",
+            model="gpt-5.4",
+            permission_mode="acceptEdits",
+            working_dir="/work",
+        )
+        args = runner._build_args("hello", session_id=sid)
+        assert "--json" in args
+        assert "--model" in args
+        assert "--ask-for-approval" not in args
+        assert "--cd" not in args
 
     def test_resume_session_id_before_prompt(self) -> None:
         sid = "019e29a0-d5b0-71f0-bdc0-46f09a06fdaf"

--- a/tests/test_codex_usage.py
+++ b/tests/test_codex_usage.py
@@ -1,0 +1,111 @@
+"""Tests for Codex rate-limit fetching and formatting."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+from claude_discord.discord_ui.codex_usage import build_codex_usage_lines, fetch_codex_rate_limits
+
+
+class _DummyStdin:
+    def __init__(self) -> None:
+        self.buffer = bytearray()
+
+    def write(self, data: bytes) -> None:
+        self.buffer.extend(data)
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
+class _DummyStdout:
+    def __init__(self, lines: list[str]) -> None:
+        self._lines = [line.encode("utf-8") for line in lines]
+
+    async def readline(self) -> bytes:
+        if not self._lines:
+            return b""
+        return self._lines.pop(0)
+
+
+class _DummyProcess:
+    def __init__(self, lines: list[str]) -> None:
+        self.stdin = _DummyStdin()
+        self.stdout = _DummyStdout(lines)
+        self.returncode = None
+        self.terminated = False
+        self.killed = False
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.returncode = 0
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+
+    async def wait(self) -> int:
+        self.returncode = 0 if self.returncode is None else self.returncode
+        return self.returncode
+
+
+class TestFetchCodexRateLimits:
+    async def test_reads_rate_limits_via_app_server(self) -> None:
+        process = _DummyProcess(
+            [
+                json.dumps({"id": 1, "result": {"userAgent": "probe"}}) + "\n",
+                json.dumps(
+                    {
+                        "id": 2,
+                        "result": {
+                            "rateLimits": {
+                                "limitId": "codex",
+                                "primary": {"usedPercent": 24, "windowDurationMins": 300},
+                                "secondary": {"usedPercent": 11, "windowDurationMins": 10080},
+                            }
+                        },
+                    }
+                )
+                + "\n",
+            ]
+        )
+
+        with patch(
+            "claude_discord.discord_ui.codex_usage.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=process),
+        ):
+            result = await fetch_codex_rate_limits("codex", use_cache=False)
+
+        assert result is not None
+        assert result["rateLimits"]["primary"]["usedPercent"] == 24
+
+        sent = process.stdin.buffer.decode("utf-8")
+        assert '"method": "initialize"' in sent
+        assert '"method": "account/rateLimits/read"' in sent
+
+
+class TestBuildCodexUsageLines:
+    def test_formats_primary_and_secondary_windows(self) -> None:
+        payload = {
+            "rateLimits": {
+                "primary": {
+                    "usedPercent": 24,
+                    "windowDurationMins": 300,
+                    "resetsAt": 4_102_444_800,
+                },
+                "secondary": {
+                    "usedPercent": 11,
+                    "windowDurationMins": 10080,
+                    "resetsAt": 4_102_531_200,
+                },
+            }
+        }
+
+        lines = build_codex_usage_lines(payload, now=4_102_441_200)
+
+        assert any("5h" in line and "24%" in line for line in lines)
+        assert any("7d" in line and "11%" in line for line in lines)

--- a/tests/test_session_manage.py
+++ b/tests/test_session_manage.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 
@@ -232,3 +232,47 @@ class TestUsageCommand:
         assert embed is not None
         # Should show utilization percentage
         assert "61" in embed.description
+
+    async def test_usage_shows_codex_stats_for_codex_thread(self):
+        from claude_discord.cogs.session_manage import SessionManageCog
+
+        bot = MagicMock()
+        repo = MagicMock()
+        cog = SessionManageCog(bot=bot, repo=repo)
+
+        interaction = _make_thread_interaction()
+
+        backend_settings = MagicMock()
+        backend_settings.current_backend = AsyncMock(return_value="codex")
+        factory = MagicMock()
+        factory.command_for.return_value = "codex"
+        chat_cog = MagicMock()
+        chat_cog._backend_settings = backend_settings
+        chat_cog._factory = factory
+        bot.get_cog.return_value = chat_cog
+
+        with patch(
+            "claude_discord.cogs.session_manage.fetch_codex_rate_limits",
+            new=AsyncMock(
+                return_value={
+                    "rateLimits": {
+                        "primary": {
+                            "usedPercent": 24,
+                            "windowDurationMins": 300,
+                            "resetsAt": 4_102_444_800,
+                        },
+                        "secondary": {
+                            "usedPercent": 11,
+                            "windowDurationMins": 10080,
+                            "resetsAt": 4_102_531_200,
+                        },
+                    }
+                }
+            ),
+        ):
+            await cog.usage_show.callback(cog, interaction)
+
+        embed = interaction.response.send_message.call_args.kwargs.get("embed")
+        assert embed is not None
+        assert "Codex Usage" in embed.title
+        assert "24" in embed.description

--- a/tests/test_statusline_footer.py
+++ b/tests/test_statusline_footer.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, patch
 from claude_discord.cogs.event_processor import _post_statusline_footer
 
 _STATUSLINE_MOD = "claude_discord.discord_ui.statusline"
+_CODEX_USAGE_MOD = "claude_discord.discord_ui.codex_usage"
 
 
 async def test_posts_api_line_when_no_statusline_configured() -> None:
@@ -72,3 +73,44 @@ async def test_combines_api_line_and_statusline_output() -> None:
     assert "Ctx 45%" in body
     # The API line should appear above the statusline output.
     assert body.index("API:") < body.index("Ctx 45%")
+
+
+async def test_posts_codex_usage_footer() -> None:
+    thread = AsyncMock()
+    with (
+        patch(
+            f"{_CODEX_USAGE_MOD}.fetch_codex_rate_limits",
+            new=AsyncMock(
+                return_value={
+                    "rateLimits": {
+                        "primary": {
+                            "usedPercent": 24,
+                            "windowDurationMins": 300,
+                            "resetsAt": 4_102_444_800,
+                        },
+                        "secondary": {
+                            "usedPercent": 11,
+                            "windowDurationMins": 10080,
+                            "resetsAt": 4_102_531_200,
+                        },
+                    }
+                }
+            ),
+        ),
+    ):
+        await _post_statusline_footer(
+            thread=thread,
+            working_dir=None,
+            model="gpt-5.5",
+            context_window=None,
+            input_tokens=None,
+            cache_creation_tokens=None,
+            cache_read_tokens=None,
+            api_label="OpenAI API (direct)",
+            backend="codex",
+            command="codex",
+        )
+    body = thread.send.await_args.args[0]
+    assert "API: OpenAI API (direct)" in body
+    assert "5h" in body
+    assert "7d" in body


### PR DESCRIPTION
## Summary
- add a Codex usage helper that reads account rate limits through `codex app-server` and formats 5h / 7d usage lines for Discord
- show those usage lines in the completion footer and `/usage` command when the current thread is using the Codex backend
- stop passing unsupported `--ask-for-approval` and `--cd` flags to `codex exec resume`

## Why
Codex threads had no equivalent of Claude's status line, so users could not see current usage windows from Discord. The resume path also still passed flags that Codex does not accept, which could break resumed sessions.

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/test_codex_runner.py tests/test_session_manage.py tests/test_statusline_footer.py tests/test_codex_usage.py -v`
- `uv run pytest tests/ -v --cov=claude_discord` (locally hit one existing env-specific failure in `tests/test_backend_factory_api_port.py` because `API_PORT=8099` is set in this shell)
