### PR TITLE
fix: ignore missing Discord thread during response send

### DIFF
--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -624,10 +624,14 @@ class EventProcessor:
                 # No streamer content — post the full text block directly.
                 # (Current CLI delivers each text block complete, so this is the
                 # normal path; capture the last message URL for inbox linking.)
-                for chunk in chunk_message(event.text):
-                    sent = await self._config.thread.send(chunk)
-                    if sent is not None:
-                        self._state.last_assistant_url = sent.jump_url
+                try:
+                    for chunk in chunk_message(event.text):
+                        sent = await self._config.thread.send(chunk)
+                        if sent is not None:
+                            self._state.last_assistant_url = sent.jump_url
+                except Exception:
+                    logger.warning("Failed to send assistant text", exc_info=True)
+                    return
             self._state.partial_text = ""
             self._state.accumulated_text = event.text
             self._assistant_text_sent = True

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -565,6 +565,19 @@ class TestConnectionErrorResilience:
         assert "t1" not in p._state.active_timers
 
     @pytest.mark.asyncio
+    async def test_assistant_text_send_failure_does_not_raise(
+        self, thread: MagicMock, runner: MagicMock
+    ) -> None:
+        """If the thread disappears, assistant text delivery should not crash the session."""
+        thread.send.side_effect = discord.NotFound(MagicMock(), "Unknown Channel")
+        config = _make_config(thread, runner)
+        p = EventProcessor(config)
+
+        await p.process(StreamEvent(message_type=MessageType.ASSISTANT, text="Hello"))
+
+        assert p.assistant_text_sent is False
+
+    @pytest.mark.asyncio
     async def test_tool_result_edit_failure_does_not_raise(
         self, thread: MagicMock, runner: MagicMock
     ) -> None:


### PR DESCRIPTION
## Summary
- Catch Discord/API send failures when posting assistant text directly to a thread
- Log the failure as a warning and stop processing that text event instead of surfacing an unexpected session error
- Add regression coverage for a deleted/missing Discord thread returning `NotFound`

## Verification
- `uv run pytest tests/test_event_processor.py::TestConnectionErrorResilience::test_assistant_text_send_failure_does_not_raise -q`
- `uv run pytest tests/test_event_processor.py -q`
- `uv run ruff check claude_discord/cogs/event_processor.py tests/test_event_processor.py`
- `uv run ruff format --check claude_discord/cogs/event_processor.py tests/test_event_processor.py`

## Security
- No subprocess, CLI argument, environment, or user-input validation paths changed.
- Ran the project security-audit quick scan; existing `subprocess.run` uses are unchanged and outside this patch.
