### PR TITLE
feat: dual-engine status footer (Claude + Codex usage after each turn)

### DIFF
--- a/claude_discord/backend_settings.py
+++ b/claude_discord/backend_settings.py
@@ -30,6 +30,16 @@ MODEL_THREAD_PREFIX = "model.thread."  # + thread_id + "." + backend
 EFFORT_GLOBAL_PREFIX = "effort.global."  # + backend
 EFFORT_THREAD_PREFIX = "effort.thread."  # + thread_id + "." + backend
 
+# Codex status footer toggle (2-layer: global default + per-thread override).
+#   "auto" — show the Codex status line only when it can actually be fetched
+#            (codex installed + logged in). Invisible for Claude-only users.
+#   "on"   — always attempt; surface a hint when the fetch fails.
+#   "off"  — never show the Codex status line.
+CODEX_STATUS_GLOBAL = "status.codex.global"
+CODEX_STATUS_THREAD_PREFIX = "status.codex.thread."  # + thread_id
+CODEX_STATUS_MODES = ("auto", "on", "off")
+CODEX_STATUS_DEFAULT = "auto"
+
 
 class BackendSettings:
     """Thin wrapper around SettingsRepository that resolves backend/model."""
@@ -114,7 +124,31 @@ class BackendSettings:
         v = await self.repo.get(f"{EFFORT_GLOBAL_PREFIX}{backend}")
         return v if v else None
 
+    async def codex_status_mode(self, thread_id: int | None = None) -> str:
+        """Return the Codex status footer mode for this thread (or globally).
+
+        Resolution: thread override > global > ``CODEX_STATUS_DEFAULT`` (auto).
+        """
+        if thread_id is not None:
+            v = await self.repo.get(f"{CODEX_STATUS_THREAD_PREFIX}{thread_id}")
+            if v in CODEX_STATUS_MODES:
+                return v
+        v = await self.repo.get(CODEX_STATUS_GLOBAL)
+        if v in CODEX_STATUS_MODES:
+            return v
+        return CODEX_STATUS_DEFAULT
+
     # ── Mutation ────────────────────────────────────────────
+
+    async def set_codex_status_mode(self, mode: str, *, thread_id: int | None = None) -> None:
+        if mode not in CODEX_STATUS_MODES:
+            raise ValueError(f"unknown codex status mode {mode!r}")
+        if thread_id is not None:
+            await self.repo.set(f"{CODEX_STATUS_THREAD_PREFIX}{thread_id}", mode)
+            logger.info("codex status set: thread=%d -> %s", thread_id, mode)
+        else:
+            await self.repo.set(CODEX_STATUS_GLOBAL, mode)
+            logger.info("codex status set: global -> %s", mode)
 
     async def set_backend(self, backend: str, *, thread_id: int | None = None) -> None:
         if backend not in ALL_BACKENDS:
@@ -168,4 +202,6 @@ class BackendSettings:
                 deleted += 1
             if await self.repo.delete(f"{EFFORT_THREAD_PREFIX}{thread_id}.{b}"):
                 deleted += 1
+        if await self.repo.delete(f"{CODEX_STATUS_THREAD_PREFIX}{thread_id}"):
+            deleted += 1
         return deleted

--- a/claude_discord/cogs/backend_command.py
+++ b/claude_discord/cogs/backend_command.py
@@ -22,7 +22,12 @@ from discord.ext import commands
 
 from claude_code_core.codex_runner import VALID_CODEX_EFFORTS
 
-from ..backend_settings import ALL_BACKENDS, BackendSettings
+from ..backend_settings import (
+    ALL_BACKENDS,
+    CODEX_STATUS_DEFAULT,
+    CODEX_STATUS_MODES,
+    BackendSettings,
+)
 
 if TYPE_CHECKING:
     from ..backend_factory import BackendFactory
@@ -453,3 +458,76 @@ class BackendCommandCog(commands.Cog):
     def _effort_label(effort: str | None) -> str:
         """Human-readable effort label; ``None`` means the backend CLI's default."""
         return f"`{effort}`" if effort else "_(CLI default)_"
+
+    # ── /engine-status ─────────────────────────────────────────────
+
+    @app_commands.command(
+        name="engine-status",
+        description="Show/set whether the Codex usage line appears after each turn",
+    )
+    @app_commands.choices(
+        mode=[Choice(name=m, value=m) for m in CODEX_STATUS_MODES],
+        scope=[
+            Choice(name="thread", value=SCOPE_THREAD),
+            Choice(name="global", value=SCOPE_GLOBAL),
+        ],
+    )
+    @app_commands.describe(
+        mode=(
+            "auto: show Codex usage only when it can be fetched; "
+            "on: always; off: never. Omit to show current setting."
+        ),
+        scope=(
+            "thread: only this thread; global: server-wide default. "
+            "Default: thread when invoked in a thread, otherwise global."
+        ),
+    )
+    async def engine_status_command(
+        self,
+        interaction: discord.Interaction,
+        mode: str | None = None,
+        scope: str | None = None,
+    ) -> None:
+        thread_id_now = self._thread_id_or_none(interaction)
+
+        # Show current selection if no mode provided.
+        if mode is None:
+            current_g = await self._settings.codex_status_mode(None)
+            lines = [f"\U0001f9e0 **Global Codex status**: `{current_g}`"]
+            if thread_id_now is not None:
+                current_t = await self._settings.codex_status_mode(thread_id_now)
+                tag = " (thread override)" if current_t != current_g else ""
+                lines.append(f"\U0001f9f5 **This thread**: `{current_t}`{tag}")
+            lines.append(
+                f"-# auto = show Codex usage only when reachable (default: "
+                f"`{CODEX_STATUS_DEFAULT}`)."
+            )
+            await interaction.response.send_message("\n".join(lines), ephemeral=True)
+            return
+
+        if mode not in CODEX_STATUS_MODES:
+            await interaction.response.send_message(
+                f"Unknown mode `{mode}`. Choose: {', '.join(CODEX_STATUS_MODES)}.",
+                ephemeral=True,
+            )
+            return
+
+        resolved_scope, target_thread_id = self._resolve_scope(interaction, scope)
+        if resolved_scope == SCOPE_THREAD and target_thread_id is None:
+            await interaction.response.send_message(
+                "`scope:thread` requires the command to be run inside a thread.",
+                ephemeral=True,
+            )
+            return
+
+        await self._settings.set_codex_status_mode(mode, thread_id=target_thread_id)
+
+        scope_label = (
+            f"<#{target_thread_id}>"
+            if resolved_scope == SCOPE_THREAD and target_thread_id is not None
+            else "**globally**"
+        )
+        await interaction.response.send_message(
+            f"\U0001f300 Codex status set to `{mode}` {scope_label}.",
+            ephemeral=False,
+        )

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -75,6 +75,7 @@ _HELP_CATEGORY: dict[str, str | None] = {
     "sync-settings": "📌 Session",
     "model": "🤖 Model",
     "backend": "🤖 Model",
+    "engine-status": "🤖 Model",
     "effort": "⚡ Effort",
     "tools-show": "🔧 Advanced",
     "tools-set": "🔧 Advanced",
@@ -1119,6 +1120,10 @@ class ClaudeChatCog(commands.Cog):
                     chat_only=chat_only,
                     notify_user_id=user_message.author.id,
                     result_sink=result_sink,
+                    backend_settings=self._backend_settings,
+                    codex_command=(
+                        self._factory.codex_command if self._factory is not None else "codex"
+                    ),
                 )
             )
         finally:

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -533,25 +533,35 @@ class EventProcessor:
                 if self._config.status:
                     await self._config.status.set_done()
 
-                # Post the configured statusLine as Discord subtext. Only
-                # meaningful for the Claude backend — the statusLine command
-                # reads ~/.claude/settings.json and surfaces Anthropic-specific
-                # quota windows (5h, 7d) that have no Codex equivalent. Skip
-                # for non-claude backends entirely.
-                if _backend_name_from_runner(self._config.runner) == "claude":
-                    asyncio.create_task(
-                        _post_statusline_footer(
-                            thread=self._config.thread,
-                            working_dir=self._config.runner.working_dir,
-                            model=self._config.runner.model,
-                            context_window=event.context_window,
-                            input_tokens=event.input_tokens,
-                            cache_creation_tokens=event.cache_creation_tokens,
-                            cache_read_tokens=event.cache_read_tokens,
-                            api_label=self._config.runner.describe_api(),
-                        ),
-                        name=f"statusline-{self._config.thread.id}",
-                    )
+                # Post the per-turn engine status footer.
+                #
+                # - Claude statusLine (read from ~/.claude/settings.json)
+                #   surfaces Anthropic quota windows (5h, 7d).
+                # - Codex status line surfaces Codex usage via `codex
+                #   app-server` (account/rateLimits/read).
+                #
+                # When the 2-layer Codex toggle (status.codex) is enabled both
+                # are shown after every turn, so the user can compare usage and
+                # decide which engine to use. The Codex probe only runs for
+                # interactive chat (backend_settings is wired) — headless flows
+                # leave it None and incur no extra subprocess.
+                asyncio.create_task(
+                    _post_engine_status_footer(
+                        thread=self._config.thread,
+                        backend=_backend_name_from_runner(self._config.runner),
+                        working_dir=self._config.runner.working_dir,
+                        model=self._config.runner.model,
+                        context_window=event.context_window,
+                        input_tokens=event.input_tokens,
+                        cache_creation_tokens=event.cache_creation_tokens,
+                        cache_read_tokens=event.cache_read_tokens,
+                        api_label=self._config.runner.describe_api(),
+                        backend_settings=self._config.backend_settings,
+                        codex_command=self._config.codex_command,
+                        thread_id=self._config.thread.id,
+                    ),
+                    name=f"statusline-{self._config.thread.id}",
+                )
 
                 # Schedule inbox classification as a background task (non-blocking).
                 # Only runs when inbox_repo is wired in (THREAD_INBOX_ENABLED=true).
@@ -814,6 +824,49 @@ class EventProcessor:
 # ---------------------------------------------------------------------------
 
 
+async def _render_claude_statusline_text(
+    working_dir: str | None,
+    model: str,
+    context_window: int | None,
+    input_tokens: int | None,
+    cache_creation_tokens: int | None,
+    cache_read_tokens: int | None,
+) -> str | None:
+    """Render the configured Claude statusLine to Discord-ready text (or None).
+
+    Reads ``statusLine.command`` from ``~/.claude/settings.json`` and executes
+    it with the current session state. Returns the (max 3) non-empty output
+    lines joined, or ``None`` when no command is configured / it produced
+    nothing.
+    """
+    import os
+
+    from ..discord_ui.statusline import (
+        build_statusline_json,
+        read_statusline_command,
+        render_statusline,
+    )
+
+    command = read_statusline_command()
+    if not command:
+        return None
+    cwd = working_dir or os.path.expanduser("~")
+    json_input = build_statusline_json(
+        cwd=cwd,
+        model_id=model,
+        model_display_name=model,
+        context_size=context_window or 200000,
+        input_tokens=input_tokens or 0,
+        cache_creation_tokens=cache_creation_tokens or 0,
+        cache_read_tokens=cache_read_tokens or 0,
+    )
+    result = await render_statusline(command, json_input)
+    if not result:
+        return None
+    lines = [line for line in result.splitlines() if line.strip()]
+    return "\n".join(lines[:3]) if lines else None
+
+
 async def _post_statusline_footer(
     thread: object,
     working_dir: str | None,
@@ -832,38 +885,95 @@ async def _post_statusline_footer(
     (read from ``~/.claude/settings.json``) is appended below it when present.
     Posts nothing when neither is available.
     """
-    import os
-
-    from ..discord_ui.statusline import (
-        build_statusline_json,
-        read_statusline_command,
-        render_statusline,
+    statusline_text = await _render_claude_statusline_text(
+        working_dir,
+        model,
+        context_window,
+        input_tokens,
+        cache_creation_tokens,
+        cache_read_tokens,
     )
-
-    statusline_text: str | None = None
-    command = read_statusline_command()
-    if command:
-        cwd = working_dir or os.path.expanduser("~")
-        json_input = build_statusline_json(
-            cwd=cwd,
-            model_id=model,
-            model_display_name=model,
-            context_size=context_window or 200000,
-            input_tokens=input_tokens or 0,
-            cache_creation_tokens=cache_creation_tokens or 0,
-            cache_read_tokens=cache_read_tokens or 0,
-        )
-        result = await render_statusline(command, json_input)
-        if result:
-            lines = [line for line in result.splitlines() if line.strip()]
-            if lines:
-                statusline_text = "\n".join(lines[:3])
 
     parts: list[str] = []
     if api_label:
         parts.append(f"\U0001f517 API: {api_label}")
     if statusline_text:
         parts.append(statusline_text)
+
+    if not parts:
+        return
+
+    body = "\n".join(parts)
+    with contextlib.suppress(Exception):
+        await thread.send(f"```\n{body}\n```")  # type: ignore[union-attr]
+
+
+async def _post_engine_status_footer(
+    thread: object,
+    *,
+    backend: str,
+    working_dir: str | None,
+    model: str,
+    context_window: int | None,
+    input_tokens: int | None,
+    cache_creation_tokens: int | None,
+    cache_read_tokens: int | None,
+    api_label: str | None,
+    backend_settings: object | None,
+    codex_command: str,
+    thread_id: int | None,
+) -> None:
+    """Post the per-turn engine status footer (Claude statusLine + Codex line).
+
+    The Codex status line is gated by the 2-layer ``status.codex`` toggle:
+      - ``off``  → never shown
+      - ``auto`` → shown only when it can be fetched (codex installed +
+        logged in); silently hidden otherwise
+      - ``on``   → always attempted; a short hint is shown when it fails
+
+    The Claude statusLine renders on Claude turns as before. It is *also*
+    rendered on Codex turns when the Codex status line is active, so the
+    Anthropic quota stays visible for side-by-side comparison.
+    """
+    from ..backend_settings import BackendSettings
+    from ..discord_ui.engine_status import get_codex_status_line
+
+    # Resolve the Codex-status mode (off when no settings resolver is wired,
+    # e.g. headless flows).
+    mode = "off"
+    if isinstance(backend_settings, BackendSettings):
+        mode = await backend_settings.codex_status_mode(thread_id)
+    show_codex = mode in ("auto", "on")
+
+    # Codex line (account/rateLimits/read via codex app-server), cached.
+    codex_line: str | None = None
+    if show_codex:
+        codex_line = await get_codex_status_line(codex_command)
+        if codex_line is None and mode == "on":
+            codex_line = "\U0001f916 Codex: 残量取得失敗（codex login 済みか確認）"
+
+    # Render the Claude statusLine on Claude turns, or whenever the Codex line
+    # is being shown (so both engines appear together). On non-Claude turns the
+    # session model id is not a Claude model, so suppress the model label.
+    render_claude_sl = backend == "claude" or codex_line is not None
+    statusline_text: str | None = None
+    if render_claude_sl:
+        statusline_text = await _render_claude_statusline_text(
+            working_dir,
+            model if backend == "claude" else "",
+            context_window,
+            input_tokens,
+            cache_creation_tokens,
+            cache_read_tokens,
+        )
+
+    parts: list[str] = []
+    if api_label and backend == "claude":
+        parts.append(f"\U0001f517 API: {api_label}")
+    if statusline_text:
+        parts.append(statusline_text)
+    if codex_line:
+        parts.append(codex_line)
 
     if not parts:
         return

--- a/claude_discord/cogs/run_config.py
+++ b/claude_discord/cogs/run_config.py
@@ -24,6 +24,7 @@ from ..database.repository import SessionRepository
 from ..discord_ui.status import StatusManager
 
 if TYPE_CHECKING:
+    from ..backend_settings import BackendSettings
     from ..database.inbox_repo import ThreadInboxRepository
     from ..database.repository import UsageStatsRepository
     from ..discord_ui.thread_dashboard import ThreadStatusDashboard
@@ -96,6 +97,14 @@ class RunConfig:
     # internal compact/AskUserQuestion reruns via dataclasses.replace, and fires
     # exactly once at the true terminal return in run_claude_with_config.
     result_sink: Callable[[str | None, str | None], Awaitable[None]] | None = None
+
+    # Backend/model settings resolver. When provided (interactive chat only),
+    # the per-turn footer consults it for the 2-layer Codex-status toggle
+    # (status.codex global/thread). Headless flows (scheduler, webhook, API
+    # ingest) leave this None, so they never spawn the Codex status probe.
+    backend_settings: BackendSettings | None = None
+    # Command used to invoke Codex (for the Codex status probe in the footer).
+    codex_command: str = "codex"
 
     # Prevent accidental field mutation — RunConfig is a value object.
     # Use dataclasses.replace() to create modified copies.

--- a/claude_discord/discord_ui/engine_status.py
+++ b/claude_discord/discord_ui/engine_status.py
@@ -1,0 +1,219 @@
+"""Codex engine status for the per-turn footer.
+
+Fetches Codex usage / rate-limit data via the ``codex app-server`` JSON-RPC
+method ``account/rateLimits/read`` — the same call the Codex TUI makes on
+startup — and formats it into a compact, Discord-ready line.
+
+No browser automation, no public REST API: we drive the official client's
+local stdio backend over JSON-RPC. The call is read-only and incurs no billing
+(it is exactly what ``codex`` itself does every time it starts an interactive
+session).
+
+The result is cached per ``codex_command`` with a short TTL so that rapid
+successive turns do not each spawn an ``app-server`` process.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import shlex
+import time
+from collections.abc import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+# JSON-RPC method exposed by `codex app-server` that returns the same payload
+# the TUI shows in its startup banner.
+_RATE_LIMITS_METHOD = "account/rateLimits/read"
+
+_DEFAULT_TIMEOUT = 15.0
+# Successful results are cached this long; rate-limit windows move slowly
+# (5h / weekly) so a short cache avoids spawning app-server every turn.
+_DEFAULT_TTL = 90.0
+# Failures (codex missing, not logged in) are cached for a shorter window so we
+# do not hammer a broken setup on every message, but still recover quickly.
+_FAIL_TTL = 30.0
+
+
+async def fetch_codex_rate_limits(
+    codex_command: str = "codex",
+    timeout: float = _DEFAULT_TIMEOUT,
+) -> dict | None:
+    """Return the raw ``account/rateLimits/read`` result, or ``None`` on failure.
+
+    Spawns ``<codex_command> app-server``, performs the ``initialize``
+    handshake, then calls the rate-limits method and returns its ``result``
+    object. Any error (codex not installed, not logged in, protocol change,
+    timeout) yields ``None`` — callers treat that as "Codex status unavailable".
+
+    Security: always ``create_subprocess_exec`` (never a shell). ``codex_command``
+    comes from trusted configuration, not user input, but is still split with
+    ``shlex`` and passed as discrete argv entries.
+    """
+    parts = shlex.split(codex_command) if codex_command else ["codex"]
+    if not parts:
+        parts = ["codex"]
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *parts,
+            "app-server",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+    except (OSError, ValueError):
+        logger.debug("Failed to spawn codex app-server", exc_info=True)
+        return None
+
+    async def _exchange() -> dict | None:
+        assert proc.stdin is not None and proc.stdout is not None
+        init = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"clientInfo": {"name": "ccdb-engine-status", "version": "1.0.0"}},
+        }
+        read = {"jsonrpc": "2.0", "id": 2, "method": _RATE_LIMITS_METHOD, "params": None}
+        proc.stdin.write((json.dumps(init) + "\n").encode())
+        proc.stdin.write((json.dumps(read) + "\n").encode())
+        await proc.stdin.drain()
+
+        while True:
+            line = await proc.stdout.readline()
+            if not line:  # EOF
+                return None
+            try:
+                msg = json.loads(line)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if msg.get("id") == 2:
+                return msg.get("result") if "result" in msg else None
+
+    try:
+        return await asyncio.wait_for(_exchange(), timeout=timeout)
+    except (TimeoutError, Exception):
+        logger.debug("codex app-server rate-limits exchange failed", exc_info=True)
+        return None
+    finally:
+        with contextlib.suppress(ProcessLookupError):
+            proc.terminate()
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(proc.wait(), timeout=3)
+
+
+def _fmt_pct(snap: dict | None) -> str | None:
+    """Return ``"N%"`` from a primary/secondary snapshot, or ``None``."""
+    if not isinstance(snap, dict):
+        return None
+    pct = snap.get("usedPercent")
+    if pct is None:
+        return None
+    try:
+        return f"{round(float(pct))}%"
+    except (TypeError, ValueError):
+        return None
+
+
+def format_codex_status_line(data: dict | None) -> str | None:
+    """Format a ``account/rateLimits/read`` result into one Discord line.
+
+    Example: ``🤖 Codex: 5h 1% · 週次 8% · クレジット 0 (prolite)``.
+    Returns ``None`` when there is nothing meaningful to show.
+    """
+    if not isinstance(data, dict):
+        return None
+    snap = data.get("rateLimits")
+    if not isinstance(snap, dict):
+        return None
+
+    segments: list[str] = []
+    primary = _fmt_pct(snap.get("primary"))
+    if primary is not None:
+        segments.append(f"5h {primary}")
+    secondary = _fmt_pct(snap.get("secondary"))
+    if secondary is not None:
+        segments.append(f"週次 {secondary}")
+
+    credit_info = snap.get("credits")
+    if isinstance(credit_info, dict):
+        if credit_info.get("unlimited"):
+            segments.append("クレジット 無制限")
+        elif credit_info.get("balance") is not None:
+            segments.append(f"クレジット {credit_info.get('balance')}")
+
+    if not segments:
+        return None
+
+    plan = snap.get("planType")
+    suffix = f" ({plan})" if plan else ""
+    reached = snap.get("rateLimitReachedType")
+    warn = " ⚠ 上限到達" if reached else ""
+    return f"\U0001f916 Codex: {' · '.join(segments)}{suffix}{warn}"
+
+
+class CodexStatusProvider:
+    """TTL-cached provider of the formatted Codex status line.
+
+    ``fetcher`` and ``clock`` are injectable for testing. In production the
+    fetcher is :func:`fetch_codex_rate_limits` and the clock is
+    ``time.monotonic``.
+    """
+
+    def __init__(
+        self,
+        codex_command: str = "codex",
+        *,
+        ttl: float = _DEFAULT_TTL,
+        fail_ttl: float = _FAIL_TTL,
+        fetcher: Callable[[str], Awaitable[dict | None]] | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._command = codex_command
+        self._ttl = ttl
+        self._fail_ttl = fail_ttl
+        self._fetcher = fetcher or (lambda cmd: fetch_codex_rate_limits(cmd))
+        self._clock = clock
+        self._cached_line: str | None = None
+        self._cached_at: float | None = None
+        self._cache_was_success = False
+        self._lock = asyncio.Lock()
+
+    def _is_fresh(self) -> bool:
+        if self._cached_at is None:
+            return False
+        ttl = self._ttl if self._cache_was_success else self._fail_ttl
+        return (self._clock() - self._cached_at) < ttl
+
+    async def get_line(self, *, force: bool = False) -> str | None:
+        """Return the cached status line, refreshing it when stale."""
+        async with self._lock:
+            if not force and self._is_fresh():
+                return self._cached_line
+            data = await self._fetcher(self._command)
+            line = format_codex_status_line(data)
+            self._cached_line = line
+            self._cached_at = self._clock()
+            self._cache_was_success = line is not None
+            return line
+
+
+# Module-level provider registry keyed by codex command so a single cache is
+# shared across all turns/threads for a given command.
+_PROVIDERS: dict[str, CodexStatusProvider] = {}
+
+
+def _provider_for(codex_command: str) -> CodexStatusProvider:
+    prov = _PROVIDERS.get(codex_command)
+    if prov is None:
+        prov = CodexStatusProvider(codex_command)
+        _PROVIDERS[codex_command] = prov
+    return prov
+
+
+async def get_codex_status_line(codex_command: str = "codex") -> str | None:
+    """Convenience entry point used by the per-turn footer (cached)."""
+    return await _provider_for(codex_command).get_line()

--- a/tests/test_backend_settings.py
+++ b/tests/test_backend_settings.py
@@ -10,6 +10,7 @@ import pytest
 
 from claude_discord.backend_settings import (
     BACKEND_GLOBAL,
+    CODEX_STATUS_GLOBAL,
     BackendSettings,
 )
 from claude_discord.database.settings_repo import SettingsRepository
@@ -101,6 +102,53 @@ class TestResolution:
         deleted = await s.clear_thread_overrides(7)
         assert deleted == 2
         assert await s.current_backend(thread_id=7) == "claude"
+
+
+class TestCodexStatusMode:
+    async def _settings(self) -> BackendSettings:
+        repo, _ = await _new_repo()
+        return BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+        )
+
+    async def test_default_is_auto(self) -> None:
+        s = await self._settings()
+        assert await s.codex_status_mode() == "auto"
+        assert await s.codex_status_mode(thread_id=5) == "auto"
+
+    async def test_global_set(self) -> None:
+        s = await self._settings()
+        await s.set_codex_status_mode("on")
+        assert await s.codex_status_mode() == "on"
+
+    async def test_thread_overrides_global(self) -> None:
+        s = await self._settings()
+        await s.set_codex_status_mode("on")
+        await s.set_codex_status_mode("off", thread_id=42)
+        assert await s.codex_status_mode() == "on"
+        assert await s.codex_status_mode(thread_id=42) == "off"
+        # other thread sees global
+        assert await s.codex_status_mode(thread_id=1) == "on"
+
+    async def test_invalid_value_in_db_falls_through(self) -> None:
+        s = await self._settings()
+        await s.repo.set(CODEX_STATUS_GLOBAL, "bogus")
+        assert await s.codex_status_mode() == "auto"
+
+    async def test_set_rejects_unknown_mode(self) -> None:
+        s = await self._settings()
+        with pytest.raises(ValueError):
+            await s.set_codex_status_mode("sometimes")
+
+    async def test_clear_thread_overrides_removes_codex_status(self) -> None:
+        s = await self._settings()
+        await s.set_codex_status_mode("off", thread_id=7)
+        deleted = await s.clear_thread_overrides(7)
+        assert deleted == 1
+        assert await s.codex_status_mode(thread_id=7) == "auto"
 
 
 class TestMutationValidation:

--- a/tests/test_engine_status.py
+++ b/tests/test_engine_status.py
@@ -1,0 +1,118 @@
+"""Tests for the Codex engine status footer helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from claude_discord.discord_ui.engine_status import (
+    CodexStatusProvider,
+    format_codex_status_line,
+)
+
+# Representative `account/rateLimits/read` result (trimmed to what we read).
+SAMPLE = {
+    "rateLimits": {
+        "limitId": "codex",
+        "primary": {"usedPercent": 1, "windowDurationMins": 300, "resetsAt": 1782198285},
+        "secondary": {"usedPercent": 8, "windowDurationMins": 10080, "resetsAt": 1782361421},
+        "credits": {"hasCredits": False, "unlimited": False, "balance": "0"},
+        "planType": "prolite",
+        "rateLimitReachedType": None,
+    }
+}
+
+
+class TestFormat:
+    def test_basic_line(self) -> None:
+        line = format_codex_status_line(SAMPLE)
+        assert line is not None
+        assert "Codex" in line
+        assert "5h 1%" in line
+        assert "週次 8%" in line
+        assert "クレジット 0" in line
+        assert "(prolite)" in line
+
+    def test_unlimited_credits(self) -> None:
+        data = {"rateLimits": {"primary": {"usedPercent": 5}, "credits": {"unlimited": True}}}
+        line = format_codex_status_line(data)
+        assert line is not None
+        assert "クレジット 無制限" in line
+
+    def test_rounds_fractional_percent(self) -> None:
+        data = {"rateLimits": {"primary": {"usedPercent": 12.6}}}
+        line = format_codex_status_line(data)
+        assert line is not None
+        assert "5h 13%" in line
+
+    def test_rate_limit_reached_warning(self) -> None:
+        data = {
+            "rateLimits": {
+                "primary": {"usedPercent": 100},
+                "rateLimitReachedType": "rate_limit_reached",
+            }
+        }
+        line = format_codex_status_line(data)
+        assert line is not None
+        assert "上限到達" in line
+
+    @pytest.mark.parametrize("bad", [None, {}, {"rateLimits": None}, {"rateLimits": {}}, "x"])
+    def test_returns_none_for_unusable(self, bad: object) -> None:
+        assert format_codex_status_line(bad) is None  # type: ignore[arg-type]
+
+
+class TestProviderCache:
+    async def test_caches_within_ttl(self) -> None:
+        calls = {"n": 0}
+
+        async def fake_fetch(_cmd: str) -> dict:
+            calls["n"] += 1
+            return SAMPLE
+
+        now = {"t": 1000.0}
+        prov = CodexStatusProvider("codex", ttl=90.0, fetcher=fake_fetch, clock=lambda: now["t"])
+
+        first = await prov.get_line()
+        assert first is not None
+        # Second call within TTL → cached, no extra fetch.
+        now["t"] = 1050.0
+        await prov.get_line()
+        assert calls["n"] == 1
+
+        # After TTL expiry → refetch.
+        now["t"] = 1200.0
+        await prov.get_line()
+        assert calls["n"] == 2
+
+    async def test_failure_uses_short_ttl(self) -> None:
+        calls = {"n": 0}
+
+        async def failing_fetch(_cmd: str) -> None:
+            calls["n"] += 1
+            return None
+
+        now = {"t": 0.0}
+        prov = CodexStatusProvider(
+            "codex", ttl=90.0, fail_ttl=30.0, fetcher=failing_fetch, clock=lambda: now["t"]
+        )
+
+        assert await prov.get_line() is None
+        # Within fail_ttl → still cached (no refetch).
+        now["t"] = 10.0
+        assert await prov.get_line() is None
+        assert calls["n"] == 1
+        # After fail_ttl → refetch.
+        now["t"] = 40.0
+        assert await prov.get_line() is None
+        assert calls["n"] == 2
+
+    async def test_force_bypasses_cache(self) -> None:
+        calls = {"n": 0}
+
+        async def fake_fetch(_cmd: str) -> dict:
+            calls["n"] += 1
+            return SAMPLE
+
+        prov = CodexStatusProvider("codex", fetcher=fake_fetch, clock=lambda: 0.0)
+        await prov.get_line()
+        await prov.get_line(force=True)
+        assert calls["n"] == 2

--- a/tests/test_engine_status_footer.py
+++ b/tests/test_engine_status_footer.py
@@ -1,0 +1,117 @@
+"""Tests for _post_engine_status_footer (Claude statusLine + Codex line gating)."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import aiosqlite
+
+from claude_discord.backend_settings import BackendSettings
+from claude_discord.cogs.event_processor import _post_engine_status_footer
+from claude_discord.database.settings_repo import SettingsRepository
+
+_EP = "claude_discord.cogs.event_processor"
+_ES = "claude_discord.discord_ui.engine_status"
+
+
+async def _settings(mode: str) -> BackendSettings:
+    tmp = Path(tempfile.mkdtemp()) / "settings.db"
+    async with aiosqlite.connect(str(tmp)) as db:
+        await db.execute("CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+        await db.commit()
+    s = BackendSettings(
+        SettingsRepository(str(tmp)),
+        env_backend="claude",
+        env_model_for_claude="sonnet",
+        env_model_for_codex="",
+    )
+    await s.set_codex_status_mode(mode)
+    return s
+
+
+async def _run(*, backend: str, mode: str, codex_line, statusline) -> str | None:
+    thread = AsyncMock()
+    settings = await _settings(mode)
+    with (
+        patch(f"{_ES}.get_codex_status_line", AsyncMock(return_value=codex_line)),
+        patch(f"{_EP}._render_claude_statusline_text", AsyncMock(return_value=statusline)),
+    ):
+        await _post_engine_status_footer(
+            thread,
+            backend=backend,
+            working_dir="/tmp",
+            model="sonnet",
+            context_window=200000,
+            input_tokens=100,
+            cache_creation_tokens=0,
+            cache_read_tokens=0,
+            api_label="Anthropic API (direct)",
+            backend_settings=settings,
+            codex_command="codex",
+            thread_id=1,
+        )
+    if thread.send.await_count == 0:
+        return None
+    return thread.send.await_args.args[0]
+
+
+class TestGating:
+    async def test_off_claude_turn_shows_only_claude(self) -> None:
+        body = await _run(
+            backend="claude", mode="off", codex_line="🤖 Codex: x", statusline="Ctx 4%"
+        )
+        assert body is not None
+        assert "Codex" not in body
+        assert "Ctx 4%" in body
+        assert "API:" in body
+
+    async def test_auto_claude_turn_shows_both(self) -> None:
+        body = await _run(
+            backend="claude", mode="auto", codex_line="🤖 Codex: 5h 1%", statusline="Ctx 4%"
+        )
+        assert body is not None
+        assert "Codex: 5h 1%" in body
+        assert "Ctx 4%" in body
+
+    async def test_auto_codex_turn_no_api_label_but_shows_codex(self) -> None:
+        body = await _run(
+            backend="codex", mode="auto", codex_line="🤖 Codex: 5h 1%", statusline="Ctx 0%"
+        )
+        assert body is not None
+        assert "Codex: 5h 1%" in body
+        # API label is Claude-specific; suppressed on codex turns.
+        assert "API:" not in body
+
+    async def test_auto_codex_turn_fetch_fails_posts_nothing(self) -> None:
+        body = await _run(backend="codex", mode="auto", codex_line=None, statusline=None)
+        assert body is None
+
+    async def test_off_codex_turn_posts_nothing(self) -> None:
+        body = await _run(
+            backend="codex", mode="off", codex_line="🤖 Codex: x", statusline="Ctx 0%"
+        )
+        assert body is None
+
+    async def test_no_settings_means_off(self) -> None:
+        thread = AsyncMock()
+        with (
+            patch(f"{_ES}.get_codex_status_line", AsyncMock(return_value="🤖 Codex: x")),
+            patch(f"{_EP}._render_claude_statusline_text", AsyncMock(return_value=None)),
+        ):
+            await _post_engine_status_footer(
+                thread,
+                backend="codex",
+                working_dir="/tmp",
+                model="gpt-5.4",
+                context_window=None,
+                input_tokens=None,
+                cache_creation_tokens=None,
+                cache_read_tokens=None,
+                api_label="OpenAI",
+                backend_settings=None,
+                codex_command="codex",
+                thread_id=1,
+            )
+        assert thread.send.await_count == 0

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "3.1.2"
+version = "3.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Show **Codex usage** (5h window / weekly window / credits) alongside the existing Claude `statusLine` after each turn, so users running **both** Claude and Codex can compare usage at a glance and decide which engine to use next.

Codex data comes from the official `codex app-server` JSON-RPC method `account/rateLimits/read` — the same call the Codex TUI makes on startup. No browser automation, no scraping, read-only, no billing.

Example footer (when enabled, on a Claude turn):
```
🔗 API: Anthropic API (direct)
Ctx 4% · ...        (the existing Claude statusLine)
🤖 Codex: 5h 1% · 週次 8% · クレジット 0 (prolite)
```

## Behaviour

A new `/engine-status` command controls the Codex line via a **2-layer toggle** (global default + per-thread override), mirroring `/backend`:

- **`auto`** (default) — show the Codex line only when it can actually be fetched (codex installed + logged in). **Invisible for Claude-only / ccdb-only users**, so nothing changes for them (Zero-Config).
- **`on`** — always attempt; show a short hint when the fetch fails.
- **`off`** — never show.

When the Codex line is shown, the Claude `statusLine` is also rendered (even on Codex turns) so both engines' usage appear together.

## Design notes

- **Interactive-only probe**: the Codex fetch runs only when `RunConfig.backend_settings` is wired (interactive chat). Headless flows (scheduler, webhook, API ingest) leave it `None` and never spawn `app-server` — no added latency there.
- **TTL cache** (90s success / 30s failure) per `codex_command`, so rapid successive turns don't each spawn an `app-server` process.
- Claude statusLine rendering was extracted into `_render_claude_statusline_text()` and reused by both the legacy footer and the new combined footer (no behaviour change to the existing path).

## Files

- `discord_ui/engine_status.py` *(new)* — fetch (`account/rateLimits/read` over stdio JSON-RPC) + format + TTL-cached provider
- `backend_settings.py` — `codex_status_mode` resolver/setter (2-layer, default `auto`)
- `cogs/event_processor.py` — `_post_engine_status_footer` (Claude statusLine + Codex line) + extracted helper
- `cogs/backend_command.py` — `/engine-status` command
- `cogs/run_config.py`, `cogs/claude_chat.py` — wire `backend_settings` + `codex_command`
- `cogs/claude_chat.py` — register `/engine-status` in `_HELP_CATEGORY`

## Tests

- `tests/test_engine_status.py` — formatting (incl. unlimited credits, fractional %, limit-reached warning, unusable input) + TTL cache (hit/expiry/failure-ttl/force)
- `tests/test_engine_status_footer.py` — gating matrix (off/auto × claude/codex turn, fetch-fail, no-settings)
- `tests/test_backend_settings.py` — `codex_status_mode` resolution/override/validation/cleanup

All 1563 tests pass locally; `ruff check` + `ruff format --check` clean.

## Security

- `create_subprocess_exec` only (no `shell=True`); `codex_command` comes from trusted config and is `shlex`-split into discrete argv.
- No user input reaches the subprocess args (the JSON-RPC payload is static).
- No secrets logged; failures are `logger.debug` with `exc_info` (logs only, never Discord).

## Test plan

- [ ] `/engine-status` (no arg) shows current global/thread mode
- [ ] `/engine-status on` → after a turn, Codex usage line appears under the Claude statusLine
- [ ] `/engine-status off` → no Codex line
- [ ] `auto` with codex not logged in → no Codex line (silent)
- [ ] Codex-only user / no codex installed → no change to existing behaviour