### PR TITLE
Add gpt-5.6-sol to Codex model suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Visual cues so you never forget which one you're talking to:
 
 - **Claude sessions** open with a blurple embed titled "🤖 Claude Code session started".
 - **Codex sessions** open with an OpenAI-teal embed titled "🌀 OpenAI Codex session started".
-- The completion embed prepends a `🧠 Claude · sonnet` / `🧠 Codex · gpt-5.5` chip alongside the usual duration / cost / token / context metrics. (When a backend's model is left at the CLI default, the chip shows just the backend name.)
+- The completion embed prepends a `🧠 Claude · sonnet` / `🧠 Codex · gpt-5.6-sol` chip alongside the usual duration / cost / token / context metrics. (When a backend's model is left at the CLI default, the chip shows just the backend name.)
 
 Concrete example:
 

--- a/claude_discord/backend_factory.py
+++ b/claude_discord/backend_factory.py
@@ -24,8 +24,8 @@ logger = logging.getLogger(__name__)
 #
 # ``codex`` is intentionally ``None``: when no model is configured we omit
 # ``--model`` entirely so the Codex CLI uses its own default (the ``model``
-# key in ~/.codex/config.toml, currently gpt-5.5). Hard-coding a version here
-# only goes stale — the console default already moved from gpt-5.4 to gpt-5.5.
+# key in ~/.codex/config.toml, currently gpt-5.6-sol). Hard-coding a version
+# here only goes stale as the Codex console default moves.
 DEFAULT_MODEL: dict[str, str | None] = {"claude": "sonnet", "codex": None}
 DEFAULT_COMMAND = {"claude": "claude", "codex": "codex"}
 

--- a/claude_discord/cogs/backend_command.py
+++ b/claude_discord/cogs/backend_command.py
@@ -67,9 +67,9 @@ SUGGESTED_MODELS: dict[str, list[tuple[str, str]]] = {
         ("fable", "Fable 5 (state-of-the-art, token-efficient)"),
     ],
     "codex": [
-        ("gpt-5.5", "GPT-5.5 (current Codex console default)"),
+        ("gpt-5.6-sol", "GPT-5.6 SOL (current Codex console default)"),
+        ("gpt-5.5", "GPT-5.5 (previous default)"),
         ("gpt-5.5-codex", "GPT-5.5 Codex"),
-        ("gpt-5.4", "GPT-5.4 (previous default)"),
         ("o4-mini", "o4-mini (fast)"),
     ],
 }
@@ -277,7 +277,7 @@ class BackendCommandCog(commands.Cog):
     )
     @app_commands.autocomplete(name=_model_name_autocomplete)
     @app_commands.describe(
-        name="Model id (e.g. sonnet, opus, gpt-5.4, o4-mini). Omit to show current.",
+        name="Model id (e.g. sonnet, opus, gpt-5.6-sol, o4-mini). Omit to show current.",
         scope=(
             "thread: only this thread; global: server-wide. "
             "Default: thread when in thread, else global."

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -309,9 +309,9 @@ class ClaudeChatCog(commands.Cog):
         #    Honoured only when the current backend is claude. Passing a
         #    Claude model id to Codex would cause `codex exec` to fail
         #    with an unknown model error.
-        # 3. Env-derived per-backend default, then the factory's hard-coded
-        #    default (sonnet for claude, gpt-5.4 for codex). Returned as
-        #    None here so factory.build() picks the right one.
+        # 3. Env-derived per-backend default, then the factory's backend default
+        #    (sonnet for claude, CLI default for codex). Returned as None here
+        #    so factory.build() picks the right one.
         explicit_model = await self._backend_settings.explicit_model(backend, thread_id)
         model: str | None
         if explicit_model:

--- a/claude_discord/main.py
+++ b/claude_discord/main.py
@@ -47,7 +47,7 @@ def load_config() -> dict[str, str]:
     backend = os.getenv("CCDB_BACKEND", "claude")
     # Default model is backend-specific: Claude needs an explicit alias
     # ("sonnet"), but Codex defers to its own config.toml default when left
-    # empty (so we never pin a stale version like gpt-5.4).
+    # empty (so we never pin a stale Codex model version).
     default_model = "" if backend == "codex" else "sonnet"
 
     return {

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -179,7 +179,7 @@ ccdb 3.0 では、Bot を再起動せずにどの AI が次のセッションを
 
 - **Claude セッション** は "🤖 Claude Code session started" というタイトルのブルーパープル embed で開始。
 - **Codex セッション** は "🌀 OpenAI Codex session started" というタイトルの OpenAI ティール embed で開始。
-- 完了 embed には通常の実行時間 / コスト / トークン / コンテキストメトリクスと並んで `🧠 Claude · sonnet` / `🧠 Codex · gpt-5.4` チップが表示されます。
+- 完了 embed には通常の実行時間 / コスト / トークン / コンテキストメトリクスと並んで `🧠 Claude · sonnet` / `🧠 Codex · gpt-5.6-sol` チップが表示されます。
 
 使用例:
 

--- a/tests/test_model_command.py
+++ b/tests/test_model_command.py
@@ -102,6 +102,16 @@ class TestModelAutocomplete:
         # No Claude models leaked in.
         assert "sonnet" not in values
 
+    async def test_codex_backend_suggests_latest_codex_model_first(self) -> None:
+        settings = await _settings()
+        await settings.set_backend("codex")
+        cog = _make_cog(settings)
+        interaction = _channel_interaction()
+
+        choices = await cog._model_name_autocomplete(interaction, "")
+
+        assert choices[0].value == "gpt-5.6-sol"
+
     async def test_filters_by_current_substring(self) -> None:
         settings = await _settings()
         cog = _make_cog(settings)


### PR DESCRIPTION
## Summary
- add `gpt-5.6-sol` as the first Codex `/model` autocomplete suggestion
- mark `gpt-5.5` as the previous Codex default and refresh model examples/docs
- add a regression test that keeps the latest Codex suggestion first

## Verification
- `uv run ruff check claude_discord tests/test_model_command.py`
- `uv run ruff format --check claude_discord tests/test_model_command.py`
- `git diff --check`
- `uv run pytest tests/test_model_command.py tests/test_backend_factory_codex_defaults.py tests/test_build_runner_for_thread.py tests/test_codex_runner.py tests/test_main_backend.py -q`