### PR TITLE
feat: authenticated /api/ingest endpoint with base64 attachments

### DIFF
--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -14,6 +14,8 @@ Security:
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 import contextlib
 import hmac
 import json
@@ -23,6 +25,7 @@ import re
 import uuid
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from aiohttp import web
@@ -46,6 +49,27 @@ if TYPE_CHECKING:
 _MAX_RUN_PROMPT_BYTES = 64 * 1024
 # Skill names are passed toward the CLI; restrict to a safe charset.
 _SKILL_NAME_RE = re.compile(r"^[\w-]+$")
+
+# /api/ingest — authenticated spawn for untrusted external clients (browser
+# extensions, mobile shortcuts, webhooks) that may carry file attachments.
+_MAX_INGEST_ATTACHMENTS = 20
+_MAX_INGEST_TOTAL_BYTES = 50 * 1024 * 1024
+# Characters allowed in a saved attachment filename; everything else → "_".
+_UNSAFE_FILENAME_RE = re.compile(r"[^\w.\-]+")
+
+
+def _safe_attachment_name(raw: object, index: int) -> str:
+    """Reduce a client-supplied filename to a safe basename.
+
+    Strips any directory component (path-traversal guard), replaces unsafe
+    characters, and drops leading dots so attachments can't masquerade as
+    hidden/dotfiles. Falls back to ``attachment_{index}`` when nothing usable
+    remains.
+    """
+    name = os.path.basename(str(raw or "")).strip()
+    name = _UNSAFE_FILENAME_RE.sub("_", name).lstrip(".")
+    return name or f"attachment_{index}"
+
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +107,8 @@ class ApiServer:
         host: str = "127.0.0.1",
         port: int = 8080,
         api_secret: str | None = None,
+        ingest_token: str | None = None,
+        working_dir: str | None = None,
         task_repo: TaskRepository | None = None,
         lounge_repo: LoungeRepository | None = None,
         lounge_channel_id: int | None = None,
@@ -98,6 +124,8 @@ class ApiServer:
         self.host = host
         self.port = port
         self.api_secret = api_secret
+        self.ingest_token = ingest_token
+        self.working_dir = working_dir
         self.task_repo = task_repo
         self.lounge_repo = lounge_repo
         self.resume_repo = resume_repo
@@ -136,6 +164,8 @@ class ApiServer:
         self.app.router.add_post("/api/lounge", self.post_lounge)
         # Session spawn route
         self.app.router.add_post("/api/spawn", self.spawn)
+        # Authenticated external ingest route (browser extension / webhooks)
+        self.app.router.add_post("/api/ingest", self.ingest)
         # Async one-shot AI run routes (requires run_repo + backend_factory)
         self.app.router.add_post("/api/run", self.create_run)
         self.app.router.add_get("/api/run/{run_id}", self.get_run)
@@ -678,6 +708,189 @@ class ApiServer:
                 "status": "spawned",
                 "thread_id": str(thread.id),
                 "thread_name": thread.name,
+            },
+            status=201,
+        )
+
+    # ------------------------------------------------------------------
+    # Authenticated external ingest endpoint (/api/ingest)
+    # ------------------------------------------------------------------
+
+    def _ingest_root(self) -> Path:
+        """Directory under which ingested attachments are saved."""
+        return Path(self.working_dir or os.getcwd()) / "ingest"
+
+    def _save_ingest_attachments(
+        self, attachments: list[dict], thread_id: str
+    ) -> tuple[list[Path], web.Response | None]:
+        """Decode base64 attachments to disk under a per-request directory.
+
+        Returns ``(saved_paths, error_response)``. On any validation failure the
+        second element is a ready-to-return :class:`web.Response` and the first
+        is empty.
+        """
+        if len(attachments) > _MAX_INGEST_ATTACHMENTS:
+            return [], web.json_response(
+                {"error": f"Too many attachments (max {_MAX_INGEST_ATTACHMENTS})"},
+                status=400,
+            )
+
+        dest_dir = self._ingest_root() / thread_id
+        saved: list[Path] = []
+        total = 0
+        for i, att in enumerate(attachments):
+            if not isinstance(att, dict):
+                return [], web.json_response(
+                    {"error": f"Attachment {i} must be an object"}, status=400
+                )
+            data_b64 = att.get("data")
+            if not data_b64:
+                return [], web.json_response(
+                    {"error": f"Attachment {i} missing 'data'"}, status=400
+                )
+            try:
+                blob = base64.b64decode(str(data_b64), validate=True)
+            except (binascii.Error, ValueError):
+                return [], web.json_response(
+                    {"error": f"Attachment {i} has invalid base64 'data'"}, status=400
+                )
+            total += len(blob)
+            if total > _MAX_INGEST_TOTAL_BYTES:
+                return [], web.json_response(
+                    {"error": "Attachments exceed total size limit"}, status=413
+                )
+            filename = _safe_attachment_name(att.get("filename"), i)
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            path = dest_dir / filename
+            try:
+                path.write_bytes(blob)
+            except OSError as exc:
+                logger.error("Failed to write ingest attachment: %s", exc)
+                return [], web.json_response({"error": "Failed to persist attachment"}, status=500)
+            saved.append(path)
+            logger.info("Saved ingest attachment %s (%d bytes)", _sanitize_log(path), len(blob))
+        return saved, None
+
+    async def ingest(self, request: web.Request) -> web.Response:
+        """POST /api/ingest — authenticated spawn for untrusted external clients.
+
+        Unlike ``/api/spawn`` (trusted, unauthenticated localhost callers), this
+        endpoint is meant for clients such as a browser extension. It requires a
+        dedicated bearer token (``ingest_token``) and can carry base64 file
+        attachments that are written to ``{working_dir}/ingest/{thread_id}/`` so
+        the spawned Claude session can read them.
+
+        The endpoint is opt-in: when no ``ingest_token`` is configured it
+        responds ``503`` so it can never run unauthenticated by accident. It is
+        independent of the global ``api_secret`` middleware, so enabling it does
+        not change the auth requirements of any other route.
+
+        Body (JSON):
+            content: The message body / instruction (required). ``prompt`` is
+                accepted as an alias.
+            thread_name: Custom thread title (optional).
+            channel_id: Parent channel ID (optional; defaults to startup value).
+            auto_start: Start a Claude session immediately (optional, default true).
+            attachments: Optional list of ``{filename, mimetype?, data}`` where
+                ``data`` is base64-encoded file bytes.
+
+        Returns (201):
+            ``{"status": "spawned", "thread_id": "...", "thread_name": "...",
+               "attachments_saved": N}``
+        """
+        # --- Opt-in + auth (independent of the global api_secret middleware) ---
+        if not self.ingest_token:
+            return web.json_response({"error": "Ingest endpoint is disabled"}, status=503)
+
+        auth_header = request.headers.get("Authorization", "")
+        if not auth_header.startswith("Bearer "):
+            return web.json_response({"error": "Missing Authorization header"}, status=401)
+        if not hmac.compare_digest(auth_header[7:], self.ingest_token):
+            return web.json_response({"error": "Invalid token"}, status=401)
+
+        try:
+            data = await request.json()
+        except json.JSONDecodeError:
+            return web.json_response({"error": "Invalid JSON"}, status=400)
+
+        content = (data.get("content") or data.get("prompt") or "").strip()
+        if not content:
+            return web.json_response({"error": "content is required"}, status=400)
+
+        raw_channel_id = data.get("channel_id") or self.default_channel_id
+        if not raw_channel_id:
+            return web.json_response({"error": "No channel specified"}, status=400)
+
+        attachments = data.get("attachments") or []
+        if not isinstance(attachments, list):
+            return web.json_response({"error": "attachments must be a list"}, status=400)
+
+        from ..cogs.claude_chat import ClaudeChatCog  # avoid circular import
+
+        cog: ClaudeChatCog | None = self.bot.cogs.get("ClaudeChatCog")  # type: ignore[assignment]
+        if cog is None:
+            return web.json_response({"error": "ClaudeChatCog is not loaded"}, status=503)
+
+        try:
+            channel_id = int(raw_channel_id)
+        except (TypeError, ValueError):
+            return web.json_response({"error": "channel_id must be an integer"}, status=400)
+
+        import discord as _discord
+
+        raw = self.bot.get_channel(channel_id)
+        if raw is None:
+            try:
+                raw = await self.bot.fetch_channel(channel_id)
+            except Exception as exc:
+                return web.json_response({"error": str(exc)}, status=500)
+
+        if not isinstance(raw, _discord.TextChannel):
+            return web.json_response(
+                {"error": "Channel must be a text channel that supports threads"},
+                status=400,
+            )
+
+        # Save attachments under a stable per-request id reused for the dir name.
+        request_id = uuid.uuid4().hex
+        saved_paths, err = self._save_ingest_attachments(attachments, request_id)
+        if err is not None:
+            return err
+
+        prompt = content
+        if saved_paths:
+            listing = "\n".join(f"- {p}" for p in saved_paths)
+            prompt = (
+                f"{content}\n\n"
+                f"添付ファイル（ローカルに保存済み。Read ツール等で参照できます）:\n{listing}"
+            )
+
+        thread_name: str | None = data.get("thread_name") or None
+        auto_start: bool = data.get("auto_start", True)
+
+        try:
+            thread = await cog.spawn_session(
+                raw,
+                prompt,
+                thread_name=thread_name,
+                auto_start=auto_start,
+            )
+        except Exception as exc:
+            logger.error("ingest spawn_session failed: %s", exc, exc_info=True)
+            return web.json_response({"error": str(exc)}, status=500)
+
+        logger.info(
+            "Ingested external session in thread %s (%s), %d attachment(s)",
+            thread.id,
+            _sanitize_log(thread.name),
+            len(saved_paths),
+        )
+        return web.json_response(
+            {
+                "status": "spawned",
+                "thread_id": str(thread.id),
+                "thread_name": thread.name,
+                "attachments_saved": len(saved_paths),
             },
             status=201,
         )

--- a/claude_discord/main.py
+++ b/claude_discord/main.py
@@ -155,6 +155,8 @@ async def main() -> None:
             default_channel_id=channel_id,
             host=config["api_host"],
             port=int(config["api_port"]),
+            ingest_token=os.getenv("CCDB_INGEST_TOKEN") or None,
+            working_dir=config["working_dir"] or None,
         )
 
     async with bot:

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -745,3 +745,165 @@ class TestMarkResume:
             headers={"Content-Type": "application/json"},
         )
         assert resp.status == 400
+
+
+class TestIngest:
+    """Tests for POST /api/ingest — authenticated external spawn with attachments."""
+
+    INGEST_TOKEN = "ingest-secret-xyz"
+    AUTH = {"Authorization": f"Bearer {INGEST_TOKEN}"}
+
+    @pytest.fixture
+    def mock_cog(self) -> MagicMock:
+        thread = MagicMock()
+        thread.id = 111222333
+        thread.name = "Ingested thread"
+        cog = MagicMock()
+        cog.spawn_session = AsyncMock(return_value=thread)
+        return cog
+
+    @pytest.fixture
+    def bot_with_text_channel(self, mock_cog: MagicMock) -> MagicMock:
+        import discord
+
+        b = MagicMock()
+        channel = MagicMock(spec=discord.TextChannel)
+        channel.send = AsyncMock()
+        b.get_channel.return_value = channel
+        b.cogs = {"ClaudeChatCog": mock_cog}
+        return b
+
+    @pytest.fixture
+    async def ingest_client(
+        self,
+        repo: NotificationRepository,
+        bot_with_text_channel: MagicMock,
+        tmp_path,
+    ) -> TestClient:
+        api = ApiServer(
+            repo=repo,
+            bot=bot_with_text_channel,
+            default_channel_id=12345,
+            ingest_token=self.INGEST_TOKEN,
+            working_dir=str(tmp_path),
+        )
+        api._ingest_tmp = str(tmp_path)  # expose for assertions
+        server = TestServer(api.app)
+        client = TestClient(server)
+        client._api = api  # type: ignore[attr-defined]
+        await client.start_server()
+        yield client
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_ingest_disabled_without_token(
+        self, repo: NotificationRepository, bot_with_text_channel: MagicMock
+    ) -> None:
+        api = ApiServer(repo=repo, bot=bot_with_text_channel, default_channel_id=12345)
+        server = TestServer(api.app)
+        client = TestClient(server)
+        await client.start_server()
+        try:
+            resp = await client.post("/api/ingest", json={"content": "hi"}, headers=self.AUTH)
+            assert resp.status == 503
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_ingest_missing_auth_returns_401(self, ingest_client: TestClient) -> None:
+        resp = await ingest_client.post("/api/ingest", json={"content": "hi"})
+        assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_ingest_wrong_token_returns_401(self, ingest_client: TestClient) -> None:
+        resp = await ingest_client.post(
+            "/api/ingest",
+            json={"content": "hi"},
+            headers={"Authorization": "Bearer nope"},
+        )
+        assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_ingest_returns_201_with_thread_info(self, ingest_client: TestClient) -> None:
+        resp = await ingest_client.post(
+            "/api/ingest", json={"content": "Teams thread body"}, headers=self.AUTH
+        )
+        assert resp.status == 201
+        data = await resp.json()
+        assert data["status"] == "spawned"
+        assert data["thread_id"] == "111222333"
+        assert data["attachments_saved"] == 0
+
+    @pytest.mark.asyncio
+    async def test_ingest_missing_content_returns_400(self, ingest_client: TestClient) -> None:
+        resp = await ingest_client.post("/api/ingest", json={}, headers=self.AUTH)
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_ingest_accepts_prompt_alias(
+        self, ingest_client: TestClient, mock_cog: MagicMock
+    ) -> None:
+        resp = await ingest_client.post(
+            "/api/ingest", json={"prompt": "Via alias"}, headers=self.AUTH
+        )
+        assert resp.status == 201
+        _channel, prompt = mock_cog.spawn_session.call_args.args
+        assert prompt == "Via alias"
+
+    @pytest.mark.asyncio
+    async def test_ingest_saves_attachment_and_references_path(
+        self, ingest_client: TestClient, mock_cog: MagicMock, tmp_path
+    ) -> None:
+        import base64
+
+        payload = base64.b64encode(b"hello file").decode()
+        resp = await ingest_client.post(
+            "/api/ingest",
+            json={
+                "content": "See attached",
+                "attachments": [{"filename": "report.txt", "data": payload}],
+            },
+            headers=self.AUTH,
+        )
+        assert resp.status == 201
+        data = await resp.json()
+        assert data["attachments_saved"] == 1
+
+        # File written under {working_dir}/ingest/**/report.txt with correct bytes
+        matches = list(tmp_path.glob("ingest/*/report.txt"))
+        assert len(matches) == 1
+        assert matches[0].read_bytes() == b"hello file"
+
+        # Saved path is referenced in the prompt passed to spawn_session
+        _channel, prompt = mock_cog.spawn_session.call_args.args
+        assert "report.txt" in prompt
+        assert str(matches[0]) in prompt
+
+    @pytest.mark.asyncio
+    async def test_ingest_rejects_path_traversal_filename(
+        self, ingest_client: TestClient, tmp_path
+    ) -> None:
+        import base64
+
+        payload = base64.b64encode(b"x").decode()
+        resp = await ingest_client.post(
+            "/api/ingest",
+            json={
+                "content": "evil",
+                "attachments": [{"filename": "../../etc/passwd", "data": payload}],
+            },
+            headers=self.AUTH,
+        )
+        assert resp.status == 201
+        # Nothing written outside the ingest dir; basename sanitised to "passwd"
+        assert list(tmp_path.glob("ingest/*/passwd"))
+        assert not list(tmp_path.glob("**/etc/passwd"))
+
+    @pytest.mark.asyncio
+    async def test_ingest_invalid_base64_returns_400(self, ingest_client: TestClient) -> None:
+        resp = await ingest_client.post(
+            "/api/ingest",
+            json={"content": "x", "attachments": [{"filename": "a.bin", "data": "!!!notb64"}]},
+            headers=self.AUTH,
+        )
+        assert resp.status == 400

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "3.0.12"
+version = "3.0.16"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Adds an opt-in, token-gated `POST /api/ingest` endpoint that lets **untrusted external clients** (browser extensions, mobile shortcuts, webhooks) spawn a Claude session and ship along **file attachments** as base64.

Motivation: a browser extension needs to push the current Teams thread (body + attachments) into a new Discord/Claude session over the home network.

## Design

- **Independent of the global `api_secret` middleware.** The handler verifies its own `Bearer <ingest_token>` (constant-time). This is deliberate: enabling ingest must **not** retroactively require auth on every other route (lounge/spawn/run/notify), which would break existing unauthenticated callers.
- **Secure-by-default opt-in.** When `ingest_token` is unset the route returns `503` — it can never run unauthenticated by accident.
- **Attachments** are base64-decoded and written to `{working_dir}/ingest/{id}/` with path-traversal-safe basenames, per-count (20) and total-size (50 MB) caps, then the saved paths are appended to the spawn prompt so Claude can read them.
- **Backward-compatible constructor.** New params `ingest_token` / `working_dir` default to `None`; wired in `main.py` from `CCDB_INGEST_TOKEN` / working dir. No behaviour change for existing consumers (zero-config).

## Tests (TDD)

9 new tests in `tests/test_api_server.py::TestIngest`:
- disabled→503, missing/wrong token→401
- happy path 201, `prompt` alias, missing content→400
- attachment saved to disk + path referenced in prompt
- path-traversal filename sanitised, invalid base64→400

`ruff check` / `ruff format --check` clean; full `test_api_server.py` (59) green.

## Notes

- Binds remain `127.0.0.1` by default; cross-machine use is the operator's call (would expose existing unauthenticated routes to the LAN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)