### PR TITLE
fix: normalize JSON-encoded AskUserQuestion payloads (#458)

### DIFF
--- a/claude_code_core/parser.py
+++ b/claude_code_core/parser.py
@@ -310,23 +310,44 @@ def _parse_rate_limit_event(data: dict[str, Any], event: StreamEvent) -> None:
 
 
 def _parse_ask_questions(tool_input: dict[str, Any]) -> list[AskQuestion]:
-    """Parse AskUserQuestion tool input into a list of AskQuestion objects."""
-    questions_raw = tool_input.get("questions", [])
+    """Parse AskUserQuestion input, including JSON-encoded nested values."""
+
+    def _as_list(value: Any) -> list[Any]:
+        if isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except (TypeError, ValueError):
+                return []
+        return value if isinstance(value, list) else []
+
+    def _as_dict(value: Any) -> dict[str, Any] | None:
+        if isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except (TypeError, ValueError):
+                return None
+        return value if isinstance(value, dict) else None
+
     result: list[AskQuestion] = []
-    for q in questions_raw:
+    for raw_question in _as_list(tool_input.get("questions", [])):
+        question = _as_dict(raw_question)
+        if question is None:
+            continue
         options = [
             AskOption(
-                label=o.get("label", ""),
-                description=o.get("description", ""),
+                label=option.get("label", ""),
+                description=option.get("description", ""),
             )
-            for o in q.get("options", [])
-            if o.get("label")
+            for option in (
+                _as_dict(raw_option) for raw_option in _as_list(question.get("options", []))
+            )
+            if option is not None and option.get("label")
         ]
         result.append(
             AskQuestion(
-                question=q.get("question", ""),
-                header=q.get("header", ""),
-                multi_select=bool(q.get("multiSelect", False)),
+                question=question.get("question", ""),
+                header=question.get("header", ""),
+                multi_select=bool(question.get("multiSelect", False)),
                 options=options,
             )
         )

--- a/tests/test_ask_feature.py
+++ b/tests/test_ask_feature.py
@@ -206,6 +206,64 @@ class TestParserAskUserQuestion:
         assert questions[0].question == "Q1?"
         assert questions[1].question == "Q2?"
 
+    def test_questions_as_json_string_is_decoded(self) -> None:
+        tool_input = {
+            "questions": json.dumps(
+                [{"question": "Q?", "header": "H", "options": [{"label": "A"}]}]
+            )
+        }
+        questions = _parse_ask_questions(tool_input)
+        assert len(questions) == 1
+        assert questions[0].question == "Q?"
+        assert questions[0].header == "H"
+        assert questions[0].options[0].label == "A"
+
+    def test_question_element_as_json_string_is_decoded(self) -> None:
+        tool_input = {"questions": [json.dumps({"question": "Q?", "options": [{"label": "A"}]})]}
+        questions = _parse_ask_questions(tool_input)
+        assert len(questions) == 1
+        assert questions[0].question == "Q?"
+        assert questions[0].options[0].label == "A"
+
+    def test_options_as_json_string_is_decoded(self) -> None:
+        options = json.dumps([{"label": "A"}, {"label": "B"}])
+        questions = _parse_ask_questions({"questions": [{"question": "Q?", "options": options}]})
+        assert len(questions[0].options) == 2
+
+    def test_non_dict_questions_are_skipped(self) -> None:
+        tool_input = {"questions": ["just a string", 42, None, {"question": "Real?"}]}
+        questions = _parse_ask_questions(tool_input)
+        assert len(questions) == 1
+        assert questions[0].question == "Real?"
+
+    def test_non_json_string_questions_returns_empty(self) -> None:
+        assert _parse_ask_questions({"questions": "totally not json"}) == []
+
+    def test_parse_line_with_string_questions_does_not_raise(self) -> None:
+        line = json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "tool-ask",
+                            "name": "AskUserQuestion",
+                            "input": {
+                                "questions": json.dumps(
+                                    [{"question": "Pick?", "options": [{"label": "Red"}]}]
+                                )
+                            },
+                        }
+                    ]
+                },
+            }
+        )
+        event = parse_line(line)
+        assert event is not None
+        assert event.ask_questions[0].question == "Pick?"
+        assert event.ask_questions[0].options[0].label == "Red"
+
 
 # ---------------------------------------------------------------------------
 # embeds


### PR DESCRIPTION
## Summary

- Decode JSON-encoded `questions`, question entries, and `options` before parsing
- Skip malformed values instead of crashing the stream-json session
- Add six regression tests, including the end-to-end `parse_line` path
- Based on the reproducer and proposed approach from @cKreymborg

## Test plan

- [x] Confirm all six regression tests fail on current main
- [x] `ruff check` and `ruff format --check` pass
- [x] Full suite: 1615 passed, coverage 79.94%
- [x] Public API import smoke test passes

Closes #458