### PR TITLE
docs: document PATH override for systemd-launched sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,3 +53,12 @@ CLAUDE_WORKING_DIR=
 # Limits
 MAX_CONCURRENT_SESSIONS=3
 SESSION_TIMEOUT_SECONDS=300
+
+# Toolchain PATH (recommended when running as a systemd service)
+# systemd starts the unit with a minimal default PATH and never reads ~/.bashrc
+# or ~/.profile, so Claude sessions spawned by the bot only see system-wide
+# binaries. If your toolchain (Node.js, etc.) lives under ~/.local/bin, builds
+# that work in your terminal will fail inside a Discord session with a stale
+# version. Because this file is loaded via EnvironmentFile=, setting PATH here
+# fixes it for the service and every session it spawns.
+# PATH=/home/you/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin


### PR DESCRIPTION
## Why

The bot unit is started by systemd, which uses a minimal default PATH and never reads `~/.bashrc` / `~/.profile`. Every Claude session the bot spawns therefore inherits that PATH and only sees system-wide binaries — anything installed under `~/.local/bin` is invisible.

On this host that meant sessions resolved `/usr/bin/node` (v20) instead of the v22 toolchain in `~/.local/bin`, so Astro builds failed with `Node.js v20.20.2 is not supported by Astro!` even though the same build succeeded in a terminal. `uv` was affected the same way.

`.env` is loaded through `EnvironmentFile=`, so setting `PATH` there fixes the service and everything it spawns. This commit documents that in `.env.example` so the setting survives a machine rebuild.

## Changes

- `.env.example`: commented `PATH=` entry with an explanation of the failure mode.

## Test plan

- [x] Documentation only, no code paths touched.
- [x] Verified on the live host that `PATH` in `.env` reaches the service process (`/proc/<pid>/environ`) and that `npm run build` then resolves Node v22.