### PR TITLE
fix: recover image-heavy Codex sessions after resume failure (#475)

### DIFF
--- a/claude_code_core/codex_runner.py
+++ b/claude_code_core/codex_runner.py
@@ -13,6 +13,7 @@ import os
 import re
 import signal
 from collections.abc import AsyncGenerator
+from pathlib import Path
 from urllib.parse import urlparse
 
 from .types import (
@@ -137,6 +138,14 @@ def parse_codex_line(line: str) -> StreamEvent | None:
 # accumulate forever — we synthesize a completion to close it immediately.
 _ATOMIC_ITEM_TYPES: frozenset[str] = frozenset({"file_changes"})
 _MISSING_ROLLOUT_PATTERN = re.compile(r"no rollout found for thread id", re.IGNORECASE)
+_RESUME_STREAM_DISCONNECT_PATTERN = re.compile(
+    r"stream disconnected before completion:.*"
+    r"websocket closed by server before response\.completed",
+    re.IGNORECASE,
+)
+_RECOVERY_MESSAGE_LIMIT = 12
+_RECOVERY_MESSAGE_CHARS = 4_000
+_RECOVERY_TRANSCRIPT_CHARS = 24_000
 
 
 def _atomic_tool_completion(event: StreamEvent) -> StreamEvent | None:
@@ -161,6 +170,82 @@ def _atomic_tool_completion(event: StreamEvent) -> StreamEvent | None:
 def _is_missing_rollout_error(error: str | None) -> bool:
     """Return True when Codex cannot resume because local rollout history is gone."""
     return bool(error and _MISSING_ROLLOUT_PATTERN.search(error))
+
+
+def _is_resume_stream_disconnect(error: str | None) -> bool:
+    """Return True for the persistent Codex Responses WebSocket failure."""
+    return bool(error and _RESUME_STREAM_DISCONNECT_PATTERN.search(error))
+
+
+def _find_rollout(session_id: str, env: dict[str, str]) -> Path | None:
+    """Find Codex's local rollout for a validated session ID."""
+    codex_home = Path(env.get("CODEX_HOME") or Path.home() / ".codex")
+    sessions_dir = codex_home / "sessions"
+    if not sessions_dir.is_dir():
+        return None
+    return next(sessions_dir.rglob(f"*-{session_id}.jsonl"), None)
+
+
+def _text_transcript_from_rollout(session_id: str, env: dict[str, str]) -> str:
+    """Extract bounded user/assistant text without loading image/tool payloads.
+
+    Failed resume attempts append user messages without a matching assistant
+    response. Trim that incomplete tail because the current prompt is included
+    separately in the recovery request.
+    """
+    rollout = _find_rollout(session_id, env)
+    if rollout is None:
+        return ""
+
+    messages: list[tuple[str, str]] = []
+    last_assistant_index: int | None = None
+    try:
+        with rollout.open(encoding="utf-8") as stream:
+            for line in stream:
+                # Image/tool records can be several megabytes. Reject them
+                # before JSON parsing and retain only lightweight event_msg text.
+                if '"event_msg"' not in line:
+                    continue
+                if '"user_message"' not in line and '"agent_message"' not in line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                payload = record.get("payload", {})
+                event_type = payload.get("type")
+                message = payload.get("message")
+                if event_type not in {"user_message", "agent_message"} or not isinstance(
+                    message, str
+                ):
+                    continue
+                role = "User" if event_type == "user_message" else "Assistant"
+                messages.append((role, message[:_RECOVERY_MESSAGE_CHARS]))
+                if role == "Assistant":
+                    last_assistant_index = len(messages) - 1
+    except OSError:
+        logger.warning("Could not read Codex rollout for recovery", exc_info=True)
+        return ""
+
+    if last_assistant_index is not None:
+        messages = messages[: last_assistant_index + 1]
+    messages = messages[-_RECOVERY_MESSAGE_LIMIT:]
+    transcript = "\n\n".join(f"{role}:\n{text}" for role, text in messages)
+    return transcript[-_RECOVERY_TRANSCRIPT_CHARS:]
+
+
+def _build_resume_recovery_prompt(prompt: str, session_id: str, env: dict[str, str]) -> str:
+    """Build a text-only handoff when a Codex resume is permanently stuck."""
+    transcript = _text_transcript_from_rollout(session_id, env)
+    context = transcript or "(No prior text transcript was available.)"
+    return (
+        "A previous Codex session could not be resumed after exhausting its transport retries. "
+        "Continue the same task in this replacement session. Use the text-only transcript below "
+        "for intent, inspect the current workspace for the authoritative work state, and do not "
+        "repeat completed work.\n\n"
+        f"Previous text transcript:\n{context}\n\n"
+        f"Current user message:\n{prompt}"
+    )
 
 
 class CodexRunner:
@@ -209,13 +294,15 @@ class CodexRunner:
     ) -> AsyncGenerator[StreamEvent, None]:
         """Run Codex CLI and yield stream events."""
         attempt_session_id = session_id
+        attempt_prompt = prompt
         retried_without_resume = False
 
         while True:
-            args = self._build_args(prompt, attempt_session_id)
+            args = self._build_args(attempt_prompt, attempt_session_id)
             env = self._build_env()
             cwd = self.working_dir or os.getcwd()
             should_retry_without_resume = False
+            saw_progress = False
 
             logger.info("Starting Codex CLI: %s (cwd=%s)", " ".join(args[:6]) + " ...", cwd)
 
@@ -232,7 +319,7 @@ class CodexRunner:
             logger.info("Codex CLI started: pid=%s", self._process.pid)
 
             if self._process.stdin is not None:
-                await self._send_prompt(prompt)
+                await self._send_prompt(attempt_prompt)
 
             try:
                 async for event in self._read_stream():
@@ -249,6 +336,25 @@ class CodexRunner:
                         should_retry_without_resume = True
                         retried_without_resume = True
                         break
+                    if (
+                        attempt_session_id
+                        and not retried_without_resume
+                        and not saw_progress
+                        and _is_resume_stream_disconnect(event.error)
+                    ):
+                        logger.warning(
+                            "Codex session %s could not resume after WebSocket retries; "
+                            "rolling over to a text-only recovery session",
+                            attempt_session_id,
+                        )
+                        attempt_prompt = _build_resume_recovery_prompt(
+                            prompt, attempt_session_id, env
+                        )
+                        should_retry_without_resume = True
+                        retried_without_resume = True
+                        break
+                    if event.text or event.tool_use is not None or event.tool_result_id:
+                        saw_progress = True
                     yield event
             except TimeoutError:
                 logger.warning("Codex CLI timed out after %ds", self.timeout_seconds)

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -251,6 +251,161 @@ class TestCodexRunnerRun:
         assert events[0].error is not None
         assert "CLI exited with code 1" in events[0].error
 
+    @pytest.mark.asyncio
+    async def test_resume_stream_disconnect_rolls_over_with_text_context(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """Image-heavy Codex sessions must not leave a thread permanently stuck."""
+        stale_session = "019f68db-1a72-7bc1-a222-af76b9dd4cdb"
+        sessions_dir = tmp_path / "sessions" / "2026" / "07" / "16"
+        sessions_dir.mkdir(parents=True)
+        rollout = sessions_dir / f"rollout-2026-07-16T11-56-57-{stale_session}.jsonl"
+        records = [
+            {
+                "type": "event_msg",
+                "payload": {"type": "user_message", "message": "Design a dashboard"},
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "custom_tool_call_output",
+                    "output": [
+                        {"type": "input_image", "image_url": "data:image/png;base64,SECRET"}
+                    ],
+                },
+            },
+            {
+                "type": "event_msg",
+                "payload": {
+                    "type": "agent_message",
+                    "message": "I generated three variants and updated the files.",
+                },
+            },
+        ]
+        rollout.write_text("\n".join(json.dumps(record) for record in records) + "\n")
+
+        disconnect_line = json.dumps(
+            {
+                "type": "error",
+                "message": (
+                    "stream disconnected before completion: "
+                    "websocket closed by server before response.completed"
+                ),
+            }
+        ).encode()
+        started_line = json.dumps(
+            {"type": "thread.started", "thread_id": "019f-replacement-session"}
+        ).encode()
+        completed_line = json.dumps({"type": "turn.completed", "usage": {}}).encode()
+        first_process = _FakeProcess(stdout_lines=[disconnect_line + b"\n"], pid=100)
+        replacement_process = _FakeProcess(
+            stdout_lines=[started_line + b"\n", completed_line + b"\n"],
+            pid=101,
+        )
+        processes = [first_process, replacement_process]
+        calls: list[tuple[str, ...]] = []
+
+        async def fake_create_subprocess_exec(*args, **kwargs):
+            calls.append(args)
+            return processes.pop(0)
+
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        monkeypatch.setattr(
+            "claude_code_core.codex_runner.asyncio.create_subprocess_exec",
+            fake_create_subprocess_exec,
+        )
+        runner = CodexRunner(command="codex", working_dir="/work")
+
+        events = [event async for event in runner.run("continue", session_id=stale_session)]
+
+        assert len(calls) == 2
+        assert calls[0][:3] == ("codex", "exec", "resume")
+        assert "resume" not in calls[1]
+        assert [event.error for event in events if event.error] == []
+        assert events[0].session_id == "019f-replacement-session"
+        replacement_process.stdin.write.assert_called_once()
+        recovery_prompt = replacement_process.stdin.write.call_args.args[0].decode()
+        assert "Design a dashboard" in recovery_prompt
+        assert "I generated three variants and updated the files." in recovery_prompt
+        assert "Current user message:\ncontinue" in recovery_prompt
+        assert "data:image" not in recovery_prompt
+        # Subprocess argv must still never contain prompt text.
+        assert all("Design a dashboard" not in arg for call in calls for arg in call)
+
+    @pytest.mark.asyncio
+    async def test_new_session_stream_disconnect_does_not_retry(self, monkeypatch) -> None:
+        disconnect_line = json.dumps(
+            {
+                "type": "error",
+                "message": (
+                    "stream disconnected before completion: "
+                    "websocket closed by server before response.completed"
+                ),
+            }
+        ).encode()
+        process = _FakeProcess(stdout_lines=[disconnect_line + b"\n"])
+        calls = 0
+
+        async def fake_create_subprocess_exec(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            return process
+
+        monkeypatch.setattr(
+            "claude_code_core.codex_runner.asyncio.create_subprocess_exec",
+            fake_create_subprocess_exec,
+        )
+        runner = CodexRunner(command="codex")
+
+        events = [event async for event in runner.run("hello")]
+
+        assert calls == 1
+        assert len(events) == 1
+        assert events[0].error is not None
+        assert "websocket closed" in events[0].error
+
+    @pytest.mark.asyncio
+    async def test_resume_disconnect_after_output_does_not_retry(self, monkeypatch) -> None:
+        message_line = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {"id": "msg-1", "type": "agent_message", "text": "Partial output"},
+            }
+        ).encode()
+        disconnect_line = json.dumps(
+            {
+                "type": "error",
+                "message": (
+                    "stream disconnected before completion: "
+                    "websocket closed by server before response.completed"
+                ),
+            }
+        ).encode()
+        process = _FakeProcess(stdout_lines=[message_line + b"\n", disconnect_line + b"\n"])
+        calls = 0
+
+        async def fake_create_subprocess_exec(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            return process
+
+        monkeypatch.setattr(
+            "claude_code_core.codex_runner.asyncio.create_subprocess_exec",
+            fake_create_subprocess_exec,
+        )
+        runner = CodexRunner(command="codex")
+
+        events = [
+            event
+            async for event in runner.run(
+                "continue", session_id="019f68db-1a72-7bc1-a222-af76b9dd4cdb"
+            )
+        ]
+
+        assert calls == 1
+        assert [event.text for event in events if event.text] == ["Partial output"]
+        assert len([event for event in events if event.error]) == 1
+
 
 class TestParseCodexLine:
     """Tests for parse_codex_line() — Codex JSONL → StreamEvent."""


### PR DESCRIPTION
## Summary

- detect the persistent Codex Responses WebSocket failure after `exec resume` exhausts retries
- extract a bounded text-only user/assistant transcript from the local rollout, excluding image and tool payloads
- roll over once to a replacement Codex session before any output has been produced
- avoid retrying new sessions or partially executed turns to prevent loops and duplicate side effects

## Test plan

- [x] regression test for resume failure and text-only session rollover
- [x] no retry for new-session failures
- [x] no retry after partial assistant output
- [x] real affected rollout extraction excludes inline image data
- [x] `uv run ruff check claude_code_core/ claude_discord/ tests/test_codex_runner.py`
- [x] `uv run ruff format --check claude_code_core/codex_runner.py tests/test_codex_runner.py`
- [x] 1,618 tests passed with CI-equivalent isolated HOME/environment

Closes #475
