### PR TITLE
fix: interrupt session even when Stop button message is deleted

### DIFF
--- a/claude_discord/discord_ui/views.py
+++ b/claude_discord/discord_ui/views.py
@@ -87,7 +87,8 @@ class StopView(discord.ui.View):
         button.disabled = True
         self.stop()
 
-        await interaction.response.edit_message(view=self)
+        with contextlib.suppress(discord.HTTPException):
+            await interaction.response.edit_message(view=self)
         await self._runner.interrupt()
 
         with contextlib.suppress(discord.HTTPException):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -90,6 +90,32 @@ class TestStopViewButtonClick:
         assert "stopped" in embed.title.lower()
 
     @pytest.mark.asyncio
+    async def test_click_still_interrupts_when_message_deleted(self) -> None:
+        """interrupt() is called even if the message was deleted before clicking Stop."""
+        runner = _make_runner()
+        view = StopView(runner)
+        interaction = _make_interaction()
+        interaction.response.edit_message = AsyncMock(
+            side_effect=discord.NotFound(MagicMock(), "Unknown Message")
+        )
+
+        await _click(view, interaction)
+
+        runner.interrupt.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_click_no_crash_when_edit_raises_http_exception(self) -> None:
+        """stop_button does not propagate HTTPException from edit_message."""
+        runner = _make_runner()
+        view = StopView(runner)
+        interaction = _make_interaction()
+        interaction.response.edit_message = AsyncMock(
+            side_effect=discord.HTTPException(MagicMock(), "rate limited")
+        )
+
+        await _click(view, interaction)  # should not raise
+
+    @pytest.mark.asyncio
     async def test_double_click_is_noop(self) -> None:
         """A second click after the first is ignored (idempotent)."""
         runner = _make_runner()


### PR DESCRIPTION
## Summary

- `StopView.stop_button` で `edit_message` が `discord.NotFound (10008: Unknown Message)` を投げると `interrupt()` が呼ばれずセッションが止まらないバグを修正
- `edit_message` を `contextlib.suppress(discord.HTTPException)` でラップし、メッセージが削除済みでも `interrupt()` が確実に呼ばれるように
- 再現したログ: `2026-06-27 10:20:56 [ERROR] discord.ui.view: Ignoring exception in view <StopView>`

## Test plan

- [x] `test_click_still_interrupts_when_message_deleted` — NotFound 時も interrupt() が呼ばれることを確認
- [x] `test_click_no_crash_when_edit_raises_http_exception` — HTTPException が propagate しないことを確認
- [x] 既存テスト 1592 件すべてパス
- [x] ruff check/format クリア