### PR TITLE
fix: normalize notify thread names

### DIFF
--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -57,6 +57,7 @@ _MAX_INGEST_UNZIP_MEMBERS = 5000
 # single request from buffering an unbounded amount of base64 in memory.
 _MAX_SPAWN_ATTACHMENTS = 10
 _MAX_SPAWN_TOTAL_BYTES = 25 * 1024 * 1024
+_MAX_DISCORD_THREAD_NAME_LENGTH = 100
 
 # Max accepted request body. aiohttp defaults to 1 MiB, which 413s any real
 # ingest (a full conversation thread plus base64 attachments). Base64 inflates
@@ -133,6 +134,16 @@ def _sanitize_log(value: object) -> str:
     attacks where an attacker embeds fake log entries in a single field.
     """
     return re.sub(r"[\r\n]", " ", str(value))
+
+
+def _normalize_thread_name(value: object) -> str | None:
+    """Return a Discord-safe thread name, or None when no usable name was supplied."""
+    if value is None:
+        return None
+    name = str(value).strip()
+    if not name:
+        return None
+    return name[:_MAX_DISCORD_THREAD_NAME_LENGTH]
 
 
 class ApiServer:
@@ -372,7 +383,7 @@ class ApiServer:
                 return poll_result
             poll_obj = poll_result
 
-        thread_name = data.get("thread_name")
+        thread_name = _normalize_thread_name(data.get("thread_name"))
         fmt = data.get("format", "text" if thread_name else "embed")
 
         # Determine target: create a new thread or send directly to channel

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -372,6 +372,34 @@ class TestNotifyThread:
         assert data["thread_id"] == "111222333"
         assert data["thread_name"] == "PR Review"
 
+    @pytest.mark.asyncio
+    async def test_notify_blank_thread_name_sends_to_channel(
+        self, thread_client: TestClient, bot_with_thread: MagicMock
+    ) -> None:
+        """Whitespace-only thread_name is treated as absent, avoiding Discord 400s."""
+        channel = bot_with_thread.get_channel.return_value
+        resp = await thread_client.post(
+            "/api/notify",
+            json={"message": "No thread please", "thread_name": "   "},
+        )
+        assert resp.status == 200
+        channel.create_thread.assert_not_called()
+        channel.send.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_notify_thread_name_is_trimmed_and_limited_to_discord_max(
+        self, thread_client: TestClient, bot_with_thread: MagicMock
+    ) -> None:
+        """Thread names are normalized before passing them to Discord."""
+        channel = bot_with_thread.get_channel.return_value
+        raw_name = f"  {'a' * 120}  "
+        resp = await thread_client.post(
+            "/api/notify",
+            json={"message": "Long title", "thread_name": raw_name},
+        )
+        assert resp.status == 200
+        channel.create_thread.assert_called_once_with(name="a" * 100)
+
 
 class TestSchedule:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Normalize `/api/notify` `thread_name` values before creating Discord threads.
- Treat whitespace-only names as absent, so the notification is sent to the channel instead of causing a Discord 400.
- Trim names and cap them at Discord's 100-character thread name limit.

## Log finding
- `logs/discord-bot.log` had one error in the last 12 hours: `2026-07-03 03:01:07 [ERROR] aiohttp.server` from `POST /api/notify`.
- Root cause: Discord rejected `create_thread(name=...)` with `Invalid Form Body: In name: Must be between 1 and 100 in length`.
- Similar `/api/notify` errors were present around 03:00 on 2026-06-30, 2026-07-01, and 2026-07-02, so this is recurring.

## Tests
- `uv run pytest tests/test_api_server.py::TestNotifyThread -q`
- `uv run ruff check claude_discord tests/test_api_server.py`
- `uv run ruff format --check claude_discord tests/test_api_server.py`
- `uv run pytest tests/test_api_server.py -q`
- `timeout 900 uv run pytest tests/ -x -q` timed out after reaching 63% with no failure output.
