### PR TITLE
fix: suppress ServerDisconnectedError in LiveToolTimer on bot shutdown

### DIFF
--- a/claude_discord/discord_ui/tool_timer.py
+++ b/claude_discord/discord_ui/tool_timer.py
@@ -11,6 +11,7 @@ import contextlib
 import logging
 import time
 
+import aiohttp
 import discord
 
 from ..claude.types import ToolUseEvent
@@ -49,14 +50,14 @@ class LiveToolTimer:
     async def _loop(self) -> None:
         try:
             # Show 0s immediately so the user sees the timer as soon as the tool starts.
-            with contextlib.suppress(discord.HTTPException):
+            with contextlib.suppress(discord.HTTPException, aiohttp.ClientConnectionError):
                 await self._msg.edit(
                     embed=tool_use_embed(self._tool, in_progress=True, elapsed_s=0)
                 )
             while True:
                 await asyncio.sleep(TOOL_TIMER_INTERVAL)
                 elapsed = int(time.monotonic() - self._start)
-                with contextlib.suppress(discord.HTTPException):
+                with contextlib.suppress(discord.HTTPException, aiohttp.ClientConnectionError):
                     await self._msg.edit(
                         embed=tool_use_embed(self._tool, in_progress=True, elapsed_s=elapsed)
                     )

--- a/tests/test_tool_timer.py
+++ b/tests/test_tool_timer.py
@@ -1,0 +1,69 @@
+"""Tests for LiveToolTimer — elapsed-time embed updater."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import discord
+
+from claude_discord.claude.types import ToolCategory, ToolUseEvent
+from claude_discord.discord_ui.tool_timer import LiveToolTimer
+
+
+def _make_tool() -> ToolUseEvent:
+    return ToolUseEvent(
+        tool_id="tool-123",
+        tool_name="Bash",
+        tool_input={"command": "ls"},
+        category=ToolCategory.COMMAND,
+    )
+
+
+class TestLiveToolTimerLoop:
+    async def test_cancels_cleanly(self) -> None:
+        """Cancelling the timer task should not raise — CancelledError is caught internally."""
+        msg = MagicMock(spec=discord.Message)
+        msg.edit = AsyncMock()
+        timer = LiveToolTimer(msg, _make_tool())
+        task = timer.start()
+        await asyncio.sleep(0)  # let the initial edit fire
+        task.cancel()
+        await asyncio.sleep(0)  # let cancel propagate
+        assert task.done()
+        # CancelledError is caught inside _loop(), so the task has no stored exception
+        assert task.exception() is None
+
+    async def test_suppresses_http_exception_on_edit(self) -> None:
+        """discord.HTTPException during edit should be swallowed, not stored as task exception."""
+        msg = MagicMock(spec=discord.Message)
+        response = MagicMock()
+        response.status = 403
+        msg.edit = AsyncMock(side_effect=discord.Forbidden(response, "Missing Permissions"))
+        timer = LiveToolTimer(msg, _make_tool())
+        task = timer.start()
+        await asyncio.sleep(0)  # initial edit fires and raises Forbidden — should be suppressed
+        task.cancel()
+        await asyncio.sleep(0)
+        assert task.done()
+        assert task.exception() is None
+
+    async def test_suppresses_server_disconnected_error(self) -> None:
+        """ServerDisconnectedError (raised on bot shutdown) must be suppressed.
+
+        Previously this caused an 'asyncio: Task exception was never retrieved'
+        log error on every bot restart while a tool was in progress.
+        ServerDisconnectedError is an aiohttp error — not a discord.HTTPException —
+        so it was previously not caught by the suppress block.
+        """
+        msg = MagicMock(spec=discord.Message)
+        msg.edit = AsyncMock(side_effect=aiohttp.ServerDisconnectedError("Server disconnected"))
+        timer = LiveToolTimer(msg, _make_tool())
+        task = timer.start()
+        await asyncio.sleep(0)  # initial edit fires and raises ServerDisconnectedError
+        task.cancel()
+        await asyncio.sleep(0)
+        assert task.done()
+        # Must NOT store ServerDisconnectedError as the task exception
+        assert task.exception() is None


### PR DESCRIPTION
## Summary

- `LiveToolTimer._loop()` suppressed only `discord.HTTPException`, but `aiohttp.ClientConnectionError` (parent of `ServerDisconnectedError`) is a separate hierarchy
- On every bot restart while a tool timer was in flight, the `ServerDisconnectedError` escaped the suppress block and produced an `asyncio: Task exception was never retrieved` log error
- Fix: add `aiohttp.ClientConnectionError` to both suppress contexts in `_loop()`

## Root cause (observed in logs)

```
2026-06-16 14:19:40 [ERROR] asyncio: Task exception was never retrieved
future: <Task finished name='Task-92871' coro=<LiveToolTimer._loop() done> exception=ServerDisconnectedError('Server disconnected')>
```

This error occurred at bot shutdown (after `Shutdown detected: marking N active session(s) for restart-resume`).  Happened 2× in the last 12 hours.

## Test plan

- [x] `test_cancels_cleanly` — task cancellation completes without stored exception
- [x] `test_suppresses_http_exception_on_edit` — `discord.Forbidden` is still suppressed
- [x] `test_suppresses_server_disconnected_error` — `ServerDisconnectedError` is now suppressed (regression guard)
- [x] `ruff check` + `ruff format` pass
- [x] Full test suite pass