### PR TITLE
fix: catch asyncio.TimeoutError in thread_renamer for Python 3.10

### DIFF
--- a/claude_discord/discord_ui/thread_renamer.py
+++ b/claude_discord/discord_ui/thread_renamer.py
@@ -110,7 +110,8 @@ async def suggest_title(
         )
         try:
             stdout, _stderr = await asyncio.wait_for(proc.communicate(), timeout=_TIMEOUT_SECONDS)
-        except TimeoutError:
+        except (TimeoutError, asyncio.TimeoutError):
+            # asyncio.TimeoutError != builtins.TimeoutError on Python 3.10; catch both.
             proc.kill()
             await proc.communicate()
             logger.warning("thread title renamer timed out after %ds", _TIMEOUT_SECONDS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ markers = [
 ]
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py310"
 line-length = 100
 
 [tool.pyright]

--- a/tests/test_thread_renamer.py
+++ b/tests/test_thread_renamer.py
@@ -282,14 +282,7 @@ class TestSuggestTitleErrors:
 
     @pytest.mark.asyncio
     async def test_kills_process_on_timeout(self):
-        """After asyncio.TimeoutError, proc.kill() and cleanup communicate() are called.
-
-        Raises asyncio.TimeoutError from inside the mock coroutine (the exact type
-        asyncio.wait_for raises on timeout).  The second communicate() call returns
-        normally so lines 56-59 of thread_renamer are all exercised:
-          proc.kill() → await proc.communicate() → logger.warning() → return None
-        """
-
+        """After builtin TimeoutError, proc.kill() and cleanup communicate() are called."""
         proc = _make_proc(b"")
         call_count = 0
 
@@ -303,4 +296,31 @@ class TestSuggestTitleErrors:
         proc.communicate = _timeout_on_first_call
         with patch("asyncio.create_subprocess_exec", return_value=proc):
             await suggest_title("some request")
+        proc.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_kills_process_on_asyncio_timeout(self):
+        """asyncio.TimeoutError (raised by asyncio.wait_for on real timeout) is caught.
+
+        On Python 3.10, asyncio.TimeoutError != builtins.TimeoutError — they have
+        separate inheritance chains. A plain 'except TimeoutError:' misses asyncio's
+        version, leaving the subprocess alive. This test reproduces that scenario by
+        raising asyncio.TimeoutError directly from the mock communicate coroutine.
+        """
+        import asyncio as _asyncio
+
+        proc = _make_proc(b"")
+        call_count = 0
+
+        async def _asyncio_timeout_on_first_call():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise _asyncio.TimeoutError()
+            return b"", b""
+
+        proc.communicate = _asyncio_timeout_on_first_call
+        with patch("asyncio.create_subprocess_exec", return_value=proc):
+            result = await suggest_title("some request")
+        assert result is None
         proc.kill.assert_called_once()


### PR DESCRIPTION
## Summary

- **Bug**: On Python 3.10, `asyncio.wait_for` raises `asyncio.TimeoutError` (≡ `concurrent.futures.TimeoutError`) which is **not** a subclass of `builtins.TimeoutError`. The existing `except TimeoutError:` block never triggered on a real timeout, leaving `proc.kill()` uncalled and logging a misleading "thread title renamer failed" message.
- **Fix**: Catch `(TimeoutError, asyncio.TimeoutError)` — safe on all versions (Python 3.11+ unifies them).
- **Config fix**: Corrected `ruff target-version` from `py311` → `py310` to match `requires-python = ">=3.10"` and avoid `UP041` false positives.
- **Test added**: `test_kills_process_on_asyncio_timeout` covers the `asyncio.TimeoutError` path that the existing timeout test missed.

## Root cause

Detected via the automated maintenance agent from this log entry:
```
2026-06-12 22:54:44 [WARNING] thread title renamer failed
asyncio.exceptions.TimeoutError
```
The outer `except Exception:` caught the timeout instead of the inner `except TimeoutError:`.

## Test plan

- [x] `uv run pytest tests/test_thread_renamer.py -v` — all 27 tests pass
- [x] `uv run ruff check claude_discord/` — no errors
- [x] `uv run ruff format --check claude_discord/` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)