### PR TITLE
feat: post file attachments into the thread created by /api/spawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`/api/spawn` can post file attachments into the new thread** — `POST /api/spawn` now accepts an optional `attachments` array of `{filename, data}` where `data` is base64-encoded file bytes. After the seed prompt is posted, ccdb decodes them and posts them into the freshly created thread as real Discord file attachments (batched at Discord's 10-files-per-message limit, 8 MB/file skip), so a programmatic caller can surface the original files alongside the prompt. The motivating case: a Forgejo Issue/PR watcher that spawns a Discord thread and wants the issue's attachments viewable in-thread. Filenames are reduced to a safe basename (path-traversal guarded, shared with the ingest path); attachments are capped at 10 files / 25 MB total per request and validated (a bad base64 payload returns 400) before any thread is created. Backward-compatible: omit `attachments` and behaviour is unchanged (Zero-Config). Adds `attachments` to `ClaudeChatCog.spawn_session()` and `send_file_blobs()`/`collect_discord_files_from_blobs()` in `discord_ui/file_sender.py`. The body limit raised in v3.1.0 (#446) already covers these base64 payloads.
+
 ## [3.1.0] - 2026-06-18
 
 ### Added

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -36,6 +36,7 @@ from ..database.resume_repo import PendingResumeRepository
 from ..database.settings_repo import SettingsRepository
 from ..discord_ui.chunker import chunk_message
 from ..discord_ui.embeds import stopped_embed
+from ..discord_ui.file_sender import send_file_blobs
 from ..discord_ui.status import StatusManager
 from ..discord_ui.thread_dashboard import ThreadState, ThreadStatusDashboard
 from ..discord_ui.thread_renamer import suggest_title
@@ -711,6 +712,7 @@ class ClaudeChatCog(commands.Cog):
         fork: bool = False,
         auto_start: bool = True,
         result_sink: Callable[[str | None, str | None], Awaitable[None]] | None = None,
+        attachments: list[tuple[str, bytes]] | None = None,
     ) -> discord.Thread:
         """Create a new thread and optionally start a Claude Code session.
 
@@ -739,6 +741,11 @@ class ClaudeChatCog(commands.Cog):
                         caller (e.g. /api/ingest) retrieve the final reply.
                         Only wired when ``auto_start`` is True (otherwise no
                         session runs and no result would ever be produced).
+            attachments: Optional ``(filename, bytes)`` pairs to post into the
+                        new thread as Discord file attachments, right after the
+                        seed prompt. Lets a programmatic caller (e.g. a Forgejo
+                        Issue watcher via ``/api/spawn``) surface the original
+                        attachments so they're viewable in the thread.
 
         Returns:
             The newly created :class:`discord.Thread`.
@@ -759,6 +766,10 @@ class ClaudeChatCog(commands.Cog):
         seed_message = await thread.send(chunks[0])
         for chunk in chunks[1:]:
             seed_message = await thread.send(chunk)
+        # Surface any caller-provided attachments in the thread so they're
+        # viewable alongside the prompt (e.g. files attached to a Forgejo Issue).
+        if attachments:
+            await send_file_blobs(thread, attachments)
         if auto_start:
             # Run Claude in the background so /api/spawn returns immediately.
             # The caller gets the thread reference without waiting for Claude to finish.

--- a/claude_discord/discord_ui/file_sender.py
+++ b/claude_discord/discord_ui/file_sender.py
@@ -100,6 +100,85 @@ def collect_discord_files(
     return result
 
 
+def collect_discord_files_from_blobs(
+    blobs: list[tuple[str, bytes]],
+    max_bytes: int = _MAX_FILE_BYTES,
+) -> list[discord.File]:
+    """Build ``discord.File`` objects from in-memory ``(filename, bytes)`` pairs.
+
+    The in-memory twin of :func:`collect_discord_files`: used when the file
+    bytes are already in hand (e.g. downloaded from a remote API and forwarded
+    over ``/api/spawn``) rather than sitting on disk.
+
+    Skips blobs that exceed *max_bytes* (default: 8 MB, Discord's non-boosted
+    upload cap). The display filename is reduced to its basename so a
+    caller-supplied path can never embed directory components.
+
+    Args:
+        blobs: ``(filename, data)`` pairs to attach.
+        max_bytes: Per-file size limit.
+
+    Returns:
+        List of ``discord.File`` objects, ready to pass to ``thread.send()``.
+    """
+    result: list[discord.File] = []
+
+    for filename, data in blobs:
+        if len(data) > max_bytes:
+            logger.info(
+                "Skipping blob exceeding size limit (%d > %d bytes): %s",
+                len(data),
+                max_bytes,
+                filename,
+            )
+            continue
+        display_name = Path(filename).name or "attachment"
+        result.append(discord.File(io.BytesIO(data), filename=display_name))
+
+    return result
+
+
+async def send_file_blobs(
+    thread: discord.Thread,
+    blobs: list[tuple[str, bytes]],
+    content: str | None = "-# 📎 Files attached",
+) -> None:
+    """Send in-memory ``(filename, bytes)`` attachments to *thread* in batches.
+
+    The in-memory twin of :func:`send_files`. Sends in batches of up to 10
+    (Discord API limit); any Discord error is suppressed so a network hiccup
+    never propagates to the caller. Does nothing when *blobs* is empty or every
+    blob fails qualification (oversized).
+
+    Args:
+        thread: Discord thread to post attachments to.
+        blobs: ``(filename, data)`` pairs to send.
+        content: Message text for the first batch (subsequent batches send no
+            text). Pass ``None`` to attach files with no accompanying message.
+    """
+    if not blobs:
+        return
+
+    files = collect_discord_files_from_blobs(blobs)
+    if not files:
+        return
+
+    for i in range(0, len(files), _MAX_FILES_PER_MESSAGE):
+        batch = files[i : i + _MAX_FILES_PER_MESSAGE]
+        try:
+            await thread.send(
+                content=content if i == 0 else None,
+                files=batch,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to send blob attachment batch %d/%d to Discord",
+                i // _MAX_FILES_PER_MESSAGE + 1,
+                -(-len(files) // _MAX_FILES_PER_MESSAGE),
+                exc_info=True,
+            )
+
+
 async def send_files(
     thread: discord.Thread,
     file_paths: list[str],

--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -44,6 +44,11 @@ if TYPE_CHECKING:
 # extensions, mobile shortcuts, webhooks) that may carry file attachments.
 _MAX_INGEST_ATTACHMENTS = 20
 _MAX_INGEST_TOTAL_BYTES = 50 * 1024 * 1024
+# /api/spawn — trusted localhost callers may forward attachments to post into
+# the spawned thread (e.g. files attached to a Forgejo Issue). Capped to keep a
+# single request from buffering an unbounded amount of base64 in memory.
+_MAX_SPAWN_ATTACHMENTS = 10
+_MAX_SPAWN_TOTAL_BYTES = 25 * 1024 * 1024
 
 # Max accepted request body. aiohttp defaults to 1 MiB, which 413s any real
 # ingest (a full conversation thread plus base64 attachments). Base64 inflates
@@ -65,6 +70,49 @@ def _safe_attachment_name(raw: object, index: int) -> str:
     name = os.path.basename(str(raw or "")).strip()
     name = _UNSAFE_FILENAME_RE.sub("_", name).lstrip(".")
     return name or f"attachment_{index}"
+
+
+def _decode_spawn_attachments(
+    attachments: object,
+) -> tuple[list[tuple[str, bytes]], web.Response | None]:
+    """Decode ``/api/spawn`` base64 attachments into ``(filename, bytes)`` pairs.
+
+    Each item must be an object ``{filename?, data}`` where ``data`` is
+    base64-encoded file bytes. Filenames are reduced to a safe basename. On any
+    validation failure the second element is a ready-to-return 400 response and
+    the first is empty.
+    """
+    if not attachments:
+        return [], None
+    if not isinstance(attachments, list):
+        return [], web.json_response({"error": "attachments must be a list"}, status=400)
+    if len(attachments) > _MAX_SPAWN_ATTACHMENTS:
+        return [], web.json_response(
+            {"error": f"Too many attachments (max {_MAX_SPAWN_ATTACHMENTS})"},
+            status=400,
+        )
+
+    decoded: list[tuple[str, bytes]] = []
+    total = 0
+    for i, att in enumerate(attachments):
+        if not isinstance(att, dict):
+            return [], web.json_response({"error": f"Attachment {i} must be an object"}, status=400)
+        data_b64 = att.get("data")
+        if not data_b64:
+            return [], web.json_response({"error": f"Attachment {i} missing 'data'"}, status=400)
+        try:
+            blob = base64.b64decode(str(data_b64), validate=True)
+        except (binascii.Error, ValueError):
+            return [], web.json_response(
+                {"error": f"Attachment {i} has invalid base64 'data'"}, status=400
+            )
+        total += len(blob)
+        if total > _MAX_SPAWN_TOTAL_BYTES:
+            return [], web.json_response(
+                {"error": "Attachments exceed total size limit"}, status=413
+            )
+        decoded.append((_safe_attachment_name(att.get("filename"), i), blob))
+    return decoded, None
 
 
 logger = logging.getLogger(__name__)
@@ -739,12 +787,20 @@ class ApiServer:
         thread_name: str | None = data.get("thread_name") or None
         auto_start: bool = data.get("auto_start", True)
 
+        # Optional attachments to post into the new thread (e.g. files attached
+        # to a Forgejo Issue forwarded by a watcher). Decoded here; posting is
+        # handled inside spawn_session right after the seed prompt.
+        decoded_attachments, att_err = _decode_spawn_attachments(data.get("attachments"))
+        if att_err is not None:
+            return att_err
+
         try:
             thread = await cog.spawn_session(
                 raw,
                 prompt,
                 thread_name=thread_name,
                 auto_start=auto_start,
+                attachments=decoded_attachments or None,
             )
         except Exception as exc:
             logger.error("spawn_session failed: %s", exc, exc_info=True)

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -642,6 +642,92 @@ class TestSpawn:
         assert kwargs.get("auto_start") is True
 
     @pytest.mark.asyncio
+    async def test_spawn_accepts_payload_over_1mb(
+        self, spawn_client: TestClient, mock_cog: MagicMock
+    ) -> None:
+        """A >1MB attachment body must not be 413'd (aiohttp's default body limit
+        is 1MB; ApiServer raises client_max_size for base64 payloads)."""
+        import base64
+
+        blob = b"\x00" * (2 * 1024 * 1024)  # 2 MB → ~2.7 MB base64
+        resp = await spawn_client.post(
+            "/api/spawn",
+            json={
+                "prompt": "big attachment",
+                "attachments": [{"filename": "big.bin", "data": base64.b64encode(blob).decode()}],
+            },
+        )
+        assert resp.status == 201
+        kwargs = mock_cog.spawn_session.call_args.kwargs
+        assert kwargs["attachments"][0][1] == blob
+
+    @pytest.mark.asyncio
+    async def test_spawn_decodes_attachments_and_passes_to_cog(
+        self, spawn_client: TestClient, mock_cog: MagicMock
+    ) -> None:
+        import base64
+
+        blob = b"%PDF-1.4 hello"
+        resp = await spawn_client.post(
+            "/api/spawn",
+            json={
+                "prompt": "Issue with attachment",
+                "attachments": [{"filename": "spec.pdf", "data": base64.b64encode(blob).decode()}],
+            },
+        )
+        assert resp.status == 201
+        kwargs = mock_cog.spawn_session.call_args.kwargs
+        assert kwargs.get("attachments") == [("spec.pdf", blob)]
+
+    @pytest.mark.asyncio
+    async def test_spawn_without_attachments_passes_none(
+        self, spawn_client: TestClient, mock_cog: MagicMock
+    ) -> None:
+        await spawn_client.post("/api/spawn", json={"prompt": "No files"})
+        kwargs = mock_cog.spawn_session.call_args.kwargs
+        assert kwargs.get("attachments") is None
+
+    @pytest.mark.asyncio
+    async def test_spawn_invalid_base64_attachment_returns_400(
+        self, spawn_client: TestClient
+    ) -> None:
+        resp = await spawn_client.post(
+            "/api/spawn",
+            json={
+                "prompt": "Bad file",
+                "attachments": [{"filename": "x.bin", "data": "not!!base64!!"}],
+            },
+        )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_spawn_attachments_must_be_a_list(self, spawn_client: TestClient) -> None:
+        resp = await spawn_client.post(
+            "/api/spawn",
+            json={"prompt": "x", "attachments": {"filename": "a"}},
+        )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_spawn_sanitizes_attachment_filename(
+        self, spawn_client: TestClient, mock_cog: MagicMock
+    ) -> None:
+        import base64
+
+        await spawn_client.post(
+            "/api/spawn",
+            json={
+                "prompt": "traversal",
+                "attachments": [
+                    {"filename": "../../etc/passwd", "data": base64.b64encode(b"x").decode()}
+                ],
+            },
+        )
+        kwargs = mock_cog.spawn_session.call_args.kwargs
+        name = kwargs["attachments"][0][0]
+        assert "/" not in name and ".." not in name
+
+    @pytest.mark.asyncio
     async def test_spawn_auto_start_false_passed_to_cog(
         self, spawn_client: TestClient, mock_cog: MagicMock
     ) -> None:

--- a/tests/test_file_sender.py
+++ b/tests/test_file_sender.py
@@ -14,6 +14,8 @@ import pytest
 from claude_discord.discord_ui.file_sender import (
     _relative_path,
     collect_discord_files,
+    collect_discord_files_from_blobs,
+    send_file_blobs,
     send_files,
 )
 
@@ -189,3 +191,84 @@ class TestSendFiles:
         await send_files(thread, [str(f)], str(tmp_path))
 
         thread.send.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# collect_discord_files_from_blobs
+# ---------------------------------------------------------------------------
+
+
+class TestCollectDiscordFilesFromBlobs:
+    def test_blob_returned_as_discord_file(self) -> None:
+        files = collect_discord_files_from_blobs([("report.pdf", b"%PDF-1.4 data")])
+
+        assert len(files) == 1
+        assert files[0].filename == "report.pdf"
+
+    def test_strips_directory_component_from_filename(self) -> None:
+        files = collect_discord_files_from_blobs([("sub/dir/img.png", b"\x89PNG")])
+
+        assert files[0].filename == "img.png"
+
+    def test_oversized_blob_skipped(self) -> None:
+        files = collect_discord_files_from_blobs([("big.bin", b"x" * 11)], max_bytes=10)
+
+        assert files == []
+
+    def test_empty_list_returns_empty(self) -> None:
+        assert collect_discord_files_from_blobs([]) == []
+
+
+# ---------------------------------------------------------------------------
+# send_file_blobs
+# ---------------------------------------------------------------------------
+
+
+class TestSendFileBlobs:
+    @pytest.mark.asyncio
+    async def test_does_nothing_for_empty_list(self) -> None:
+        thread = MagicMock()
+        thread.send = AsyncMock()
+
+        await send_file_blobs(thread, [])
+
+        thread.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sends_blob_attachment(self) -> None:
+        thread = MagicMock()
+        thread.send = AsyncMock()
+
+        await send_file_blobs(thread, [("a.txt", b"hello")])
+
+        thread.send.assert_called_once()
+        kwargs = thread.send.call_args.kwargs
+        assert len(kwargs["files"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_discord_error_does_not_propagate(self) -> None:
+        thread = MagicMock()
+        thread.send = AsyncMock(side_effect=Exception("connection reset"))
+
+        await send_file_blobs(thread, [("a.txt", b"hello")])
+
+    @pytest.mark.asyncio
+    async def test_batches_more_than_10_blobs(self) -> None:
+        thread = MagicMock()
+        thread.send = AsyncMock()
+
+        blobs = [(f"f{i}.txt", b"x") for i in range(12)]
+        await send_file_blobs(thread, blobs)
+
+        assert thread.send.call_count == 2
+        assert len(thread.send.call_args_list[0].kwargs["files"]) == 10
+        assert len(thread.send.call_args_list[1].kwargs["files"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_custom_content_used_on_first_batch(self) -> None:
+        thread = MagicMock()
+        thread.send = AsyncMock()
+
+        await send_file_blobs(thread, [("a.txt", b"hi")], content="📎 Forgejo 添付")
+
+        assert thread.send.call_args.kwargs["content"] == "📎 Forgejo 添付"


### PR DESCRIPTION
## Summary

`POST /api/spawn` now accepts an optional `attachments` array of `{filename, data}` (base64 file bytes). After the seed prompt, ccdb decodes them and posts them into the freshly created thread as real Discord file attachments, so a programmatic caller can surface the original files alongside the prompt.

Motivating case: a Forgejo Issue/PR watcher that spawns a Discord thread and wants the issue's attachments viewable in-thread (instead of just a link behind an SSO gate).

## Changes
- `discord_ui/file_sender.py`: `collect_discord_files_from_blobs()` + `send_file_blobs()` — the in-memory twins of the existing path-based helpers (8 MB/file skip, 10-files/message batching, errors suppressed).
- `cogs/claude_chat.py`: `spawn_session(..., attachments=[(filename, bytes)])` posts blobs after the seed prompt.
- `ext/api_server.py`: `_decode_spawn_attachments()` validates + base64-decodes; filenames reduced to a safe basename (path-traversal guarded, shared with ingest); capped at 10 files / 25 MB total; invalid base64 → 400, before any thread is created.

Backward-compatible / Zero-Config: omit `attachments` and behaviour is unchanged.

## Test plan
- [x] `tests/test_file_sender.py`: blob collection (basename strip, oversize skip, empty) + send batching/error-suppression/custom content
- [x] `tests/test_api_server.py`: decode + pass-through, none when absent, invalid base64 → 400, non-list → 400, filename sanitization
- [x] `ruff check` + `ruff format --check` clean; targeted suites green (178 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)