### PR TITLE
fix: send Codex prompts via stdin on current main

### DIFF
--- a/claude_code_core/codex_runner.py
+++ b/claude_code_core/codex_runner.py
@@ -221,7 +221,7 @@ class CodexRunner:
 
             self._process = await asyncio.create_subprocess_exec(
                 *args,
-                stdin=asyncio.subprocess.DEVNULL,
+                stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=cwd,
@@ -230,6 +230,9 @@ class CodexRunner:
             )
 
             logger.info("Codex CLI started: pid=%s", self._process.pid)
+
+            if self._process.stdin is not None:
+                await self._send_prompt(prompt)
 
             try:
                 async for event in self._read_stream():
@@ -315,6 +318,26 @@ class CodexRunner:
         """Codex CLI does not support stdin injection; this is a no-op."""
         logger.debug("inject_tool_result called on CodexRunner (no-op): %s", request_id)
 
+    async def _send_prompt(self, prompt: str) -> None:
+        """Write the initial prompt to stdin and close it.
+
+        ``codex exec -`` and ``codex exec resume <session_id> -`` read the
+        prompt from stdin. Keeping the prompt out of argv avoids OS E2BIG /
+        ``Argument list too long`` failures for large Discord attachments.
+        """
+        assert self._process is not None and self._process.stdin is not None
+        try:
+            self._process.stdin.write(prompt.encode())
+            await self._process.stdin.drain()
+            self._process.stdin.close()
+            wait_closed = getattr(self._process.stdin, "wait_closed", None)
+            if wait_closed is not None:
+                await wait_closed()
+        except (BrokenPipeError, ConnectionResetError):
+            logger.debug("Codex stdin closed before prompt write completed", exc_info=True)
+        except Exception:
+            logger.warning("_send_prompt: failed to write to stdin", exc_info=True)
+
     def _build_args(self, prompt: str, session_id: str | None) -> list[str]:
         """Build command-line arguments for codex CLI.
 
@@ -322,8 +345,10 @@ class CodexRunner:
             codex exec [OPTIONS] [PROMPT]
             codex exec resume [OPTIONS] [SESSION_ID] [PROMPT]
 
-        Both subcommands accept --json and --model. The resume positional
-        args come AFTER any flags, with SESSION_ID before PROMPT.
+        Both subcommands accept --json and --model. We pass "-" as the prompt
+        positional so Codex reads the actual prompt from stdin instead of argv.
+        The resume positional args come AFTER any flags, with SESSION_ID before
+        the stdin marker.
         """
         # Always under the `exec` subcommand. `resume` is its sub-subcommand.
         args = [self.command, "exec"]
@@ -352,10 +377,10 @@ class CodexRunner:
         if self.working_dir and not session_id:
             args.extend(["--cd", self.working_dir])
 
-        # Positional args come last. For resume: SESSION_ID then PROMPT.
+        # Positional args come last. For resume: SESSION_ID then stdin marker.
         if session_id:
             args.append(session_id)
-        args.append(prompt)
+        args.append("-")
         return args
 
     _STRIPPED_ENV_KEYS = frozenset(

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -91,10 +92,18 @@ class TestCodexRunnerBuildArgs:
         assert "--cd" in args or "-C" in args
         assert "/tmp/work" in args
 
-    def test_prompt_is_last_arg(self) -> None:
+    def test_prompt_is_not_in_args(self) -> None:
         runner = CodexRunner(command="codex", model="o4-mini")
         args = runner._build_args("hello world", session_id=None)
-        assert args[-1] == "hello world"
+        assert "hello world" not in args
+        assert args[-1] == "-"
+
+    def test_large_prompt_is_not_in_args(self) -> None:
+        runner = CodexRunner(command="codex", model="o4-mini")
+        large_prompt = "x" * 200_000
+        args = runner._build_args(large_prompt, session_id=None)
+        assert large_prompt not in args
+        assert args[-1] == "-"
 
     def test_session_id_validation(self) -> None:
         runner = CodexRunner(command="codex", model="o4-mini")
@@ -482,23 +491,26 @@ class TestCodexRunnerArgvStructure:
         assert "--cd" in args
         assert "/work" in args
 
-    def test_resume_session_id_before_prompt(self) -> None:
+    def test_resume_session_id_before_stdin_marker(self) -> None:
         sid = "019e29a0-d5b0-71f0-bdc0-46f09a06fdaf"
         runner = CodexRunner(command="codex", model="gpt-5.4")
         args = runner._build_args("hello-prompt", session_id=sid)
-        # SESSION_ID must come BEFORE PROMPT in `codex exec resume`.
-        assert args.index(sid) < args.index("hello-prompt"), (
-            "SESSION_ID must precede PROMPT in codex exec resume"
+        # SESSION_ID must come BEFORE the stdin marker in `codex exec resume`.
+        assert "hello-prompt" not in args
+        assert args.index(sid) < args.index("-"), (
+            "SESSION_ID must precede stdin marker in codex exec resume"
         )
 
-    def test_prompt_is_always_last(self) -> None:
+    def test_stdin_marker_is_always_last(self) -> None:
         runner = CodexRunner(command="codex", model="gpt-5.4")
         # New session
         args = runner._build_args("the-prompt", session_id=None)
-        assert args[-1] == "the-prompt"
+        assert "the-prompt" not in args
+        assert args[-1] == "-"
         # Resume
         args = runner._build_args("the-prompt", session_id="019e29a0-d5b0-71f0-bdc0-46f09a06fdaf")
-        assert args[-1] == "the-prompt"
+        assert "the-prompt" not in args
+        assert args[-1] == "-"
 
     def test_dangerously_bypass_flag_for_resume(self) -> None:
         sid = "019e29a0-d5b0-71f0-bdc0-46f09a06fdaf"
@@ -523,3 +535,53 @@ class TestCodexRunnerArgvStructure:
             assert args.index("resume") == 2, (
                 f"resume must follow exec at index 2, got index {args.index('resume')}"
             )
+
+
+class TestCodexRunnerStdin:
+    """Prompt delivery tests for CodexRunner.
+
+    Codex CLI reads instructions from stdin when the prompt positional is "-".
+    This keeps large Discord attachment prompts out of argv and avoids E2BIG.
+    """
+
+    @pytest.mark.asyncio
+    async def test_run_writes_prompt_to_stdin(self) -> None:
+        import asyncio as _asyncio
+
+        runner = CodexRunner(command="codex")
+        large_prompt = "x" * 200_000
+
+        written: list[bytes] = []
+
+        def capture_write(data: bytes) -> None:
+            written.append(data)
+
+        mock_stdin = MagicMock()
+        mock_stdin.write = capture_write
+        mock_stdin.drain = AsyncMock()
+        mock_stdin.close = MagicMock()
+        mock_stdin.wait_closed = AsyncMock()
+
+        mock_process = AsyncMock()
+        mock_process.pid = 42
+        mock_process.returncode = None
+        mock_process.stdout = AsyncMock()
+        mock_process.stdout.readline = AsyncMock(return_value=b"")
+        mock_process.stderr = AsyncMock()
+        mock_process.stderr.read = AsyncMock(return_value=b"")
+        mock_process.stdin = mock_stdin
+        mock_process.wait = AsyncMock(return_value=0)
+
+        with (
+            patch("asyncio.create_subprocess_exec", return_value=mock_process) as mock_exec,
+            patch.object(runner, "_cleanup", new_callable=AsyncMock),
+        ):
+            _ = [event async for event in runner.run(large_prompt)]
+
+        call_args = mock_exec.call_args.args
+        call_kwargs = mock_exec.call_args.kwargs
+        assert large_prompt not in call_args
+        assert call_args[-1] == "-"
+        assert call_kwargs["stdin"] == _asyncio.subprocess.PIPE
+        assert written == [large_prompt.encode()]
+        mock_stdin.close.assert_called_once()

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -37,6 +37,9 @@ class _FakeProcess:
     ) -> None:
         self.stdout = _FakeStream(stdout_lines)
         self.stderr = _FakeStream(read_data=stderr)
+        self.stdin = MagicMock()
+        self.stdin.drain = AsyncMock()
+        self.stdin.wait_closed = AsyncMock()
         self.returncode = returncode
         self.pid = pid
 


### PR DESCRIPTION
## Summary
- refreshes #460 onto the current `main`
- sends new and resumed Codex prompts through stdin using the `-` marker
- preserves the newer missing-rollout fallback: both the resume attempt and fallback new session receive the prompt through stdin
- keeps large Discord attachment prompts out of argv to avoid `E2BIG`

## Validation
- `uv run ruff check claude_code_core claude_discord tests`
- `uv run ruff format --check claude_code_core claude_discord tests`
- `uv run pytest tests/test_codex_runner.py -q` — 45 passed
- security audit completed for subprocess args, session ID validation, environment stripping, and prompt handling

Supersedes #460, whose branch conflicts with changes merged after it was opened.