### PR TITLE
Honor backend selection for headless automation

### DIFF
--- a/claude_discord/cogs/headless_backend.py
+++ b/claude_discord/cogs/headless_backend.py
@@ -1,0 +1,64 @@
+"""Backend resolution for non-chat automated runs."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from ..claude.runner import _UNSET
+
+if TYPE_CHECKING:
+    from claude_code_core.backend import SessionBackend
+
+    from ..backend_factory import BackendFactory
+    from ..backend_settings import BackendSettings
+
+
+async def build_headless_runner(
+    base_runner: SessionBackend,
+    *,
+    factory: BackendFactory | None = None,
+    settings: BackendSettings | None = None,
+    thread_id: int | None = None,
+    working_dir: str | None = None,
+    timeout_seconds: int | None = None,
+    allowed_tools: list[str] | None | object = _UNSET,
+    permission_mode: str | None = None,
+    dangerously_skip_permissions: bool | None = None,
+) -> SessionBackend:
+    """Build a runner for scheduler/webhook/custom-cog automation.
+
+    Chat sessions already resolve backend/model in ``ClaudeChatCog``.  Headless
+    flows used to clone the startup runner, so a global ``/backend codex`` switch
+    did not affect scheduled tasks or failure triage.  When a factory/settings
+    pair is available, resolve the current backend at spawn time; otherwise keep
+    the legacy clone behaviour.
+    """
+    if factory is not None and settings is not None:
+        backend = await settings.current_backend(thread_id)
+        model = await settings.current_model(backend, thread_id)
+        runner = factory.build(backend=backend, model=model, thread_id=thread_id)
+        effort = await settings.current_effort(backend, thread_id)
+        if effort is not None and hasattr(runner, "effort"):
+            runner.effort = effort  # type: ignore[attr-defined]
+    else:
+        runner = base_runner.clone(thread_id=thread_id)
+
+    if working_dir is not None:
+        runner.working_dir = working_dir
+    if timeout_seconds is not None:
+        runner.timeout_seconds = timeout_seconds
+    if allowed_tools is not _UNSET:
+        runner.allowed_tools = allowed_tools  # type: ignore[assignment]
+    if permission_mode is not None:
+        runner.permission_mode = permission_mode
+    if dangerously_skip_permissions is not None:
+        runner.dangerously_skip_permissions = dangerously_skip_permissions
+    return runner
+
+
+def backend_factory_from_components(components: Any) -> BackendFactory | None:
+    return vars(components).get("backend_factory")
+
+
+def backend_settings_from_components(components: Any) -> BackendSettings | None:
+    return vars(components).get("backend_settings")

--- a/claude_discord/cogs/scheduler.py
+++ b/claude_discord/cogs/scheduler.py
@@ -22,11 +22,14 @@ import discord
 from discord.ext import commands, tasks
 
 from ._run_helper import run_claude_with_config
+from .headless_backend import build_headless_runner
 from .run_config import RunConfig
 
 if TYPE_CHECKING:
     from claude_code_core.backend import SessionBackend
 
+    from ..backend_factory import BackendFactory
+    from ..backend_settings import BackendSettings
     from ..database.repository import SessionRepository
     from ..database.task_repo import TaskRepository
 
@@ -52,11 +55,15 @@ class SchedulerCog(commands.Cog):
         *,
         repo: TaskRepository,
         session_repo: SessionRepository | None = None,
+        backend_factory: BackendFactory | None = None,
+        backend_settings: BackendSettings | None = None,
     ) -> None:
         self.bot = bot
         self.runner = runner
         self.repo = repo
         self.session_repo = session_repo
+        self.backend_factory = backend_factory
+        self.backend_settings = backend_settings
         # Track in-flight tasks to avoid double-running the same task_id.
         self._running: set[int] = set()
 
@@ -143,9 +150,13 @@ class SchedulerCog(commands.Cog):
                 if thread is None:
                     return
 
-            cloned = self.runner.clone()
-            if task.get("working_dir"):
-                cloned.working_dir = task["working_dir"]
+            cloned = await build_headless_runner(
+                self.runner,
+                factory=self.backend_factory,
+                settings=self.backend_settings,
+                thread_id=thread.id,
+                working_dir=task.get("working_dir"),
+            )
 
             registry = getattr(self.bot, "session_registry", None)
             await run_claude_with_config(
@@ -156,6 +167,7 @@ class SchedulerCog(commands.Cog):
                     prompt=task["prompt"],
                     session_id=session_id,
                     registry=registry,
+                    backend_settings=self.backend_settings,
                 )
             )
 

--- a/claude_discord/cogs/webhook_trigger.py
+++ b/claude_discord/cogs/webhook_trigger.py
@@ -21,11 +21,15 @@ import discord
 from discord.ext import commands
 
 from ..cogs._run_helper import run_claude_with_config
+from ..cogs.headless_backend import build_headless_runner
 from ..cogs.run_config import RunConfig
 from ..concurrency import SessionRegistry
 
 if TYPE_CHECKING:
     from claude_code_core.backend import SessionBackend
+
+    from ..backend_factory import BackendFactory
+    from ..backend_settings import BackendSettings
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +78,8 @@ class WebhookTriggerCog(commands.Cog):
         allowed_webhook_ids: set[int] | None = None,
         channel_ids: set[int] | None = None,
         registry: SessionRegistry | None = None,
+        backend_factory: BackendFactory | None = None,
+        backend_settings: BackendSettings | None = None,
     ) -> None:
         self.bot = bot
         self.runner = runner
@@ -81,6 +87,8 @@ class WebhookTriggerCog(commands.Cog):
         self.allowed_webhook_ids = allowed_webhook_ids
         self.channel_ids = channel_ids
         self._registry = registry or getattr(bot, "session_registry", None)
+        self._backend_factory = backend_factory
+        self._backend_settings = backend_settings
         self._locks: dict[str, asyncio.Lock] = {prefix: asyncio.Lock() for prefix in triggers}
         self._active_count: int = 0
 
@@ -140,15 +148,17 @@ class WebhookTriggerCog(commands.Cog):
         """Execute a matched trigger via Claude Code."""
         thread = await message.create_thread(name=prefix[:100])
 
-        runner = self.runner.clone()
-        runner.dangerously_skip_permissions = trigger.dangerously_skip_permissions
-        if trigger.permission_mode is not None:
-            runner.permission_mode = trigger.permission_mode
-        runner.timeout_seconds = trigger.timeout
-        if trigger.working_dir:
-            runner.working_dir = trigger.working_dir
-        if trigger.allowed_tools is not None:
-            runner.allowed_tools = trigger.allowed_tools
+        runner = await build_headless_runner(
+            self.runner,
+            factory=self._backend_factory,
+            settings=self._backend_settings,
+            thread_id=thread.id,
+            working_dir=trigger.working_dir,
+            timeout_seconds=trigger.timeout,
+            allowed_tools=trigger.allowed_tools,
+            permission_mode=trigger.permission_mode,
+            dangerously_skip_permissions=trigger.dangerously_skip_permissions,
+        )
 
         self._active_count += 1
         try:
@@ -161,6 +171,7 @@ class WebhookTriggerCog(commands.Cog):
                     session_id=None,
                     status=None,
                     registry=self._registry,
+                    backend_settings=self._backend_settings,
                 )
             )
 

--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from claude_code_core.backend import SessionBackend
 
     from .backend_factory import BackendFactory
+    from .backend_settings import BackendSettings
     from .database.ingest_repo import IngestResultRepository
     from .database.lounge_repo import LoungeRepository
     from .database.repository import SessionRepository
@@ -47,6 +48,8 @@ class BridgeComponents:
     lounge_repo: LoungeRepository | None = None
     resume_repo: PendingResumeRepository | None = None
     ingest_repo: IngestResultRepository | None = None
+    backend_factory: BackendFactory | None = None
+    backend_settings: BackendSettings | None = None
 
     def apply_to_api_server(self, api_server: ApiServer) -> None:
         """Wire all optional repos to an ApiServer instance.
@@ -263,12 +266,12 @@ async def setup_bridge(
     # --- ClaudeChatCog ---
     # Build BackendSettings up front so we can also pass it into
     # ClaudeChatCog (so per-thread /backend overrides take effect on spawn).
-    _backend_settings_for_chat = None
+    backend_settings: BackendSettings | None = None
     if backend_factory is not None:
         from .backend_settings import BackendSettings
 
         _runner_class = runner.__class__.__name__
-        _backend_settings_for_chat = BackendSettings(
+        backend_settings = BackendSettings(
             settings_repo,
             env_backend=_runner_class.replace("Runner", "").lower(),
             env_model_for_claude=(runner.model if _runner_class == "ClaudeRunner" else ""),
@@ -280,7 +283,7 @@ async def setup_bridge(
         repo=session_repo,
         runner=runner,
         factory=backend_factory,
-        backend_settings=_backend_settings_for_chat,
+        backend_settings=backend_settings,
         max_concurrent=max_concurrent,
         allowed_user_ids=allowed_user_ids,
         ask_repo=ask_repo,
@@ -334,7 +337,14 @@ async def setup_bridge(
         from .cogs._run_helper import configure_wakeup_scheduler
 
         configure_wakeup_scheduler(task_repo)
-        scheduler_cog = SchedulerCog(bot, runner, repo=task_repo, session_repo=session_repo)
+        scheduler_cog = SchedulerCog(
+            bot,
+            runner,
+            repo=task_repo,
+            session_repo=session_repo,
+            backend_factory=backend_factory,
+            backend_settings=backend_settings,
+        )
         await bot.add_cog(scheduler_cog)
         logger.info("Registered SchedulerCog")
 
@@ -352,16 +362,9 @@ async def setup_bridge(
 
     # --- BackendCommandCog (optional — only if a BackendFactory was provided) ---
     if backend_factory is not None:
-        from .backend_settings import BackendSettings
         from .cogs.backend_command import BackendCommandCog
 
-        _runner_class = runner.__class__.__name__
-        backend_settings = BackendSettings(
-            settings_repo,
-            env_backend=_runner_class.replace("Runner", "").lower(),
-            env_model_for_claude=(runner.model if _runner_class == "ClaudeRunner" else ""),
-            env_model_for_codex=(runner.model if _runner_class == "CodexRunner" else ""),
-        )
+        assert backend_settings is not None
         backend_cmd_cog = BackendCommandCog(
             bot,  # type: ignore[arg-type]
             settings=backend_settings,
@@ -377,6 +380,8 @@ async def setup_bridge(
         lounge_repo=lounge_repo,
         resume_repo=resume_repo,
         ingest_repo=ingest_repo,
+        backend_factory=backend_factory,
+        backend_settings=backend_settings,
     )
 
     # Auto-wire repos to ApiServer and set runner.api_port if provided

--- a/examples/ebibot/cogs/alert_responder.py
+++ b/examples/ebibot/cogs/alert_responder.py
@@ -32,6 +32,11 @@ import discord
 from discord.ext import commands
 
 from claude_discord.cogs._run_helper import run_claude_with_config
+from claude_discord.cogs.headless_backend import (
+    backend_factory_from_components,
+    backend_settings_from_components,
+    build_headless_runner,
+)
 from claude_discord.cogs.run_config import RunConfig
 
 logger = logging.getLogger(__name__)
@@ -141,7 +146,13 @@ class AlertResponderCog(commands.Cog):
         registry = getattr(self.bot, "session_registry", None)
         lounge_repo = getattr(self.components, "lounge_repo", None)
 
-        cloned_runner = self.runner.clone()
+        backend_settings = backend_settings_from_components(self.components)
+        cloned_runner = await build_headless_runner(
+            self.runner,
+            factory=backend_factory_from_components(self.components),
+            settings=backend_settings,
+            thread_id=thread.id,
+        )
 
         await run_claude_with_config(
             RunConfig(
@@ -152,6 +163,7 @@ class AlertResponderCog(commands.Cog):
                 repo=session_repo,
                 registry=registry,
                 lounge_repo=lounge_repo,
+                backend_settings=backend_settings,
             )
         )
 

--- a/examples/ebibot/cogs/docs_sync.py
+++ b/examples/ebibot/cogs/docs_sync.py
@@ -14,6 +14,10 @@ from __future__ import annotations
 
 import os
 
+from claude_discord.cogs.headless_backend import (
+    backend_factory_from_components,
+    backend_settings_from_components,
+)
 from claude_discord.cogs.webhook_trigger import WebhookTrigger, WebhookTriggerCog
 
 _COMMON_HEADER = """\
@@ -179,5 +183,7 @@ async def setup(bot: object, runner: object, components: object) -> None:
         runner=runner,  # type: ignore[arg-type]
         triggers=DOCS_SYNC_TRIGGERS,
         channel_ids=channel_ids or None,
+        backend_factory=backend_factory_from_components(components),
+        backend_settings=backend_settings_from_components(components),
     )
     await bot.add_cog(cog)  # type: ignore[union-attr]

--- a/examples/ebibot/cogs/job_failure_triage.py
+++ b/examples/ebibot/cogs/job_failure_triage.py
@@ -26,6 +26,11 @@ import discord
 from discord.ext import commands
 
 from claude_discord.cogs._run_helper import run_claude_with_config
+from claude_discord.cogs.headless_backend import (
+    backend_factory_from_components,
+    backend_settings_from_components,
+    build_headless_runner,
+)
 from claude_discord.cogs.run_config import RunConfig
 
 logger = logging.getLogger(__name__)
@@ -190,7 +195,13 @@ class JobFailureTriageCog(commands.Cog):
         registry = getattr(self.bot, "session_registry", None)
         lounge_repo = getattr(self.components, "lounge_repo", None)
 
-        cloned_runner = self.runner.clone()
+        backend_settings = backend_settings_from_components(self.components)
+        cloned_runner = await build_headless_runner(
+            self.runner,
+            factory=backend_factory_from_components(self.components),
+            settings=backend_settings,
+            thread_id=thread.id,
+        )
 
         await run_claude_with_config(
             RunConfig(
@@ -201,6 +212,7 @@ class JobFailureTriageCog(commands.Cog):
                 repo=session_repo,
                 registry=registry,
                 lounge_repo=lounge_repo,
+                backend_settings=backend_settings,
             )
         )
 

--- a/tests/test_job_failure_triage.py
+++ b/tests/test_job_failure_triage.py
@@ -354,6 +354,34 @@ class TestStartTriage:
         assert "429" in captured_config.prompt
 
     @pytest.mark.asyncio
+    async def test_uses_current_backend_from_components(self) -> None:
+        cog = _make_cog()
+        codex_runner = MagicMock()
+        cog.components.backend_factory = MagicMock()
+        cog.components.backend_factory.build.return_value = codex_runner
+        cog.components.backend_settings = MagicMock()
+        cog.components.backend_settings.current_backend = AsyncMock(return_value="codex")
+        cog.components.backend_settings.current_model = AsyncMock(return_value=None)
+        cog.components.backend_settings.current_effort = AsyncMock(return_value=None)
+        embed = _make_failure_embed()
+        msg = _make_message(embeds=[embed])
+        msg.create_thread.return_value.id = 1357
+
+        with patch(
+            "examples.ebibot.cogs.job_failure_triage.run_claude_with_config",
+            new_callable=AsyncMock,
+        ) as mock_run:
+            await cog._start_triage(msg, _extract_failure_info(embed))
+
+        cog.runner.clone.assert_not_called()
+        cog.components.backend_factory.build.assert_called_once_with(
+            backend="codex", model=None, thread_id=1357
+        )
+        run_config = mock_run.call_args[0][0]
+        assert run_config.runner is codex_runner
+        assert run_config.backend_settings is cog.components.backend_settings
+
+    @pytest.mark.asyncio
     async def test_skips_non_text_channel(self) -> None:
         cog = _make_cog()
         embed = _make_failure_embed()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -215,6 +215,51 @@ class TestSchedulerCogMasterLoop:
         run_config = mock_run.call_args[0][0]
         assert run_config.repo is None
 
+    async def test_run_task_uses_current_backend_from_settings(self, repo: TaskRepository) -> None:
+        """Scheduled tasks should follow the runtime global backend setting."""
+        import discord
+
+        base_runner = _make_runner()
+        codex_runner = MagicMock()
+        factory = MagicMock()
+        factory.build.return_value = codex_runner
+        settings = MagicMock()
+        settings.current_backend = AsyncMock(return_value="codex")
+        settings.current_model = AsyncMock(return_value=None)
+        settings.current_effort = AsyncMock(return_value="high")
+        cog = SchedulerCog(
+            _make_bot(),
+            base_runner,
+            repo=repo,
+            backend_factory=factory,
+            backend_settings=settings,
+        )
+
+        task_id = await repo.create(
+            name="codex-task", prompt="p", interval_seconds=60, channel_id=99
+        )
+        task = await repo.get(task_id)
+
+        mock_thread = AsyncMock(spec=discord.Thread)
+        mock_thread.id = 1234
+        mock_starter_msg = AsyncMock()
+        mock_starter_msg.create_thread = AsyncMock(return_value=mock_thread)
+        mock_channel = AsyncMock(spec=discord.TextChannel)
+        mock_channel.send = AsyncMock(return_value=mock_starter_msg)
+        cog.bot.get_channel = MagicMock(return_value=mock_channel)
+
+        with patch(
+            "claude_discord.cogs.scheduler.run_claude_with_config", new_callable=AsyncMock
+        ) as mock_run:
+            await cog._run_task(task)
+
+        base_runner.clone.assert_not_called()
+        factory.build.assert_called_once_with(backend="codex", model=None, thread_id=1234)
+        assert codex_runner.effort == "high"
+        run_config = mock_run.call_args[0][0]
+        assert run_config.runner is codex_runner
+        assert run_config.backend_settings is settings
+
     async def test_disabled_task_not_run(self, cog: SchedulerCog, repo: TaskRepository) -> None:
         """Disabled tasks should not fire even if overdue."""
         task_id = await repo.create(name="dis", prompt="p", interval_seconds=60, channel_id=1)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -63,6 +63,48 @@ async def test_setup_bridge_registers_scheduler_when_enabled(tmp_path: object) -
 
 
 @pytest.mark.asyncio
+async def test_setup_bridge_wires_backend_settings_into_components_and_scheduler(
+    tmp_path: object,
+) -> None:
+    """Headless cogs should receive the same backend resolver as chat commands."""
+    from claude_discord.backend_factory import BackendFactory
+
+    bot = _make_bot()
+    runner = _make_runner()
+    runner.model = "sonnet"
+    factory = BackendFactory(
+        claude_command="claude",
+        codex_command="codex",
+        permission_mode="acceptEdits",
+        working_dir=None,
+        timeout_seconds=300,
+        dangerously_skip_permissions=False,
+        allowed_tools=None,
+        append_system_prompt=None,
+        effort=None,
+    )
+
+    result = await setup_bridge(
+        bot,
+        runner,
+        session_db_path=str(tmp_path / "sessions.db"),  # type: ignore[operator]
+        task_db_path=str(tmp_path / "tasks.db"),  # type: ignore[operator]
+        enable_scheduler=True,
+        backend_factory=factory,
+    )
+
+    assert result.backend_factory is factory
+    assert result.backend_settings is not None
+    scheduler_cog = next(
+        call.args[0]
+        for call in bot.add_cog.call_args_list
+        if call.args[0].__class__.__name__ == "SchedulerCog"
+    )
+    assert scheduler_cog.backend_factory is factory
+    assert scheduler_cog.backend_settings is result.backend_settings
+
+
+@pytest.mark.asyncio
 async def test_setup_bridge_skips_scheduler_when_disabled(tmp_path: object) -> None:
     """setup_bridge should NOT register SchedulerCog when enable_scheduler=False."""
     bot = _make_bot()

--- a/tests/test_webhook_trigger.py
+++ b/tests/test_webhook_trigger.py
@@ -112,6 +112,41 @@ class TestWebhookFiltering:
             await cog.on_message(msg)
             mock_run.assert_not_called()
 
+
+class TestWebhookBackendResolution:
+    @pytest.mark.asyncio
+    async def test_execute_trigger_uses_current_backend_from_settings(
+        self,
+        bot: MagicMock,
+        runner: MagicMock,
+    ) -> None:
+        """Webhook-triggered automation should follow the runtime backend setting."""
+        codex_runner = MagicMock()
+        factory = MagicMock()
+        factory.build.return_value = codex_runner
+        settings = MagicMock()
+        settings.current_backend = AsyncMock(return_value="codex")
+        settings.current_model = AsyncMock(return_value=None)
+        settings.current_effort = AsyncMock(return_value=None)
+        cog = WebhookTriggerCog(
+            bot=bot,
+            runner=runner,
+            triggers={"🔄 docs-sync": WebhookTrigger(prompt="Sync docs")},
+            backend_factory=factory,
+            backend_settings=settings,
+        )
+        msg = _make_message()
+        msg.create_thread.return_value.id = 2468
+
+        with patch(_PATCH_RUN, new_callable=AsyncMock) as mock_run:
+            await cog._execute_trigger(msg, "🔄 docs-sync", cog.triggers["🔄 docs-sync"])
+
+        runner.clone.assert_not_called()
+        factory.build.assert_called_once_with(backend="codex", model=None, thread_id=2468)
+        run_config = mock_run.call_args[0][0]
+        assert run_config.runner is codex_runner
+        assert run_config.backend_settings is settings
+
     @pytest.mark.asyncio
     async def test_accepts_authorized_webhook(
         self,


### PR DESCRIPTION
## Summary
- add a shared headless runner resolver that uses BackendFactory and BackendSettings
- make SchedulerCog, WebhookTriggerCog, and EbiBot custom automation honor runtime backend selection
- pass backend settings into headless RunConfig calls and cover the behavior with regression tests

## Tests
- uv run ruff check claude_discord examples/ebibot/cogs tests/test_scheduler.py tests/test_webhook_trigger.py tests/test_job_failure_triage.py tests/test_setup.py
- uv run ruff format --check claude_discord examples/ebibot/cogs tests/test_scheduler.py tests/test_webhook_trigger.py tests/test_job_failure_triage.py tests/test_setup.py
- uv run pytest tests/test_scheduler.py tests/test_webhook_trigger.py tests/test_job_failure_triage.py tests/test_setup.py -q