### PR TITLE
fix: recover from missing Codex rollout history

### DIFF
--- a/claude_code_core/codex_runner.py
+++ b/claude_code_core/codex_runner.py
@@ -136,6 +136,7 @@ def parse_codex_line(line: str) -> StreamEvent | None:
 # result arrives. For atomic tools no result would ever come, so the timer would
 # accumulate forever — we synthesize a completion to close it immediately.
 _ATOMIC_ITEM_TYPES: frozenset[str] = frozenset({"file_changes"})
+_MISSING_ROLLOUT_PATTERN = re.compile(r"no rollout found for thread id", re.IGNORECASE)
 
 
 def _atomic_tool_completion(event: StreamEvent) -> StreamEvent | None:
@@ -155,6 +156,11 @@ def _atomic_tool_completion(event: StreamEvent) -> StreamEvent | None:
         tool_result_id=event.tool_use.tool_id,
         tool_result_content="",
     )
+
+
+def _is_missing_rollout_error(error: str | None) -> bool:
+    """Return True when Codex cannot resume because local rollout history is gone."""
+    return bool(error and _MISSING_ROLLOUT_PATTERN.search(error))
 
 
 class CodexRunner:
@@ -202,37 +208,60 @@ class CodexRunner:
         session_id: str | None = None,
     ) -> AsyncGenerator[StreamEvent, None]:
         """Run Codex CLI and yield stream events."""
-        args = self._build_args(prompt, session_id)
-        env = self._build_env()
-        cwd = self.working_dir or os.getcwd()
+        attempt_session_id = session_id
+        retried_without_resume = False
 
-        logger.info("Starting Codex CLI: %s (cwd=%s)", " ".join(args[:6]) + " ...", cwd)
+        while True:
+            args = self._build_args(prompt, attempt_session_id)
+            env = self._build_env()
+            cwd = self.working_dir or os.getcwd()
+            should_retry_without_resume = False
 
-        self._process = await asyncio.create_subprocess_exec(
-            *args,
-            stdin=asyncio.subprocess.DEVNULL,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=cwd,
-            env=env,
-            limit=10 * 1024 * 1024,
-        )
+            logger.info("Starting Codex CLI: %s (cwd=%s)", " ".join(args[:6]) + " ...", cwd)
 
-        logger.info("Codex CLI started: pid=%s", self._process.pid)
-
-        try:
-            async for event in self._read_stream():
-                yield event
-        except TimeoutError:
-            logger.warning("Codex CLI timed out after %ds", self.timeout_seconds)
-            yield StreamEvent(
-                raw={},
-                message_type=MessageType.RESULT,
-                is_complete=True,
-                error=f"Timed out after {self.timeout_seconds} seconds",
+            self._process = await asyncio.create_subprocess_exec(
+                *args,
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
+                env=env,
+                limit=10 * 1024 * 1024,
             )
-        finally:
-            await self._cleanup()
+
+            logger.info("Codex CLI started: pid=%s", self._process.pid)
+
+            try:
+                async for event in self._read_stream():
+                    if (
+                        attempt_session_id
+                        and not retried_without_resume
+                        and _is_missing_rollout_error(event.error)
+                    ):
+                        logger.warning(
+                            "Codex resume history for session %s is missing; "
+                            "starting a new session instead",
+                            attempt_session_id,
+                        )
+                        should_retry_without_resume = True
+                        retried_without_resume = True
+                        break
+                    yield event
+            except TimeoutError:
+                logger.warning("Codex CLI timed out after %ds", self.timeout_seconds)
+                yield StreamEvent(
+                    raw={},
+                    message_type=MessageType.RESULT,
+                    is_complete=True,
+                    error=f"Timed out after {self.timeout_seconds} seconds",
+                )
+            finally:
+                await self._cleanup()
+
+            if should_retry_without_resume:
+                attempt_session_id = None
+                continue
+            return
 
     def clone(
         self,
@@ -393,11 +422,14 @@ class CodexRunner:
                 self._process.returncode,
                 stderr_text[:200],
             )
+            error = f"CLI exited with code {self._process.returncode}"
+            if stderr_text:
+                error = f"{error}: {stderr_text[:1000]}"
             yield StreamEvent(
                 raw={},
                 message_type=MessageType.RESULT,
                 is_complete=True,
-                error=f"CLI exited with code {self._process.returncode}",
+                error=error,
             )
 
     async def _cleanup(self) -> None:

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -11,6 +11,44 @@ from claude_code_core.codex_runner import CodexRunner, parse_codex_line
 from claude_code_core.types import MessageType
 
 
+class _FakeStream:
+    def __init__(self, lines: list[bytes] | None = None, read_data: bytes = b"") -> None:
+        self._lines = list(lines or [])
+        self._read_data = read_data
+
+    async def readline(self) -> bytes:
+        if self._lines:
+            return self._lines.pop(0)
+        return b""
+
+    async def read(self) -> bytes:
+        return self._read_data
+
+
+class _FakeProcess:
+    def __init__(
+        self,
+        *,
+        stdout_lines: list[bytes] | None = None,
+        stderr: bytes = b"",
+        returncode: int = 0,
+        pid: int = 12345,
+    ) -> None:
+        self.stdout = _FakeStream(stdout_lines)
+        self.stderr = _FakeStream(read_data=stderr)
+        self.returncode = returncode
+        self.pid = pid
+
+    async def wait(self) -> int:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.returncode = -15
+
+    def kill(self) -> None:
+        self.returncode = -9
+
+
 class TestCodexRunnerIsBackend:
     """CodexRunner must satisfy the SessionBackend protocol."""
 
@@ -128,6 +166,78 @@ class TestCodexRunnerClone:
         runner = CodexRunner(command="codex", model="gpt-5.5", effort="high")
         cloned = runner.clone(effort="low")
         assert cloned.effort == "low"
+
+
+class TestCodexRunnerRun:
+    @pytest.mark.asyncio
+    async def test_resume_missing_rollout_falls_back_to_new_session(self, monkeypatch) -> None:
+        stale_session = "13f2eb43-93cf-4df6-86d0-a20c035cc26e"
+        started_line = json.dumps(
+            {"type": "thread.started", "thread_id": "019f-new-session"}
+        ).encode()
+        completed_line = json.dumps({"type": "turn.completed", "usage": {}}).encode()
+        processes = [
+            _FakeProcess(
+                stderr=(
+                    b"Error: thread/resume: thread/resume failed: "
+                    b"no rollout found for thread id 13f2eb43-93cf-4df6-86d0-a20c035cc26e"
+                ),
+                returncode=1,
+                pid=100,
+            ),
+            _FakeProcess(
+                stdout_lines=[started_line + b"\n", completed_line + b"\n"],
+                returncode=0,
+                pid=101,
+            ),
+        ]
+        calls: list[tuple[str, ...]] = []
+
+        async def fake_create_subprocess_exec(*args, **kwargs):
+            calls.append(args)
+            return processes.pop(0)
+
+        monkeypatch.setattr(
+            "claude_code_core.codex_runner.asyncio.create_subprocess_exec",
+            fake_create_subprocess_exec,
+        )
+        runner = CodexRunner(command="codex", working_dir="/work")
+
+        events = [event async for event in runner.run("hello", session_id=stale_session)]
+
+        assert len(calls) == 2
+        assert calls[0][:3] == ("codex", "exec", "resume")
+        assert stale_session in calls[0]
+        assert "resume" not in calls[1]
+        assert "--cd" in calls[1]
+        assert "/work" in calls[1]
+        assert [event.error for event in events if event.error] == []
+        assert events[0].session_id == "019f-new-session"
+
+    @pytest.mark.asyncio
+    async def test_non_rollout_resume_error_is_reported(self, monkeypatch) -> None:
+        process = _FakeProcess(stderr=b"permission denied", returncode=1)
+
+        async def fake_create_subprocess_exec(*args, **kwargs):
+            return process
+
+        monkeypatch.setattr(
+            "claude_code_core.codex_runner.asyncio.create_subprocess_exec",
+            fake_create_subprocess_exec,
+        )
+        runner = CodexRunner(command="codex")
+
+        events = [
+            event
+            async for event in runner.run(
+                "hello",
+                session_id="019e29a0-d5b0-71f0-bdc0-46f09a06fdaf",
+            )
+        ]
+
+        assert len(events) == 1
+        assert events[0].error is not None
+        assert "CLI exited with code 1" in events[0].error
 
 
 class TestParseCodexLine:

--- a/tests/test_run_helper.py
+++ b/tests/test_run_helper.py
@@ -1435,6 +1435,7 @@ class TestCompactRerun:
             prompt="check X",
             session_id="sess-306",
             registry=registry,
+            chat_only=True,
         )
         await run_claude_with_config(config)
 


### PR DESCRIPTION
## Summary

- Detect Codex `no rollout found for thread id` resume failures
- Retry once without `resume` so the thread can start a fresh Codex session
- Preserve stderr details for non-rollout CLI failures
- Add regression coverage for the fallback and normal error reporting

## Verification

- `uv run pytest tests/test_codex_runner.py::TestCodexRunnerRun -q`
- `uv run pytest tests/test_run_helper.py::TestCompactRerun::test_compact_interrupts_cloned_runner_not_original -q`
- `uv run ruff check claude_code_core/codex_runner.py tests/test_codex_runner.py tests/test_run_helper.py`
- `git diff --check`

Closes #462