### PR TITLE
[docs-sync] Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,21 @@ The script detects the repository root dynamically (via `readlink -f` on `$0`), 
 
 The script requires the `DISCORD_WEBHOOK_URL` variable in `.env` for failure notifications (optional — the script works without it).
 
+#### Toolchain PATH — set it in `.env`
+
+systemd starts a unit with a minimal default `PATH` (typically `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`) and never sources `~/.bashrc` or `~/.profile`. The bot inherits that `PATH`, and so does every Claude/Codex session it spawns — sessions run with the bot's environment minus the stripped secrets.
+
+The result is confusing: a build that works in your terminal fails inside a Discord session, or silently runs against an older system-wide binary, because tools installed under `~/.local/bin` or `~/.npm-global/bin` are invisible to the service.
+
+Since the service loads `.env` via `EnvironmentFile=`, setting `PATH` there fixes the bot and every session at once:
+
+```bash
+# .env — match your interactive shell's PATH
+PATH=/home/you/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
+```
+
+Restart the service (`sudo systemctl restart mybot.service`), then confirm from a Discord session by asking Claude to run `which node && node --version`.
+
 ### Custom Cogs (Extend Without Forking)
 
 Add your own features by dropping Python files into a directory — no fork, no subclass, no package needed:
@@ -597,6 +612,7 @@ In chat-only mode, permission requests and `AskUserQuestion` prompts are **alway
 | `CCDB_COMMAND` | Path or name of the CLI binary (overrides `CLAUDE_COMMAND`). Used by the initial runner picked from `CCDB_BACKEND`; superseded by the two per-backend variables below when `/backend` switches at runtime. | _(auto: `claude` or `codex`)_ |
 | `CCDB_CLAUDE_COMMAND` | Explicit path to the Claude CLI binary. Used by `BackendFactory` whenever `/backend claude` is active, regardless of the initial `CCDB_BACKEND`. Falls back to `CLAUDE_COMMAND`, then `claude` (PATH). | (optional) |
 | `CCDB_CODEX_COMMAND` | Explicit path to the OpenAI Codex CLI binary. Required when running the bot under systemd (default service PATH does not include `~/.npm-global/bin`). Falls back to `codex` (PATH). | (optional) |
+| `PATH` | Binary search path for the bot **and every CLI session it spawns** — sessions inherit the bot's environment. Set it in `.env` when running under systemd, which starts units with a minimal PATH and never reads `~/.bashrc` / `~/.profile`. See [Toolchain PATH](#toolchain-path--set-it-in-env). | (inherited from the parent process) |
 | `CCDB_MODEL` | Model to use (overrides `CLAUDE_MODEL`) | `sonnet` |
 | `CCDB_PERMISSION_MODE` | Permission mode for CLI (overrides `CLAUDE_PERMISSION_MODE`) | `acceptEdits` |
 | `CCDB_DANGEROUSLY_SKIP_PERMISSIONS` | Skip all permission checks — overrides `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | `false` |

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -410,6 +410,21 @@ journalctl -u mybot.service -f
 
 `.env` に `DISCORD_WEBHOOK_URL` を設定すると障害通知が届きます（任意）。
 
+#### ツールチェーンの PATH — `.env` に設定する
+
+systemd はユニットを最小限の `PATH`（通常は `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`）で起動し、`~/.bashrc` や `~/.profile` を一切読み込みません。Bot はその `PATH` を引き継ぎ、Bot が起動する Claude / Codex の各セッションも同じ環境（除去されるシークレットを除く）を継承します。
+
+そのため、ターミナルでは成功するビルドが Discord セッションの中では失敗したり、気づかないうちに古いシステム側のバイナリで実行されたりします。`~/.local/bin` や `~/.npm-global/bin` にインストールしたツールがサービスからは見えないためです。
+
+サービスは `EnvironmentFile=` で `.env` を読み込むため、そこに `PATH` を設定すれば Bot と全セッションを一度に修正できます。
+
+```bash
+# .env — 対話シェルの PATH に合わせる
+PATH=/home/you/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
+```
+
+サービスを再起動し（`sudo systemctl restart mybot.service`）、Discord セッションで Claude に `which node && node --version` を実行させて確認してください。
+
 ### カスタム Cog（フォーク不要で機能拡張）
 
 Python ファイルをディレクトリに追加するだけで独自機能を追加できます — フォーク不要、サブクラス不要、パッケージ不要:
@@ -599,6 +614,7 @@ CHAT_ONLY_CHANNEL_IDS=444,555
 | `CCDB_COMMAND` | CLI バイナリのパスまたは名前（`CLAUDE_COMMAND` より優先）。`CCDB_BACKEND` で選択された初期ランナーに使用され、実行時に `/backend` で切り替えた際は以下の 2 つのバックエンド別変数が優先されます。 | _（自動: `claude` or `codex`）_ |
 | `CCDB_CLAUDE_COMMAND` | Claude CLI バイナリの明示的なパス。`/backend claude` がアクティブなとき `BackendFactory` が使用（`CCDB_BACKEND` の初期値に依存しない）。`CLAUDE_COMMAND`、次に `claude`（PATH）へのフォールバックあり。 | （オプション） |
 | `CCDB_CODEX_COMMAND` | OpenAI Codex CLI バイナリの明示的なパス。systemd 下で Bot を実行する場合に必須（デフォルトのサービス PATH に `~/.npm-global/bin` が含まれない）。`codex`（PATH）へのフォールバックあり。 | （オプション） |
+| `PATH` | Bot **と Bot が起動する全 CLI セッション**のバイナリ検索パス（セッションは Bot の環境を継承）。systemd はユニットを最小限の PATH で起動し `~/.bashrc` / `~/.profile` を読まないため、systemd 運用時は `.env` に設定する。[ツールチェーンの PATH](#ツールチェーンの-path--env-に設定する) 参照 | （親プロセスから継承） |
 | `CCDB_MODEL` | 使用するモデル（`CLAUDE_MODEL` より優先） | `sonnet` |
 | `CCDB_PERMISSION_MODE` | CLI のパーミッションモード（`CLAUDE_PERMISSION_MODE` より優先） | `acceptEdits` |
 | `CCDB_DANGEROUSLY_SKIP_PERMISSIONS` | 全パーミッションチェックをスキップ（`CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` より優先） | `false` |


### PR DESCRIPTION
## Summary / 概要

Documents the toolchain `PATH` override added to `.env.example` in #487.

`.env.example` に追加された PATH 上書き設定（#487）を README に反映しました。

## Changes / 変更内容

**English (`README.md`)**
- New `#### Toolchain PATH — set it in .env` subsection under *Running as a systemd Service*: explains why systemd's minimal PATH breaks builds that work in a terminal, and that `EnvironmentFile=.env` makes a single `PATH=` line fix the bot and every session it spawns.
- New `PATH` row in the Configuration table, linking to that subsection.

**日本語 (`docs/ja/README.md`)**
- 同内容を `#### ツールチェーンの PATH — .env に設定する` として追加。
- 設定テーブルに `PATH` 行を追加。

## Why it matters / なぜ重要か

systemd never sources `~/.bashrc` / `~/.profile`, and spawned Claude/Codex sessions inherit the bot's environment (`_build_env()` copies `os.environ` minus stripped secrets). So a toolchain in `~/.local/bin` is invisible inside Discord sessions — builds fail or silently use an older system-wide binary. The fix is one line in `.env`; it just wasn't discoverable from the README.

## Test plan / テスト

- [x] Docs-only change — no code touched
- [x] Anchor links verified against GitHub's slug rules (matches the existing `#バックエンド切り替え--claude--codex-をオンデマンドで` pattern)
- [x] `EnvironmentFile=` confirmed in `discord-bot.service`; PATH inheritance confirmed in `codex_runner._build_env()`
