### PR TITLE
fix: tolerate deleted Discord threads during completion

### DIFF
--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -266,6 +266,17 @@ class EventProcessor:
         """Shorthand for the chat_only flag on the config."""
         return self._config.chat_only
 
+    async def _send_thread_message(self, *args: object, **kwargs: object) -> discord.Message | None:
+        """Send a Discord message, treating a deleted thread as non-fatal."""
+        try:
+            return await self._config.thread.send(*args, **kwargs)
+        except discord.NotFound:
+            logger.info(
+                "Discord thread %d disappeared before completion delivery",
+                self._config.thread.id,
+            )
+            return None
+
     async def _on_system(self, event: StreamEvent) -> None:
         """Handle SYSTEM events — capture session_id, post start embed, compact notification."""
         # Context compaction notification (skip display in chat_only mode)
@@ -486,7 +497,7 @@ class EventProcessor:
             # error field, not a raised exception). Capture it so result_sink
             # consumers report a real error instead of an empty "done".
             self._final_error = event.error
-            await self._config.thread.send(embed=_make_error_embed(event.error))
+            await self._send_thread_message(embed=_make_error_embed(event.error))
             if self._config.status:
                 await self._config.status.set_error()
         else:
@@ -495,7 +506,7 @@ class EventProcessor:
             if response_text and not self._assistant_text_sent:
                 last_sent: discord.Message | None = None
                 for chunk in chunk_message(response_text):
-                    last_sent = await self._config.thread.send(chunk)
+                    last_sent = await self._send_thread_message(chunk)
                 if last_sent is not None:
                     last_assistant_url = last_sent.jump_url
                 last_assistant_text = response_text
@@ -517,7 +528,7 @@ class EventProcessor:
                 if self._config.status:
                     await self._config.status.set_done()
             else:
-                await self._config.thread.send(
+                await self._send_thread_message(
                     embed=session_complete_embed(
                         event.cost_usd,
                         event.duration_ms,

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -500,6 +500,31 @@ class TestOnComplete:
         assert len(embed_sends) >= 1
 
     @pytest.mark.asyncio
+    async def test_complete_send_not_found_does_not_raise(
+        self, thread: MagicMock, runner: MagicMock
+    ) -> None:
+        """If the Discord thread disappears, completion delivery is non-fatal."""
+        thread.send.side_effect = discord.NotFound(MagicMock(), "Unknown Channel")
+        config = _make_config(thread, runner)
+        p = EventProcessor(config)
+
+        await p.process(_make_result_event(session_id="s1"))
+
+        assert p.session_id == "s1"
+
+    @pytest.mark.asyncio
+    async def test_complete_send_unexpected_error_still_raises(
+        self, thread: MagicMock, runner: MagicMock
+    ) -> None:
+        """Unexpected delivery failures must not be hidden as missing channels."""
+        thread.send.side_effect = RuntimeError("unexpected delivery failure")
+        config = _make_config(thread, runner)
+        p = EventProcessor(config)
+
+        with pytest.raises(RuntimeError, match="unexpected delivery failure"):
+            await p.process(_make_result_event(session_id="s1"))
+
+    @pytest.mark.asyncio
     async def test_error_sends_error_embed(self, thread: MagicMock, runner: MagicMock) -> None:
         config = _make_config(thread, runner)
         p = EventProcessor(config)


### PR DESCRIPTION
## Summary

- treat `discord.NotFound` as a non-fatal delivery failure when a thread disappears during completion
- preserve unexpected exceptions instead of hiding real delivery failures
- apply the same behavior to final text, error embeds, and completion embeds
- keep session cleanup and result persistence running after the thread is deleted

## Validation

- `tests/test_event_processor.py`: 80 passed
- ruff check and format check passed
- ccdb subprocess/security quick scan passed; this change adds no subprocess or secret handling
- the broader local suite reached 1,062 passed before the known long-running teardown; its only failure was an inherited `CCDB_API_URL` environment variable and passes when that variable is unset, matching CI isolation

Closes #468