### PR TITLE
[docs-sync] Add /api/ingest section and missing sections to all translations (v3.1.0)

### DIFF
--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -86,6 +86,52 @@ Dispara tareas de Claude Code desde GitHub Actions a través de webhooks de Disc
 
 Un canal compartido "sala de descanso" donde todas las sesiones concurrentes se anuncian, leen las actualizaciones de las demás y se coordinan antes de operaciones destructivas.
 
+### Creación de Sesiones Programática
+
+Crea nuevas sesiones de Claude Code desde scripts, GitHub Actions u otras sesiones de Claude — sin interacción con mensajes de Discord.
+
+```bash
+# Desde otra sesión de Claude o un script CI:
+curl -X POST "$CCDB_API_URL/api/spawn" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Ejecutar escaneo de seguridad en el repositorio", "thread_name": "Security Scan"}'
+# Retorna inmediatamente con el ID del hilo; Claude se ejecuta en segundo plano
+```
+
+**Inicio diferido (`auto_start=false`)** — Crea un hilo y publica un mensaje inicial sin iniciar Claude inmediatamente. Claude inicia solo cuando un usuario responde. Útil para flujos de notificación como briefings diarios o alertas de CI.
+
+Los subprocesos de Claude reciben `DISCORD_THREAD_ID` como variable de entorno, permitiendo que las sesiones activas inicien sesiones hijas.
+
+### Ingesta Externa Autenticada y Recuperación de Resultados (`/api/ingest`)
+
+`POST /api/ingest` es el **spawn autenticado y compatible con archivos adjuntos** para clientes externos no confiables (extensiones de navegador, atajos móviles, webhooks). A diferencia de `/api/spawn` (confiable, localhost), requiere un `ingest_token` dedicado (configura `CCDB_INGEST_TOKEN`; independiente de `api_secret`) y puede llevar archivos adjuntos base64 que se escriben en disco para que la sesión creada los lea. Crea un hilo real de Discord, por lo que toda la interacción permanece observable.
+
+La sesión es **interactiva** (un hilo real de Discord donde puedes seguir respondiendo) — pero aún puedes obtener la respuesta final de forma programática. Cuando la recuperación de resultados está configurada (conectada automáticamente via `setup_bridge()`), la respuesta incluye un `result_id`, y `GET /api/ingest/{result_id}` sondea la respuesta final de la sesión.
+
+```bash
+# Publicar trabajo (con adjuntos opcionales); retorna inmediatamente
+curl -X POST "$CCDB_API_URL/api/ingest" \
+  -H "Authorization: Bearer $CCDB_INGEST_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "Resume este hilo y redacta una respuesta",
+       "attachments": [{"filename": "thread.txt", "data": "<base64>"}]}'
+# → {"status": "spawned", "thread_id": "…", "result_id": "ab12…", "attachments_saved": 1}
+
+# Sondear la respuesta final
+curl "$CCDB_API_URL/api/ingest/ab12…" -H "Authorization: Bearer $CCDB_INGEST_TOKEN"
+# → {"status": "done", "result": "…", "error": null, "thread_id": "…", "thread_name": "…"}
+```
+
+El endpoint es opcional: sin `ingest_token` configurado, `POST` responde `503`. Los resultados están limitados a 200 filas.
+
+### Reanudación al Inicio
+
+Si el bot se reinicia durante una sesión, las sesiones interrumpidas de Claude se reanudan automáticamente cuando el bot vuelve a estar en línea. Las sesiones se marcan para reanudar de tres formas:
+
+- **Automático (reinicio por actualización)** — `AutoUpgradeCog` captura todas las sesiones activas antes de un reinicio por actualización y las marca automáticamente.
+- **Automático (cualquier apagado)** — `ClaudeChatCog.cog_unload()` marca las sesiones en ejecución cuando el bot se apaga por cualquier mecanismo.
+- **Manual** — Cualquier sesión puede llamar `POST /api/mark-resume` directamente.
+
 ---
 
 ## Características
@@ -344,6 +390,8 @@ uv add "claude-code-discord-bridge[api]"
 | DELETE | `/api/tasks/{id}` | Eliminar tarea |
 | PATCH | `/api/tasks/{id}` | Actualizar tarea |
 | POST | `/api/spawn` | Crear nuevo hilo de Discord e iniciar sesión de Claude Code (no bloqueante) |
+| POST | `/api/ingest` | Spawn externo autenticado (extensión de navegador/webhook) con adjuntos base64; retorna `result_id` cuando la recuperación de resultados está configurada |
+| GET | `/api/ingest/{result_id}` | Sondear la respuesta final de la sesión creada (`status`/`result`/`error`/`thread_id`) |
 | POST | `/api/mark-resume` | Marcar hilo para reanudación automática en próximo inicio del bot |
 | GET | `/api/lounge` | Leer mensajes recientes del AI Lounge |
 | POST | `/api/lounge` | Publicar mensaje en AI Lounge |

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -82,6 +82,68 @@ Déclenchez des tâches Claude Code depuis GitHub Actions via des webhooks Disco
 
 Vous utilisez déjà Claude Code CLI directement ? Synchronisez vos sessions de terminal existantes dans des fils Discord avec `/sync-sessions`. Remplit les messages de conversation récents pour que vous puissiez continuer une session CLI depuis votre téléphone sans perdre le contexte.
 
+### AI Lounge
+
+Un canal « salon de repos » partagé où toutes les sessions concurrentes s'annoncent, lisent les mises à jour des autres et se coordonnent avant les opérations destructives.
+
+Chaque session Claude reçoit automatiquement le contexte du lounge via `--append-system-prompt` — injecté comme contexte système éphémère plutôt que dans l'historique de conversation. Cela évite l'accumulation du contexte au fil des tours, qui provoquerait des erreurs « Prompt is too long » dans les sessions longues. Le contexte injecté comprend : les messages récents des autres sessions, ainsi que la règle de vérification avant toute opération destructive.
+
+```bash
+# Les sessions publient leurs intentions avant de démarrer :
+curl -X POST "$CCDB_API_URL/api/lounge" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Starting auth refactor on feature/oauth — worktree-A", "label": "feature dev"}'
+
+# Lire les messages récents du lounge (aussi injectés automatiquement dans chaque session) :
+curl "$CCDB_API_URL/api/lounge"
+```
+
+Le canal lounge sert aussi de fil d'activité visible par les humains — ouvrez-le dans Discord pour voir d'un coup d'œil ce que fait chaque session Claude active.
+
+### Création de Session Programmatique
+
+Créez de nouvelles sessions Claude Code depuis des scripts, GitHub Actions ou d'autres sessions Claude — sans interaction avec les messages Discord.
+
+```bash
+# Depuis une autre session Claude ou un script CI :
+curl -X POST "$CCDB_API_URL/api/spawn" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Exécuter un scan de sécurité sur le dépôt", "thread_name": "Security Scan"}'
+# Retourne immédiatement avec l'ID du fil ; Claude s'exécute en arrière-plan
+```
+
+**Démarrage différé (`auto_start=false`)** — Crée un fil et publie un message d'initialisation sans démarrer Claude immédiatement. Claude ne démarre que quand un utilisateur répond. Utile pour les flux de notification.
+
+### Ingestion Externe Authentifiée et Récupération de Résultats (`/api/ingest`)
+
+`POST /api/ingest` est le **spawn authentifié et compatible avec les pièces jointes** pour les clients externes non fiables (extensions de navigateur, raccourcis mobiles, webhooks). Contrairement à `/api/spawn` (fiable, localhost), il nécessite un `ingest_token` dédié (définissez `CCDB_INGEST_TOKEN` ; indépendant de `api_secret`) et peut transporter des pièces jointes base64 écrites sur disque pour que la session créée puisse les lire. Il crée un fil Discord réel, donc toute l'interaction reste observable.
+
+La session est **interactive** (un vrai fil Discord où vous pouvez continuer à répondre) — mais vous pouvez toujours obtenir sa réponse finale de façon programmatique. Quand la récupération de résultats est configurée (câblée automatiquement via `setup_bridge()`), la réponse inclut un `result_id`, et `GET /api/ingest/{result_id}` interroge la réponse finale de la session.
+
+```bash
+# Publier le travail (avec pièces jointes optionnelles) ; retourne immédiatement
+curl -X POST "$CCDB_API_URL/api/ingest" \
+  -H "Authorization: Bearer $CCDB_INGEST_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "Résume ce fil et rédige une réponse",
+       "attachments": [{"filename": "thread.txt", "data": "<base64>"}]}'
+# → {"status": "spawned", "thread_id": "…", "result_id": "ab12…", "attachments_saved": 1}
+
+# Interroger la réponse finale
+curl "$CCDB_API_URL/api/ingest/ab12…" -H "Authorization: Bearer $CCDB_INGEST_TOKEN"
+# → {"status": "done", "result": "…", "error": null, "thread_id": "…", "thread_name": "…"}
+```
+
+L'endpoint est optionnel : sans `ingest_token` configuré, `POST` répond `503`. Les résultats sont limités à 200 lignes.
+
+### Reprise au Démarrage
+
+Si le bot redémarre en pleine session, les sessions Claude interrompues sont automatiquement reprises quand le bot revient en ligne. Les sessions sont marquées pour reprise de trois façons :
+
+- **Automatique (redémarrage pour mise à jour)** — `AutoUpgradeCog` capture toutes les sessions actives juste avant un redémarrage de mise à jour et les marque automatiquement.
+- **Automatique (tout arrêt)** — `ClaudeChatCog.cog_unload()` marque les sessions en cours d'exécution quand le bot s'arrête par n'importe quel mécanisme.
+- **Manuel** — Toute session peut appeler `POST /api/mark-resume` directement.
+
 ---
 
 ## Fonctionnalités
@@ -340,6 +402,8 @@ uv add "claude-code-discord-bridge[api]"
 | DELETE | `/api/tasks/{id}` | Supprimer tâche |
 | PATCH | `/api/tasks/{id}` | Mettre à jour tâche |
 | POST | `/api/spawn` | Créer nouveau fil Discord et démarrer session Claude Code (non bloquant) |
+| POST | `/api/ingest` | Spawn externe authentifié (extension navigateur/webhook) avec pièces jointes base64 ; retourne `result_id` quand la récupération de résultats est configurée |
+| GET | `/api/ingest/{result_id}` | Interroger la réponse finale de la session créée (`status`/`result`/`error`/`thread_id`) |
 | POST | `/api/mark-resume` | Marquer fil pour reprise automatique au prochain démarrage du bot |
 | GET | `/api/lounge` | Lire les messages récents de l'AI Lounge |
 | POST | `/api/lounge` | Publier message dans l'AI Lounge |

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -136,6 +136,28 @@ curl -X POST "$CCDB_API_URL/api/spawn" \
 
 Claude のサブプロセスには `DISCORD_THREAD_ID` 環境変数が渡されるため、実行中のセッションから子セッションを起動して作業を並列化できます。
 
+### 認証済み外部インジェストと結果取得 (`/api/ingest`)
+
+`POST /api/ingest` は、信頼できない外部クライアント（ブラウザ拡張機能、モバイルショートカット、webhook）向けの**認証済み、添付ファイル対応スポーン**です。`/api/spawn`（信頼済み、localhost）とは異なり、専用の `ingest_token`（`CCDB_INGEST_TOKEN` で設定。`api_secret` とは独立）が必要で、base64 ファイル添付をディスクに書き込み、スポーンされたセッションが読み取れるようにします。実際の Discord スレッドを作成するため、すべてのやり取りが観察可能です。
+
+セッションは**インタラクティブ**（返信し続けられる本物の Discord スレッド）ですが、最終回答をプログラム的に取得することもできます。結果取得が設定されている場合（`setup_bridge()` 経由で自動接続）、レスポンスに `result_id` が含まれ、`GET /api/ingest/{result_id}` でセッションの最終返信をポーリングできます。これがラウンドトリップパターンです: スレッド + 添付ファイルを投稿 → 待機 → 回答を読む → 自分のシステム（Teams スレッドなど）に書き戻す。一方で Discord が履歴を保持します。
+
+```bash
+# 作業を投稿（添付ファイルも可能）。すぐに返す
+curl -X POST "$CCDB_API_URL/api/ingest" \
+  -H "Authorization: Bearer $CCDB_INGEST_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "このスレッドを要約して返信草案を作成して",
+       "attachments": [{"filename": "thread.txt", "data": "<base64>"}]}'
+# → {"status": "spawned", "thread_id": "…", "result_id": "ab12…", "attachments_saved": 1}
+
+# 最終返信をポーリング
+curl "$CCDB_API_URL/api/ingest/ab12…" -H "Authorization: Bearer $CCDB_INGEST_TOKEN"
+# → {"status": "done", "result": "…", "error": null, "thread_id": "…", "thread_name": "…"}
+```
+
+このエンドポイントはオプトイン方式です。`ingest_token` が設定されていない場合、`POST` は `503` を返します。結果取得が利用できない場合、`POST` は `result_id` を省略し、`GET /api/ingest/{id}` は `503` を返します — スポーン動作は変わりません。リクエスト本文と添付ファイルは結果ストアに保存されません（状態、最終テキスト、スレッド ID のみ）。結果は最大 200 件です。
+
 ### スタートアップリジューム
 
 Bot の再起動中にセッションが中断された場合、Bot が再起動したときに自動的に再開されます。リジューム登録の方法は 3 つあります:
@@ -829,6 +851,8 @@ uv add "claude-code-discord-bridge[api]"
 | DELETE | `/api/tasks/{id}` | タスクの削除 |
 | PATCH | `/api/tasks/{id}` | タスクの更新（有効/無効、スケジュール変更） |
 | POST | `/api/spawn` | 新しい Discord スレッドを作成し Claude Code セッションを起動（非ブロッキング）。`auto_start: false` を指定するとユーザーの最初の返信まで Claude の起動を延期できる |
+| POST | `/api/ingest` | 認証済み外部スポーン（ブラウザ拡張機能 / webhook）。base64 添付ファイル対応。結果取得が設定されている場合 `result_id` を返す |
+| GET | `/api/ingest/{result_id}` | スポーンされたセッションの最終返信をポーリング（`status`/`result`/`error`/`thread_id`） |
 | POST | `/api/mark-resume` | 次回 Bot 起動時のスレッド自動リジュームを登録 |
 | GET | `/api/lounge` | AI Lounge の最近のメッセージを取得 |
 | POST | `/api/lounge` | AI Lounge にメッセージを投稿（`label` オプション） |

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -98,6 +98,36 @@ curl -X POST "$CCDB_API_URL/api/spawn" \
 # 스레드 생성 후 즉시 반환; Claude는 백그라운드에서 실행
 ```
 
+### 인증된 외부 인제스트 및 결과 조회 (`/api/ingest`)
+
+`POST /api/ingest`는 신뢰할 수 없는 외부 클라이언트(브라우저 확장 프로그램, 모바일 단축키, webhook)를 위한 **인증된, 첨부 파일 지원 스폰**입니다. `/api/spawn`(신뢰된, localhost)과 달리, 전용 `ingest_token`(`CCDB_INGEST_TOKEN`으로 설정; `api_secret`과 독립)이 필요하며, base64 파일 첨부를 디스크에 기록하여 스폰된 세션이 읽을 수 있습니다. 실제 Discord 스레드를 생성하므로 모든 상호작용을 관찰할 수 있습니다.
+
+세션은 **인터랙티브**합니다(계속 답장할 수 있는 실제 Discord 스레드) — 하지만 최종 답변을 프로그래밍 방식으로 가져올 수도 있습니다. 결과 조회가 구성된 경우(`setup_bridge()`를 통해 자동 연결), 응답에 `result_id`가 포함되며 `GET /api/ingest/{result_id}`로 세션의 최종 답변을 폴링할 수 있습니다. 이것이 왕복 패턴입니다: 스레드 + 첨부 파일 게시 → 대기 → 답변 읽기 → 자체 시스템(예: Teams 스레드)에 기록, Discord가 기록을 보관합니다.
+
+```bash
+# 작업 게시(선택적으로 첨부 파일 포함); 즉시 반환
+curl -X POST "$CCDB_API_URL/api/ingest" \
+  -H "Authorization: Bearer $CCDB_INGEST_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "이 스레드를 요약하고 답장 초안을 작성해",
+       "attachments": [{"filename": "thread.txt", "data": "<base64>"}]}'
+# → {"status": "spawned", "thread_id": "…", "result_id": "ab12…", "attachments_saved": 1}
+
+# 최종 답변 폴링
+curl "$CCDB_API_URL/api/ingest/ab12…" -H "Authorization: Bearer $CCDB_INGEST_TOKEN"
+# → {"status": "done", "result": "…", "error": null, "thread_id": "…", "thread_name": "…"}
+```
+
+이 엔드포인트는 옵트인 방식입니다: `ingest_token`이 구성되지 않으면 `POST`는 `503`을 반환합니다. 결과 조회를 사용할 수 없으면 `POST`는 `result_id`를 생략하고 `GET /api/ingest/{id}`는 `503`을 반환합니다 — 스폰 동작은 변경되지 않습니다. 요청 본문과 첨부 파일은 결과 저장소에 **저장되지 않습니다**(상태, 최종 텍스트, 스레드 ID만); 결과는 최대 200개입니다.
+
+### 시작 재개
+
+봇이 세션 도중 재시작되면, 중단된 Claude 세션이 봇이 다시 온라인이 될 때 자동으로 재개됩니다. 재개를 위한 등록 방법은 세 가지입니다:
+
+- **자동(업그레이드 재시작)** — `AutoUpgradeCog`가 패키지 업그레이드 재시작 직전에 모든 활성 세션을 스냅샷하고 자동으로 등록합니다.
+- **자동(모든 종료)** — `ClaudeChatCog.cog_unload()`가 `systemctl stop`, `bot.close()`, SIGTERM 등 모든 종료 방법에서 실행 중인 세션을 자동 등록합니다.
+- **수동** — `POST /api/mark-resume`를 직접 호출하여 등록할 수 있습니다.
+
 ---
 
 ## 기능 목록
@@ -356,6 +386,8 @@ uv add "claude-code-discord-bridge[api]"
 | DELETE | `/api/tasks/{id}` | 작업 삭제 |
 | PATCH | `/api/tasks/{id}` | 작업 업데이트 |
 | POST | `/api/spawn` | 새 Discord 스레드 생성 및 Claude Code 세션 시작 (논블로킹) |
+| POST | `/api/ingest` | 인증된 외부 스폰 (브라우저 확장/webhook), base64 첨부 파일 지원; 결과 조회가 구성된 경우 `result_id` 반환 |
+| GET | `/api/ingest/{result_id}` | 스폰된 세션의 최종 답변 폴링 (`status`/`result`/`error`/`thread_id`) |
 | POST | `/api/mark-resume` | 다음 봇 시작 시 자동 재개를 위해 스레드 마킹 |
 | GET | `/api/lounge` | 최근 AI Lounge 메시지 읽기 |
 | POST | `/api/lounge` | AI Lounge에 메시지 게시 |

--- a/docs/pt-BR/README.md
+++ b/docs/pt-BR/README.md
@@ -82,6 +82,54 @@ Dispare tarefas do Claude Code a partir do GitHub Actions via webhooks do Discor
 
 Já usa Claude Code CLI diretamente? Sincronize suas sessões de terminal existentes em threads do Discord com `/sync-sessions`. Retroalimenta mensagens de conversa recentes para que você possa continuar uma sessão CLI do seu celular sem perder contexto.
 
+### AI Lounge
+
+Um canal compartilhado de "sala de descanso" onde todas as sessões concorrentes se anunciam, leem as atualizações das outras e se coordenam antes de operações destrutivas.
+
+### Criação de Sessão Programática
+
+Crie novas sessões do Claude Code a partir de scripts, GitHub Actions ou outras sessões do Claude — sem interação com mensagens do Discord.
+
+```bash
+# A partir de outra sessão Claude ou de um script CI:
+curl -X POST "$CCDB_API_URL/api/spawn" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Executar varredura de segurança no repositório", "thread_name": "Security Scan"}'
+# Retorna imediatamente com o ID da thread; Claude executa em segundo plano
+```
+
+**Início adiado (`auto_start=false`)** — Crie uma thread e publique uma mensagem semente sem iniciar o Claude imediatamente. Claude inicia apenas quando um usuário responde. Útil para fluxos de notificação.
+
+### Ingestão Externa Autenticada e Recuperação de Resultados (`/api/ingest`)
+
+`POST /api/ingest` é o **spawn autenticado e compatível com anexos** para clientes externos não confiáveis (extensões de navegador, atalhos móveis, webhooks). Ao contrário de `/api/spawn` (confiável, localhost), requer um `ingest_token` dedicado (configure `CCDB_INGEST_TOKEN`; independente de `api_secret`) e pode carregar anexos base64 que são gravados em disco para que a sessão criada os leia. Cria uma thread real do Discord, mantendo toda a interação observável.
+
+A sessão é **interativa** (uma thread real do Discord onde você pode continuar respondendo) — mas ainda pode obter a resposta final programaticamente. Quando a recuperação de resultados está configurada (conectada automaticamente via `setup_bridge()`), a resposta inclui um `result_id`, e `GET /api/ingest/{result_id}` faz polling da resposta final da sessão.
+
+```bash
+# Publicar trabalho (com anexos opcionais); retorna imediatamente
+curl -X POST "$CCDB_API_URL/api/ingest" \
+  -H "Authorization: Bearer $CCDB_INGEST_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "Resuma esta thread e rascunhe uma resposta",
+       "attachments": [{"filename": "thread.txt", "data": "<base64>"}]}'
+# → {"status": "spawned", "thread_id": "…", "result_id": "ab12…", "attachments_saved": 1}
+
+# Polling da resposta final
+curl "$CCDB_API_URL/api/ingest/ab12…" -H "Authorization: Bearer $CCDB_INGEST_TOKEN"
+# → {"status": "done", "result": "…", "error": null, "thread_id": "…", "thread_name": "…"}
+```
+
+O endpoint é opt-in: sem `ingest_token` configurado, `POST` responde `503`. Os resultados estão limitados a 200 linhas.
+
+### Retomada na Inicialização
+
+Se o bot reiniciar durante uma sessão, as sessões Claude interrompidas são automaticamente retomadas quando o bot volta online. As sessões são marcadas para retomada de três formas:
+
+- **Automático (reinício por atualização)** — `AutoUpgradeCog` captura todas as sessões ativas antes de um reinício por atualização e as marca automaticamente.
+- **Automático (qualquer desligamento)** — `ClaudeChatCog.cog_unload()` marca as sessões em execução quando o bot é desligado por qualquer mecanismo.
+- **Manual** — Qualquer sessão pode chamar `POST /api/mark-resume` diretamente.
+
 ---
 
 ## Funcionalidades
@@ -340,6 +388,8 @@ uv add "claude-code-discord-bridge[api]"
 | DELETE | `/api/tasks/{id}` | Remover tarefa |
 | PATCH | `/api/tasks/{id}` | Atualizar tarefa |
 | POST | `/api/spawn` | Criar nova thread do Discord e iniciar sessão do Claude Code (não bloqueante) |
+| POST | `/api/ingest` | Spawn externo autenticado (extensão de navegador/webhook) com anexos base64; retorna `result_id` quando recuperação de resultados está configurada |
+| GET | `/api/ingest/{result_id}` | Polling da resposta final da sessão criada (`status`/`result`/`error`/`thread_id`) |
 | POST | `/api/mark-resume` | Marcar thread para retomada automática na próxima inicialização do bot |
 | GET | `/api/lounge` | Ler mensagens recentes do AI Lounge |
 | POST | `/api/lounge` | Publicar mensagem no AI Lounge |

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -116,6 +116,28 @@ curl -X POST "$CCDB_API_URL/api/spawn" \
 
 **延迟启动 (`auto_start=false`)** — 创建线程并发布种子消息，但不立即启动 Claude。只有当用户回复时 Claude 才启动，并自动接收种子消息作为上下文。
 
+### 认证外部摄取与结果检索 (`/api/ingest`)
+
+`POST /api/ingest` 是面向不可信外部客户端（浏览器扩展、移动快捷方式、webhook）的**认证、附件感知的生成接口**。与 `/api/spawn`（受信任的、localhost）不同，它需要专用的 `ingest_token`（通过 `CCDB_INGEST_TOKEN` 设置；与 `api_secret` 独立），并可携带 base64 文件附件写入磁盘，供生成的会话读取。它会创建真实的 Discord 线程，因此所有交互均可观察。
+
+会话是**交互式的**（真实的 Discord 线程，您可以继续回复）— 但您仍然可以以编程方式获取其最终答案。当配置了结果检索（通过 `setup_bridge()` 自动连接）时，响应中包含 `result_id`，`GET /api/ingest/{result_id}` 可轮询会话的最终回复。这是往返模式：发布线程 + 附件 → 等待 → 读取答案 → 写回您自己的系统（如 Teams 线程），同时 Discord 保留历史记录。
+
+```bash
+# 发布任务（可选附件）；立即返回
+curl -X POST "$CCDB_API_URL/api/ingest" \
+  -H "Authorization: Bearer $CCDB_INGEST_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "总结此线程并起草回复",
+       "attachments": [{"filename": "thread.txt", "data": "<base64>"}]}'
+# → {"status": "spawned", "thread_id": "…", "result_id": "ab12…", "attachments_saved": 1}
+
+# 轮询最终回复
+curl "$CCDB_API_URL/api/ingest/ab12…" -H "Authorization: Bearer $CCDB_INGEST_TOKEN"
+# → {"status": "done", "result": "…", "error": null, "thread_id": "…", "thread_name": "…"}
+```
+
+该端点为可选功能：未配置 `ingest_token` 时，`POST` 返回 `503`。结果检索不可用时，`POST` 仅省略 `result_id`，`GET /api/ingest/{id}` 返回 `503` — 生成行为不变。请求体和附件**不会**持久化到结果存储中（仅存储状态、最终文本和线程 ID）；结果上限为 200 条。
+
 ### 启动恢复
 
 如果 Bot 在会话进行中重启，被中断的 Claude 会话在 Bot 重新上线时会自动恢复。
@@ -447,6 +469,8 @@ uv add "claude-code-discord-bridge[api]"
 | DELETE | `/api/tasks/{id}` | 删除任务 |
 | PATCH | `/api/tasks/{id}` | 更新任务 |
 | POST | `/api/spawn` | 创建新 Discord 线程并启动 Claude Code 会话（非阻塞） |
+| POST | `/api/ingest` | 认证外部生成（浏览器扩展/webhook），支持 base64 附件；配置结果检索时返回 `result_id` |
+| GET | `/api/ingest/{result_id}` | 轮询生成会话的最终回复（`status`/`result`/`error`/`thread_id`） |
 | POST | `/api/mark-resume` | 标记线程在下次 Bot 启动时自动恢复 |
 | GET | `/api/lounge` | 读取最近的 AI Lounge 消息 |
 | POST | `/api/lounge` | 向 AI Lounge 发布消息 |


### PR DESCRIPTION
## Summary

- **6 translated READMEs updated** to add the `/api/ingest` (Authenticated External Ingest) section that was missing from all languages since v3.1.0
- **ja / zh-CN**: Added 1 missing section (`/api/ingest`) + 2 REST API table rows
- **ko**: Added 2 missing sections (`/api/ingest` + Startup Resume) + 2 REST API table rows  
- **es / pt-BR / fr**: Added 3–4 missing sections (Programmatic Session Creation, AI Lounge where missing, `/api/ingest`, Startup Resume) + 2 REST API table rows

## 概要

- v3.1.0 で追加された `/api/ingest`（認証済み外部インジェスト）セクションを全6言語に追加
- 翻訳が遅れていた言語（ko/es/pt-BR/fr）は複数セクションを補完

## Test plan

- [ ] Verify Japanese section appears between Programmatic Session Creation and Startup Resume
- [ ] Verify all 6 languages have `/api/ingest` in the REST API table
- [ ] Verify Korean has both the ingest section and Startup Resume section
- [ ] Verify Spanish, Portuguese, French have Programmatic Session Creation + ingest + Startup Resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)
