### PR TITLE
fix: シャットダウン時のオーナーメンション送信で RuntimeError が伝播しないようにする

### DIFF
--- a/claude_discord/discord_ui/thread_dashboard.py
+++ b/claude_discord/discord_ui/thread_dashboard.py
@@ -202,9 +202,9 @@ class ThreadStatusDashboard:
             logger.debug("Dashboard message was deleted; re-posting")
             try:
                 self._dashboard_message = await self._channel.send(embed=embed)
-            except discord.HTTPException:
+            except (discord.HTTPException, RuntimeError):
                 logger.warning("Failed to re-post dashboard message", exc_info=True)
-        except discord.HTTPException:
+        except (discord.HTTPException, RuntimeError):
             logger.debug("Failed to edit dashboard message", exc_info=True)
 
     def _prune_stale(self) -> None:

--- a/claude_discord/discord_ui/thread_dashboard.py
+++ b/claude_discord/discord_ui/thread_dashboard.py
@@ -161,7 +161,7 @@ class ThreadStatusDashboard:
                 await thread.send(
                     f"🟡 <@{self._owner_id}> Claude has finished — your reply is needed here."
                 )
-            except discord.HTTPException:
+            except (discord.HTTPException, RuntimeError):
                 logger.debug("Failed to send owner mention in thread %d", thread_id, exc_info=True)
 
     async def remove(self, thread_id: int) -> None:

--- a/tests/test_thread_dashboard.py
+++ b/tests/test_thread_dashboard.py
@@ -217,6 +217,40 @@ class TestRemove:
 
 
 # ---------------------------------------------------------------------------
+# Shutdown resilience
+# ---------------------------------------------------------------------------
+
+
+class TestShutdownResilience:
+    @pytest.mark.asyncio
+    async def test_refresh_survives_session_closed_runtime_error(self) -> None:
+        """RuntimeError('Session is closed') during bot shutdown must not propagate.
+
+        When aiohttp closes its HTTP session during shutdown, message.edit() raises
+        RuntimeError instead of discord.HTTPException. The dashboard must swallow it.
+        """
+        dashboard, channel = _make_dashboard()
+        await dashboard.initialize()
+        msg = channel.send.return_value
+        msg.edit.side_effect = RuntimeError("Session is closed")
+
+        # Should not raise
+        await dashboard.set_state(1, ThreadState.PROCESSING, "work", thread=_make_thread(1))
+
+    @pytest.mark.asyncio
+    async def test_remove_survives_session_closed_runtime_error(self) -> None:
+        """remove() must also survive RuntimeError during shutdown."""
+        dashboard, channel = _make_dashboard()
+        await dashboard.initialize()
+        msg = channel.send.return_value
+        msg.edit.side_effect = RuntimeError("Session is closed")
+        await dashboard.set_state(1, ThreadState.PROCESSING, "work")
+
+        # Should not raise
+        await dashboard.remove(1)
+
+
+# ---------------------------------------------------------------------------
 # Embed building
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `thread_dashboard.py` の `set_state()` でオーナーメンション送信中に `RuntimeError("Session is closed")` が発生するとトレースバックが記録されていた
- ボット再起動時に `_run_claude` の `finally` ブロックが `dashboard.set_state()` を呼び、aiohttp セッション閉鎖後に `thread.send()` が実行されることで再現
- `_refresh_dashboard()` には既に `(discord.HTTPException, RuntimeError)` の catch があったが、メンション送信側の except が `discord.HTTPException` のみだった
- 同じパターンを適用（1行修正）

## Root Cause

```
# Before
except discord.HTTPException:

# After  
except (discord.HTTPException, RuntimeError):
```

`2026-06-11 09:37:55` のログで確認された再現:
```
RuntimeError: Session is closed
  at thread_dashboard.py:161 set_state → thread.send()
```

## Test plan

- [x] `uv run pytest tests/ -x -q` — 1483 passed
- [x] ruff check / format — all passed