### PR TITLE
fix: thread goes silent when its session belongs to another backend

### DIFF
--- a/claude_code_core/models.py
+++ b/claude_code_core/models.py
@@ -28,6 +28,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     summary TEXT,
     context_window INTEGER,
     context_used INTEGER,
+    backend TEXT,
     created_at TEXT NOT NULL DEFAULT (datetime('now', 'localtime')),
     last_used_at TEXT NOT NULL DEFAULT (datetime('now', 'localtime'))
 );
@@ -61,6 +62,9 @@ _MIGRATIONS = [
     "ALTER TABLE sessions ADD COLUMN summary TEXT",
     "ALTER TABLE sessions ADD COLUMN context_window INTEGER",
     "ALTER TABLE sessions ADD COLUMN context_used INTEGER",
+    # Which CLI produced this session ID. Claude and Codex session stores are not
+    # interoperable, so a stored ID is only resumable by the backend that made it.
+    "ALTER TABLE sessions ADD COLUMN backend TEXT",
     # Drop UNIQUE constraint on session_id to allow fork (multiple threads, same source session)
     "DROP INDEX IF EXISTS idx_sessions_session_id",
     "CREATE INDEX IF NOT EXISTS idx_sessions_session_id ON sessions(session_id)",

--- a/claude_code_core/parser.py
+++ b/claude_code_core/parser.py
@@ -270,9 +270,19 @@ def _parse_result(data: dict[str, Any], event: StreamEvent) -> None:
     #   {"type":"result","subtype":"error","error":"..."} — explicit error subtype
     #   {"type":"result","subtype":"success","is_error":true,"result":"API Error: ..."} — API-level
     #     error reported as a "successful" result with is_error flag (e.g. 400 from Anthropic API)
+    #   {"type":"result","subtype":"error_during_execution","is_error":true,
+    #    "result":"","errors":["No conversation found with session ID: ..."]} — the CLI
+    #     failed before producing any text (e.g. --resume with a session ID that does
+    #     not exist).  There is no `result` text, so the errors[] array is the only
+    #     human-readable signal.  Without this branch the run ends silently and the
+    #     user sees no reply at all.
     subtype = data.get("subtype", "")
+    errors_list = [str(e) for e in data.get("errors", []) if e]
     if subtype == "error":
         event.error = data.get("error", "Unknown error")
+    elif subtype.startswith("error") and not result_text:
+        event.error = "\n".join(errors_list) if errors_list else f"CLI reported {subtype}"
+        event.text = ""
     elif data.get("is_error") and result_text:
         # API-level error (e.g. "API Error: 400 ...") surfaced via is_error flag.
         # Promote it to event.error so the handler shows an error display,

--- a/claude_code_core/session_repo.py
+++ b/claude_code_core/session_repo.py
@@ -32,6 +32,7 @@ class SessionRecord:
     last_used_at: str
     context_window: int | None = None
     context_used: int | None = None
+    backend: str | None = None
 
 
 class SessionRepository:
@@ -61,21 +62,28 @@ class SessionRepository:
         model: str | None = None,
         origin: str = "discord",
         summary: str | None = None,
+        backend: str | None = None,
     ) -> SessionRecord:
-        """Create or update a session mapping."""
+        """Create or update a session mapping.
+
+        ``backend`` records which CLI minted ``session_id``. Session stores are
+        not interoperable across backends, so callers must know who owns an ID
+        before passing it to ``--resume`` / ``codex exec resume``.
+        """
         async with aiosqlite.connect(self.db_path) as db:
             await db.execute(
                 """INSERT INTO sessions
-                     (thread_id, session_id, working_dir, model, origin, summary)
-                   VALUES (?, ?, ?, ?, ?, ?)
+                     (thread_id, session_id, working_dir, model, origin, summary, backend)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)
                    ON CONFLICT(thread_id) DO UPDATE SET
                      session_id = excluded.session_id,
                      working_dir = COALESCE(excluded.working_dir, sessions.working_dir),
                      model = COALESCE(excluded.model, sessions.model),
                      origin = COALESCE(excluded.origin, sessions.origin),
                      summary = COALESCE(excluded.summary, sessions.summary),
+                     backend = COALESCE(excluded.backend, sessions.backend),
                      last_used_at = datetime('now', 'localtime')""",
-                (thread_id, session_id, working_dir, model, origin, summary),
+                (thread_id, session_id, working_dir, model, origin, summary, backend),
             )
             await db.commit()
 

--- a/claude_discord/backend_settings.py
+++ b/claude_discord/backend_settings.py
@@ -41,6 +41,19 @@ CODEX_STATUS_MODES = ("auto", "on", "off")
 CODEX_STATUS_DEFAULT = "auto"
 
 
+def session_is_resumable(stored_backend: str | None, current_backend: str) -> bool:
+    """Can ``current_backend`` resume a session ID minted by ``stored_backend``?
+
+    Claude and Codex keep separate session stores, so handing a Codex rollout ID
+    to ``claude --resume`` (or vice versa) fails at the CLI level. When the
+    stored backend is unknown (records written before the ``backend`` column
+    existed) we assume it is compatible — the old behaviour.
+    """
+    if not stored_backend:
+        return True
+    return stored_backend == current_backend
+
+
 class BackendSettings:
     """Thin wrapper around SettingsRepository that resolves backend/model."""
 

--- a/claude_discord/cogs/backend_command.py
+++ b/claude_discord/cogs/backend_command.py
@@ -190,14 +190,22 @@ class BackendCommandCog(commands.Cog):
         prev_backend = await self._settings.current_backend(target_thread_id)
         await self._settings.set_backend(name, thread_id=target_thread_id)
 
-        # When the EFFECTIVE backend actually changed, drop any stored
-        # session ID so the next message starts a fresh session in the new
-        # backend. Codex and Claude session stores are not interoperable
-        # (passing a Claude session UUID to `codex exec resume` -- or vice
-        # versa -- fails at the CLI level).
+        # When the EFFECTIVE backend actually changed, drop the stored session
+        # ID unless the NEW backend can still resume it. Codex and Claude
+        # session stores are not interoperable (passing a Claude session UUID
+        # to `codex exec resume` -- or vice versa -- fails at the CLI level),
+        # but switching *back* to the backend that minted the ID is a valid
+        # way to recover a thread, so that case must keep the record.
         if prev_backend != name and target_thread_id is not None:
             try:
-                deleted = await self._chat_cog.repo.delete(target_thread_id)
+                # Keep the record only when it is KNOWN to belong to the new
+                # backend. Unknown (pre-backend-column) records are wiped, as
+                # they always were — an unknown owner is not worth the risk of
+                # a broken resume.
+                record = await self._chat_cog.repo.get(target_thread_id)
+                deleted = False
+                if record is None or record.backend != name:
+                    deleted = await self._chat_cog.repo.delete(target_thread_id)
                 if deleted:
                     logger.info(
                         "Cleared stored session for thread %d on backend switch %s -> %s",

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -25,13 +25,13 @@ from discord.ext import commands
 from claude_code_core.backend import SessionBackend
 
 from ..backend_factory import BackendFactory
-from ..backend_settings import BackendSettings
+from ..backend_settings import BackendSettings, session_is_resumable
 from ..claude.rewind import find_session_jsonl, parse_user_turns
 from ..claude.types import ImageData
 from ..concurrency import SessionRegistry
 from ..database.ask_repo import PendingAskRepository
 from ..database.lounge_repo import LoungeRepository
-from ..database.repository import SessionRepository
+from ..database.repository import SessionRecord, SessionRepository
 from ..database.resume_repo import PendingResumeRepository
 from ..database.settings_repo import SettingsRepository
 from ..discord_ui.chunker import chunk_message
@@ -939,6 +939,8 @@ class ClaudeChatCog(commands.Cog):
 
         record = await self.repo.get(thread.id)
         session_id = record.session_id if record else None
+        if record is not None and session_id:
+            session_id = await self._session_id_for_current_backend(thread, record)
         prompt, images = await self._build_prompt_and_images(message)
 
         # When there is no session record, this is the first human reply in a
@@ -991,6 +993,40 @@ class ClaudeChatCog(commands.Cog):
             working_dir_override=record.working_dir if record else None,
             chat_only=chat_only,
         )
+
+    async def _session_id_for_current_backend(
+        self, thread: discord.Thread, record: SessionRecord
+    ) -> str | None:
+        """Return the stored session ID, or ``None`` when the backend changed.
+
+        A global ``/backend`` switch does not touch per-thread session records
+        (only a thread-scoped switch does), so a thread can end up holding a
+        Codex rollout ID while the active backend is Claude.  Resuming it makes
+        the CLI exit instantly with "No conversation found with session ID" and
+        the thread looks dead.  Detect the mismatch and start fresh instead.
+        """
+        if self._backend_settings is None:
+            return record.session_id
+
+        current = await self._backend_settings.current_backend(thread.id)
+        if session_is_resumable(record.backend, current):
+            return record.session_id
+
+        logger.info(
+            "Thread %d session %s was created by %s but the active backend is %s "
+            "— starting a fresh session instead of resuming",
+            thread.id,
+            record.session_id,
+            record.backend,
+            current,
+        )
+        with contextlib.suppress(discord.HTTPException):
+            await thread.send(
+                f"-# 🔀 Backend changed (`{record.backend}` → `{current}`). "
+                f"`{current}` cannot resume a `{record.backend}` session, "
+                "so this thread starts a fresh one."
+            )
+        return None
 
     async def _build_prompt_and_images(
         self, message: discord.Message

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -322,9 +322,13 @@ class EventProcessor:
             # For new sessions, save the prompt as the summary so /resume can display it.
             # For resumed sessions (config.session_id is set), pass no summary to keep
             # the existing one via COALESCE in the SQL query.
+            backend = _backend_name_from_runner(self._config.runner)
             if self._config.session_id:
                 await self._config.repo.save(
-                    self._config.thread.id, self._state.session_id, working_dir=wd
+                    self._config.thread.id,
+                    self._state.session_id,
+                    working_dir=wd,
+                    backend=backend,
                 )
             else:
                 summary = self._config.prompt[:100] if self._config.prompt else None
@@ -333,6 +337,7 @@ class EventProcessor:
                     self._state.session_id,
                     working_dir=wd,
                     summary=summary,
+                    backend=backend,
                 )
 
         # Guard: post session_start_embed only once (Claude can emit multiple SYSTEM events).
@@ -591,7 +596,11 @@ class EventProcessor:
 
         if event.session_id:
             if self._config.repo:
-                await self._config.repo.save(self._config.thread.id, event.session_id)
+                await self._config.repo.save(
+                    self._config.thread.id,
+                    event.session_id,
+                    backend=_backend_name_from_runner(self._config.runner),
+                )
             self._state.session_id = event.session_id
 
         # Persist context window stats (requires repo + context_window in event).

--- a/claude_discord/database/models.py
+++ b/claude_discord/database/models.py
@@ -88,6 +88,8 @@ CREATE TABLE IF NOT EXISTS usage_stats (
 _MIGRATIONS = [
     "ALTER TABLE sessions ADD COLUMN origin TEXT NOT NULL DEFAULT 'discord'",
     "ALTER TABLE sessions ADD COLUMN summary TEXT",
+    # Which CLI produced this session ID (claude / codex) — see claude_code_core.models.
+    "ALTER TABLE sessions ADD COLUMN backend TEXT",
     "CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_session_id ON sessions(session_id)",
     # Lounge table added in v1.x — safe to run on existing DBs
     (

--- a/tests/test_backend_command_session_clear.py
+++ b/tests/test_backend_command_session_clear.py
@@ -12,7 +12,11 @@ import discord
 from claude_discord.backend_factory import BackendFactory
 from claude_discord.backend_settings import BackendSettings
 from claude_discord.cogs.backend_command import BackendCommandCog
+from claude_discord.database.repository import SessionRecord
 from claude_discord.database.settings_repo import SettingsRepository
+
+# Sentinel: the thread has no stored session record at all.
+_NO_RECORD = object()
 
 
 async def _new_settings_repo() -> SettingsRepository:
@@ -23,7 +27,9 @@ async def _new_settings_repo() -> SettingsRepository:
     return SettingsRepository(str(tmp))
 
 
-def _make_cog(settings: BackendSettings) -> BackendCommandCog:
+def _make_cog(
+    settings: BackendSettings, session_backend: str | None | object = _NO_RECORD
+) -> BackendCommandCog:
     bot = MagicMock()
     factory = BackendFactory(
         claude_command="claude",
@@ -41,6 +47,22 @@ def _make_cog(settings: BackendSettings) -> BackendCommandCog:
     chat_cog.runner.model = "sonnet"
     chat_cog.repo = MagicMock()
     chat_cog.repo.delete = AsyncMock(return_value=True)
+    record = (
+        None
+        if session_backend is _NO_RECORD
+        else SessionRecord(
+            thread_id=42,
+            session_id="sess-1",
+            working_dir=None,
+            model=None,
+            origin="discord",
+            summary=None,
+            created_at="",
+            last_used_at="",
+            backend=session_backend,  # type: ignore[arg-type]
+        )
+    )
+    chat_cog.repo.get = AsyncMock(return_value=record)
     cog = BackendCommandCog(bot, settings=settings, factory=factory, chat_cog=chat_cog)
     return cog
 
@@ -111,6 +133,27 @@ class TestBackendCommandClearsSession:
         await cog.backend_command.callback(cog, interaction, name="claude", scope="thread")
 
         cog._chat_cog.repo.delete.assert_awaited_once_with(42)
+
+    async def test_keeps_session_owned_by_the_target_backend(self) -> None:
+        """Switching *to* the backend that minted the stored session keeps it.
+
+        This is the recovery path for a thread whose session was stranded by a
+        global backend switch: the Codex rollout is still on disk, so pointing
+        the thread back at Codex must resume it, not wipe it.
+        """
+        repo = await _new_settings_repo()
+        settings = BackendSettings(
+            repo,
+            env_backend="claude",
+            env_model_for_claude="sonnet",
+            env_model_for_codex="",
+        )
+        cog = _make_cog(settings, session_backend="codex")
+        interaction = _make_thread_interaction(thread_id=42)
+
+        await cog.backend_command.callback(cog, interaction, name="codex", scope="thread")
+
+        cog._chat_cog.repo.delete.assert_not_awaited()
 
     async def test_global_change_does_not_clear_any_thread_session(self) -> None:
         """A global /backend change must not wipe individual threads' sessions

--- a/tests/test_backend_session_mismatch.py
+++ b/tests/test_backend_session_mismatch.py
@@ -1,0 +1,94 @@
+"""Backend/session-store mismatch handling.
+
+Regression tests for the "thread goes silent after a global /backend switch"
+bug: the thread kept a Codex rollout ID while the active backend was Claude,
+so every message spawned `claude --resume <codex-id>`, which exits instantly
+with "No conversation found with session ID" and no user-visible output.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from claude_code_core.models import init_db
+from claude_code_core.parser import parse_line
+from claude_code_core.session_repo import SessionRepository
+from claude_discord.backend_settings import session_is_resumable
+
+
+class TestSessionIsResumable:
+    def test_same_backend_is_resumable(self):
+        assert session_is_resumable("codex", "codex") is True
+
+    def test_cross_backend_is_not_resumable(self):
+        assert session_is_resumable("codex", "claude") is False
+        assert session_is_resumable("claude", "codex") is False
+
+    def test_unknown_backend_assumes_compatible(self):
+        """Records written before the backend column existed must keep working."""
+        assert session_is_resumable(None, "claude") is True
+        assert session_is_resumable("", "claude") is True
+
+
+class TestSessionRepositoryBackendColumn:
+    @pytest.mark.asyncio
+    async def test_backend_roundtrip_and_preservation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = str(Path(tmp) / "sessions.db")
+            await init_db(db_path)
+            repo = SessionRepository(db_path)
+
+            await repo.save(1, "sess-a", working_dir="/w", backend="codex")
+            assert (await repo.get(1)).backend == "codex"
+
+            # A save without an explicit backend must not wipe the stored one.
+            await repo.save(1, "sess-a2")
+            record = await repo.get(1)
+            assert record.backend == "codex"
+            assert record.working_dir == "/w"
+
+            # An explicit backend overwrites it.
+            await repo.save(1, "sess-b", backend="claude")
+            assert (await repo.get(1)).backend == "claude"
+
+    @pytest.mark.asyncio
+    async def test_backend_defaults_to_none(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = str(Path(tmp) / "sessions.db")
+            await init_db(db_path)
+            repo = SessionRepository(db_path)
+            await repo.save(2, "sess-c")
+            assert (await repo.get(2)).backend is None
+
+
+class TestErrorDuringExecutionIsSurfaced:
+    def test_resume_failure_becomes_event_error(self):
+        """subtype=error_during_execution carries no `result` text — only errors[]."""
+        line = (
+            '{"type":"result","subtype":"error_during_execution","is_error":true,'
+            '"duration_ms":0,"num_turns":0,"session_id":"019f7dfc-384f-7da2-8133-b73a5b44cd60",'
+            '"errors":["No conversation found with session ID: '
+            '019f7dfc-384f-7da2-8133-b73a5b44cd60"]}'
+        )
+        event = parse_line(line)
+        assert event is not None
+        assert event.is_complete is True
+        assert event.error is not None
+        assert "No conversation found" in event.error
+
+    def test_error_subtype_without_errors_array_still_reports(self):
+        line = '{"type":"result","subtype":"error_max_turns","is_error":true}'
+        event = parse_line(line)
+        assert event is not None
+        assert event.error is not None
+        assert "error_max_turns" in event.error
+
+    def test_successful_result_is_untouched(self):
+        line = '{"type":"result","subtype":"success","is_error":false,"result":"done"}'
+        event = parse_line(line)
+        assert event is not None
+        assert event.error is None
+        assert event.text == "done"

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -112,7 +112,7 @@ class TestOnSystem:
         await p.process(StreamEvent(message_type=MessageType.SYSTEM, session_id="s1"))
 
         repo.save.assert_called_once_with(
-            thread.id, "s1", working_dir=runner.working_dir, summary="test prompt"
+            thread.id, "s1", working_dir=runner.working_dir, summary="test prompt", backend="claude"
         )
 
     @pytest.mark.asyncio
@@ -128,7 +128,7 @@ class TestOnSystem:
         await p.process(StreamEvent(message_type=MessageType.SYSTEM, session_id="existing-sess"))
 
         repo.save.assert_called_once_with(
-            thread.id, "existing-sess", working_dir=runner.working_dir
+            thread.id, "existing-sess", working_dir=runner.working_dir, backend="claude"
         )
 
     @pytest.mark.asyncio
@@ -145,7 +145,7 @@ class TestOnSystem:
         await p.process(StreamEvent(message_type=MessageType.SYSTEM, session_id="s1"))
 
         repo.save.assert_called_once_with(
-            thread.id, "s1", working_dir=runner.working_dir, summary="x" * 100
+            thread.id, "s1", working_dir=runner.working_dir, summary="x" * 100, backend="claude"
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

A live thread stopped responding entirely: every message spawned a Claude CLI that exited in 0 ms and nothing was ever posted back.

```
Claude CLI started: pid=1031559
Claude CLI stdout line 1: {"type":"result","subtype":"error_during_execution","duration_ms":0,...}
```

Two bugs stacked:

1. **Stranded session ID.** A thread stores one session ID, but Claude and Codex keep separate session stores. `/backend` only cleared the thread's stored session when the switch was *thread-scoped*; a **global** switch left every thread holding an ID its new backend cannot resume. The broken thread held a Codex rollout ID (`019f…`, UUIDv7 — a `~/.codex/sessions/` rollout) while the active backend was Claude, so each message ran `claude -p --resume <codex-id>` → `No conversation found with session ID`.
2. **Silent failure.** `_parse_result` handled `subtype=error` and `is_error + result text`, but not `subtype=error_during_execution`, which carries **no** `result` text — only an `errors[]` array. Neither branch matched, so `event.error` stayed `None` and the run was treated as a completed session with empty output. The user saw nothing at all.

Codex's runner already recovers from missing rollout history (`_is_resume_history_missing` → retry without resume). The Claude path had no equivalent.

## Changes

- `sessions.backend` column records which CLI minted the stored session ID (migration; existing rows are `NULL` = unknown).
- On reply, a session minted by a different backend is **not** resumed — the thread starts a fresh session and posts a one-line note explaining the switch. Unknown/legacy owners keep the previous behaviour.
- `/backend` now keeps the stored session when switching **to** the backend that owns it, so pointing a thread back at Codex resumes the conversation instead of wiping it. Unknown owners are still wiped, as before.
- The parser surfaces any `error_*` result subtype using `errors[]`, so a future instant-exit failure reaches Discord instead of vanishing.

## Test plan

- [x] `tests/test_backend_session_mismatch.py` (new): resumability matrix, `backend` column round-trip + COALESCE preservation, `error_during_execution` → `event.error`.
- [x] `tests/test_backend_command_session_clear.py`: updated for the new contract + new case "switching to the owning backend keeps the session".
- [x] `tests/test_event_processor.py`: save assertions now expect `backend=`.
- [x] `ruff check` / `ruff format --check` clean.
- [x] Full suite: 1569 passed. Two pre-existing failures unrelated to this change, both reproduced on clean `HEAD`: `test_backend_factory_api_port.py::test_no_api_port_means_no_env_var` (env leakage from the ambient `CCDB_API_URL`) and a hang in `tests/test_run_helper.py`.
- [ ] Migration applies on the next bot restart (not restarted here — other sessions are active).