### PR TITLE
fix: drop --cd flag when resuming a Codex session

### DIFF
--- a/claude_code_core/codex_runner.py
+++ b/claude_code_core/codex_runner.py
@@ -265,7 +265,9 @@ class CodexRunner:
         elif self.permission_mode in _APPROVAL_MODE_MAP:
             args.extend(["--ask-for-approval", _APPROVAL_MODE_MAP[self.permission_mode]])
 
-        if self.working_dir:
+        # `--cd` is only accepted by `codex exec`, not `codex exec resume`.
+        # Resume reuses the working directory of the original session.
+        if self.working_dir and not session_id:
             args.extend(["--cd", self.working_dir])
 
         # Positional args come last. For resume: SESSION_ID then PROMPT.

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -53,6 +53,15 @@ class TestCodexRunnerBuildArgs:
         assert "--cd" in args or "-C" in args
         assert "/tmp/work" in args
 
+    def test_working_dir_flag_omitted_on_resume(self) -> None:
+        """`codex exec resume` does not accept --cd; it must be omitted on resume."""
+        runner = CodexRunner(command="codex", model="o4-mini", working_dir="/tmp/work")
+        args = runner._build_args(
+            "hello", session_id="0199a213-81c0-7800-8aa1-bbab2a035a53"
+        )
+        assert "--cd" not in args
+        assert "-C" not in args
+
     def test_prompt_is_last_arg(self) -> None:
         runner = CodexRunner(command="codex", model="o4-mini")
         args = runner._build_args("hello world", session_id=None)
@@ -253,8 +262,9 @@ class TestCodexRunnerArgvStructure:
         )
         args = runner._build_args("hello", session_id=sid)
         sid_idx = args.index(sid)
-        # --json, --model, --ask-for-approval, --cd must all come before SESSION_ID.
-        for flag in ("--json", "--model", "--ask-for-approval", "--cd"):
+        # --cd is not accepted by `codex exec resume`, so it is intentionally
+        # omitted on resume; the remaining shared flags must precede SESSION_ID.
+        for flag in ("--json", "--model", "--ask-for-approval"):
             assert flag in args, f"{flag} missing from resume args"
             assert args.index(flag) < sid_idx, (
                 f"{flag} should appear before SESSION_ID in codex exec resume"


### PR DESCRIPTION
## Summary

`codex exec resume` does not accept the `--cd` flag (it only exists on `codex exec`). Passing it makes resume invocations exit with code **2** and the error `unexpected argument '--cd' found`, so the first message in a Codex thread succeeds but every follow-up message fails immediately.

Resume reuses the working directory of the original session, so the flag is unnecessary there. This PR skips emitting `--cd` whenever `session_id` is supplied.

## Reproduction

Observed in a live ccdb session (codex backend, `gpt-5.4`):

\`\`\`
23:28:32  codex exec --json --model gpt-5.4 --skip-git-repo-check ...   ← 1st msg OK
23:29:56  codex exec resume --json --model gpt-5.4 ...                  ← 2nd msg
          ERROR: Codex CLI exited with code 2:
                 error: unexpected argument '--cd' found
                 Usage: codex exec resume --json --model <MODEL> --skip-git-repo-check [SESSION_ID] [PROMPT]
\`\`\`

Verified directly against codex-cli 0.139.0:

\`\`\`
\$ codex exec resume --json --model gpt-5.4 --cd /home/ec2-user --skip-git-repo-check <UUID> "hi"
error: unexpected argument '--cd' found
exit=2
\`\`\`

## Changes

- \`claude_code_core/codex_runner.py\` — emit \`--cd\` only when \`session_id is None\`
- \`tests/test_codex_runner.py\`
  - new test \`test_working_dir_flag_omitted_on_resume\` pinning the omission
  - existing \`test_resume_flags_precede_session_id\` no longer asserts \`--cd\` (it encoded the buggy behaviour)

## Test plan

- [x] \`pytest tests/test_codex_runner.py\` — 30/30 passing
- [ ] End-to-end: send a 2nd message in a codex thread — should resume instead of exiting 2