### PR TITLE
feat: cross-session observability (GET /api/sessions, GET /api/threads/{id}/messages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,20 @@ curl "$CCDB_API_URL/api/lounge"
 
 The lounge channel doubles as a human-visible activity feed — open it in Discord to see at a glance what every active Claude session is currently doing.
 
+### Cross-Session Observability
+
+A lounge note tells a session *that* another thread exists. These two read-only endpoints let it go and look — so two sessions that started on the same task can discover the overlap instead of both charging ahead.
+
+```bash
+# Who else is alive, where are they working, what did they last announce?
+curl "$CCDB_API_URL/api/sessions?exclude_thread=$DISCORD_THREAD_ID"
+
+# Read that thread's actual conversation
+curl "$CCDB_API_URL/api/threads/1529338965000192110/messages?limit=30"
+```
+
+`/api/sessions` merges three sources: the `sessions` table (created_at, working dir, backend), the in-memory registry (what each live session is doing *right now*), and each thread's latest lounge note. A session appears with `"state": "running"` while a turn is in flight — including sessions that never posted to the lounge at all, which is exactly when this matters. Sessions have no Discord token of their own, so the bot performs the read and the endpoints stay on the localhost control plane.
+
 ### Programmatic Session Creation
 
 Spawn new Claude Code sessions from scripts, GitHub Actions, or other Claude sessions — without Discord message interaction.
@@ -886,6 +900,8 @@ uv add "claude-code-discord-bridge[api]"
 | POST | `/api/mark-resume` | Mark a thread for automatic resume on next bot startup |
 | GET | `/api/lounge` | Read recent AI Lounge messages |
 | POST | `/api/lounge` | Post a message to the AI Lounge (with optional `label`) |
+| GET | `/api/sessions` | List every session — live and stored — with state, working dir and latest lounge note (`state=running`, `exclude_thread`, `limit`) |
+| GET | `/api/threads/{thread_id}/messages` | Read another thread's conversation, oldest first (`limit`) |
 
 ```bash
 # Send notification (embed format, default)

--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -61,6 +61,36 @@ _MAX_SPAWN_ATTACHMENTS = 10
 _MAX_SPAWN_TOTAL_BYTES = 25 * 1024 * 1024
 _MAX_DISCORD_THREAD_NAME_LENGTH = 100
 
+# /api/sessions and /api/threads/{id}/messages — cross-session observability.
+# Bounded so one session peeking at another can never pull an unbounded amount
+# of history into its own context window.
+_DEFAULT_SESSION_LIMIT = 20
+_MAX_SESSION_LIMIT = 100
+_DEFAULT_THREAD_MESSAGE_LIMIT = 30
+_MAX_THREAD_MESSAGE_LIMIT = 100
+# How far back to scan the lounge when attaching each thread's latest note.
+_LOUNGE_LOOKBACK = 50
+# Per-message cap; a single Claude reply can be many KB of code.
+_MAX_THREAD_MESSAGE_CHARS = 2000
+
+
+def _serialize_thread_message(message: object) -> dict[str, object]:
+    """Reduce a discord.Message to the fields another session needs."""
+    content = str(getattr(message, "content", "") or "")
+    truncated = len(content) > _MAX_THREAD_MESSAGE_CHARS
+    author = getattr(message, "author", None)
+    created_at = getattr(message, "created_at", None)
+    return {
+        "id": getattr(message, "id", None),
+        "author": str(getattr(author, "display_name", None) or author or "unknown"),
+        "is_bot": bool(getattr(author, "bot", False)),
+        "content": content[:_MAX_THREAD_MESSAGE_CHARS],
+        "truncated": truncated,
+        "created_at": created_at.isoformat() if hasattr(created_at, "isoformat") else None,
+        "jump_url": getattr(message, "jump_url", None),
+    }
+
+
 # Max accepted request body. aiohttp defaults to 1 MiB, which 413s any real
 # ingest (a full conversation thread plus base64 attachments). Base64 inflates
 # the decoded payload ~4/3, so the body limit must exceed the decoded
@@ -232,6 +262,9 @@ class ApiServer:
         # AI Lounge routes (requires lounge_repo)
         self.app.router.add_get("/api/lounge", self.get_lounge)
         self.app.router.add_post("/api/lounge", self.post_lounge)
+        # Cross-session observability routes (requires session_repo)
+        self.app.router.add_get("/api/sessions", self.list_sessions)
+        self.app.router.add_get("/api/threads/{thread_id}/messages", self.get_thread_messages)
         # Session spawn route
         self.app.router.add_post("/api/spawn", self.spawn)
         # Authenticated external ingest route (browser extension / webhooks)
@@ -740,6 +773,164 @@ class ApiServer:
     # ------------------------------------------------------------------
     # Session spawn endpoint (/api/spawn)
     # ------------------------------------------------------------------
+
+    def _require_session_repo(self) -> web.Response | None:
+        """Return a 503 response if session_repo is not configured."""
+        if self.session_repo is None:
+            return web.json_response(
+                {"error": "session_repo is not configured"},
+                status=503,
+            )
+        return None
+
+    def _running_thread_ids(self) -> set[int]:
+        """Threads with a Claude turn in flight right now.
+
+        Two independent signals agree in practice: the SessionRegistry (entry
+        exists only between turn start and turn end) and ClaudeChatCog's live
+        runner map.  Their union is used so a session is never reported idle
+        while it is actually working.  ``isinstance`` guards keep MagicMock
+        bots (tests, embedded setups) from producing junk.
+        """
+        from ..concurrency import SessionRegistry
+
+        running: set[int] = set()
+
+        registry = getattr(self.bot, "session_registry", None)
+        if isinstance(registry, SessionRegistry):
+            running.update(s.thread_id for s in registry.list_active())
+
+        cog = self.bot.cogs.get("ClaudeChatCog") if hasattr(self.bot, "cogs") else None
+        active_runners = getattr(cog, "_active_runners", None)
+        if isinstance(active_runners, dict):
+            running.update(int(tid) for tid in active_runners)
+
+        return running
+
+    def _active_sessions(self) -> list:
+        """Registry entries describing what each live session is doing."""
+        from ..concurrency import SessionRegistry
+
+        registry = getattr(self.bot, "session_registry", None)
+        if isinstance(registry, SessionRegistry):
+            return registry.list_active()
+        return []
+
+    async def list_sessions(self, request: web.Request) -> web.Response:
+        """GET /api/sessions — what every other Claude session is doing.
+
+        Lets a session discover its peers before touching a shared repository:
+        which threads are alive, where they are working, and what they last
+        announced in the AI Lounge.  Read-only.
+
+        Query params:
+            limit: Max persisted sessions to consider (default 20, max 100).
+                   Live sessions are always included regardless of this cap.
+            state: ``running`` to return only sessions with a turn in flight.
+            exclude_thread: Thread ID to omit (typically the caller's own).
+        """
+        if err := self._require_session_repo():
+            return err
+
+        try:
+            raw_limit = request.rel_url.query.get("limit", str(_DEFAULT_SESSION_LIMIT))
+            limit = max(1, min(_MAX_SESSION_LIMIT, int(raw_limit)))
+        except ValueError:
+            return web.json_response({"error": "limit must be an integer"}, status=400)
+
+        exclude_raw = request.rel_url.query.get("exclude_thread")
+        exclude_thread: int | None = None
+        if exclude_raw:
+            try:
+                exclude_thread = int(exclude_raw)
+            except ValueError:
+                return web.json_response({"error": "exclude_thread must be an integer"}, status=400)
+
+        records = await self.session_repo.list_all(limit=limit)  # type: ignore[union-attr]
+        lounge_messages = (
+            await self.lounge_repo.get_recent(limit=_LOUNGE_LOOKBACK)
+            if self.lounge_repo is not None
+            else []
+        )
+
+        from ..session_view import STATE_RUNNING, build_session_views
+
+        active = self._active_sessions()
+        thread_ids = {r.thread_id for r in records} | {s.thread_id for s in active}
+        views = build_session_views(
+            records=records,
+            active=active,
+            running_thread_ids=self._running_thread_ids(),
+            lounge_messages=lounge_messages,
+            thread_names=self._thread_names(thread_ids),
+        )
+
+        if request.rel_url.query.get("state") == STATE_RUNNING:
+            views = [v for v in views if v["state"] == STATE_RUNNING]
+        if exclude_thread is not None:
+            views = [v for v in views if v["thread_id"] != exclude_thread]
+
+        return web.json_response({"sessions": views})
+
+    def _thread_names(self, thread_ids: set[int]) -> dict[int, str]:
+        """Resolve Discord thread titles from the bot's cache (no API calls)."""
+        names: dict[int, str] = {}
+        for thread_id in thread_ids:
+            channel = self.bot.get_channel(thread_id)
+            name = getattr(channel, "name", None)
+            if isinstance(name, str):
+                names[thread_id] = name
+        return names
+
+    async def get_thread_messages(self, request: web.Request) -> web.Response:
+        """GET /api/threads/{thread_id}/messages — read another thread's conversation.
+
+        The companion to ``/api/sessions``: once a session knows *that* another
+        thread is working on the same thing, this is how it reads *what* that
+        thread actually did.  Sessions have no Discord token of their own, so
+        the bot performs the read and this endpoint stays localhost-only.
+
+        Query params:
+            limit: Number of most recent messages (default 30, max 100).
+
+        Returns messages oldest-first, each truncated to keep responses small.
+        """
+        try:
+            thread_id = int(request.match_info["thread_id"])
+        except (ValueError, KeyError):
+            return web.json_response({"error": "Invalid thread_id"}, status=400)
+
+        try:
+            raw_limit = request.rel_url.query.get("limit", str(_DEFAULT_THREAD_MESSAGE_LIMIT))
+            limit = max(1, min(_MAX_THREAD_MESSAGE_LIMIT, int(raw_limit)))
+        except ValueError:
+            return web.json_response({"error": "limit must be an integer"}, status=400)
+
+        channel = self.bot.get_channel(thread_id)
+        if channel is None:
+            try:
+                channel = await self.bot.fetch_channel(thread_id)
+            except Exception as exc:
+                return web.json_response({"error": str(exc)}, status=404)
+
+        if not hasattr(channel, "history"):
+            return web.json_response(
+                {"error": "Channel does not support message history"}, status=400
+            )
+
+        try:
+            messages = [msg async for msg in channel.history(limit=limit)]
+        except Exception as exc:  # forbidden, deleted thread, transient API error
+            return web.json_response({"error": str(exc)}, status=502)
+
+        messages.reverse()  # Discord returns newest-first; read order is oldest-first
+        return web.json_response(
+            {
+                "thread_id": thread_id,
+                "thread_name": getattr(channel, "name", None),
+                "messages": [_serialize_thread_message(m) for m in messages],
+            }
+        )
 
     async def spawn(self, request: web.Request) -> web.Response:
         """POST /api/spawn — create a new Discord thread and optionally start Claude Code.

--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -26,7 +26,7 @@ import zipfile
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from aiohttp import web
 
@@ -74,12 +74,12 @@ _LOUNGE_LOOKBACK = 50
 _MAX_THREAD_MESSAGE_CHARS = 2000
 
 
-def _serialize_thread_message(message: object) -> dict[str, object]:
+def _serialize_thread_message(message: Any) -> dict[str, object]:
     """Reduce a discord.Message to the fields another session needs."""
     content = str(getattr(message, "content", "") or "")
     truncated = len(content) > _MAX_THREAD_MESSAGE_CHARS
-    author = getattr(message, "author", None)
-    created_at = getattr(message, "created_at", None)
+    author: Any = getattr(message, "author", None)
+    created_at: Any = getattr(message, "created_at", None)
     return {
         "id": getattr(message, "id", None),
         "author": str(getattr(author, "display_name", None) or author or "unknown"),
@@ -913,13 +913,17 @@ class ApiServer:
             except Exception as exc:
                 return web.json_response({"error": str(exc)}, status=404)
 
-        if not hasattr(channel, "history"):
+        # Threads and text channels expose history(); categories and forums do
+        # not. discord.py's union of channel types has no common protocol for
+        # this, hence the runtime check plus an untyped handle.
+        history = getattr(channel, "history", None)
+        if history is None:
             return web.json_response(
                 {"error": "Channel does not support message history"}, status=400
             )
 
         try:
-            messages = [msg async for msg in channel.history(limit=limit)]
+            messages: list[Any] = [msg async for msg in history(limit=limit)]
         except Exception as exc:  # forbidden, deleted thread, transient API error
             return web.json_response({"error": str(exc)}, status=502)
 

--- a/claude_discord/lounge.py
+++ b/claude_discord/lounge.py
@@ -47,6 +47,23 @@ Before bot restarts, force pushes, DB operations, or anything that affects all s
 3. Only proceed if the coast is clear — report before and after
 
 This is the lounge's most critical use. Read it to make decisions, not just to write.
+
+[LOOK AT WHAT OTHER SESSIONS ARE DOING]
+A lounge note tells you a thread ID. These two endpoints let you go and look:
+
+```bash
+# Who else is alive, where are they working, what did they last announce?
+curl -s "$CCDB_API_URL/api/sessions?exclude_thread=$DISCORD_THREAD_ID"
+
+# Read another thread's actual conversation (thread_id from the call above)
+curl -s "$CCDB_API_URL/api/threads/<thread_id>/messages?limit=30"
+```
+
+Use them when a lounge note sounds like your task, when you are about to touch a
+shared repo, or when you suspect a session that never posted here. Sessions with
+``"state": "running"`` have a turn in flight right now; ``working_dir`` tells you
+whether you would collide. Reading is free and has no side effects — when in
+doubt, look before you edit.
 """
 
 _RECENT_HEADER = "\nRecent lounge messages:\n"

--- a/claude_discord/session_view.py
+++ b/claude_discord/session_view.py
@@ -1,0 +1,123 @@
+"""Cross-session observability — read-only views of what other sessions are doing.
+
+Concurrent Claude Code sessions already announce themselves in the AI Lounge,
+but a session had no way to look *at* another session: the lounge line told it
+a thread ID and nothing more.  This module builds the JSON view served by
+``GET /api/sessions`` so a session can answer "who else is running, where, and
+what did they last say?" before touching a shared repository.
+
+Everything here is pure data assembly — no Discord or database access — so the
+merge rules stay testable without a running bot.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from claude_code_core.lounge_repo import LoungeMessage
+    from claude_code_core.session_repo import SessionRecord
+
+    from .concurrency import ActiveSession
+
+# A session is "running" while a Claude turn is in flight; the SessionRegistry
+# holds an entry only between turn start and turn end (see cogs/_run_helper.py).
+STATE_RUNNING = "running"
+STATE_IDLE = "idle"
+
+
+def latest_lounge_by_thread(messages: list[LoungeMessage]) -> dict[int, LoungeMessage]:
+    """Map thread_id → that thread's most recent lounge message.
+
+    ``LoungeRepository.get_recent`` returns oldest-first, so a later match
+    simply overwrites an earlier one.
+    """
+    latest: dict[int, LoungeMessage] = {}
+    for msg in messages:
+        if msg.thread_id is not None:
+            latest[msg.thread_id] = msg
+    return latest
+
+
+def build_session_views(
+    *,
+    records: list[SessionRecord],
+    active: list[ActiveSession],
+    running_thread_ids: set[int],
+    lounge_messages: list[LoungeMessage],
+    thread_names: dict[int, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Merge the three sources of session truth into one ordered view.
+
+    Args:
+        records: Persisted sessions (``sessions`` table) — knows when a session
+            was created, its working dir, backend and model.
+        active: In-memory registry entries — knows what a session is doing
+            *right now* (the first 100 chars of the current prompt).
+        running_thread_ids: Threads with a Claude turn in flight.
+        lounge_messages: Recent AI Lounge messages, oldest first.
+        thread_names: Optional thread_id → Discord thread title.
+
+    Returns:
+        One dict per thread, running sessions first, then most recently used.
+        A thread present only in the registry (no DB row yet — its session ID
+        is minted after the first turn completes) still appears, because that
+        is exactly the session most likely to collide with the caller.
+    """
+    names = thread_names or {}
+    latest_lounge = latest_lounge_by_thread(lounge_messages)
+    by_thread: dict[int, ActiveSession] = {s.thread_id: s for s in active}
+
+    views: dict[int, dict[str, Any]] = {}
+
+    for rec in records:
+        views[rec.thread_id] = {
+            "thread_id": rec.thread_id,
+            "session_id": rec.session_id,
+            "working_dir": rec.working_dir,
+            "backend": rec.backend,
+            "model": rec.model,
+            "origin": rec.origin,
+            "summary": rec.summary,
+            "created_at": rec.created_at,
+            "last_used_at": rec.last_used_at,
+        }
+
+    # Registry entries win on working_dir/description: they describe the turn
+    # currently executing, while the DB row may predate a /cd or a worktree.
+    for thread_id, session in by_thread.items():
+        view = views.setdefault(
+            thread_id,
+            {
+                "thread_id": thread_id,
+                "session_id": None,
+                "backend": None,
+                "model": None,
+                "origin": None,
+                "summary": None,
+                "created_at": None,
+                "last_used_at": None,
+            },
+        )
+        view["current_task"] = session.description
+        if session.working_dir:
+            view["working_dir"] = session.working_dir
+
+    for thread_id, view in views.items():
+        view.setdefault("current_task", None)
+        view.setdefault("working_dir", None)
+        view["thread_name"] = names.get(thread_id)
+        view["state"] = STATE_RUNNING if thread_id in running_thread_ids else STATE_IDLE
+        msg = latest_lounge.get(thread_id)
+        view["latest_lounge"] = (
+            None
+            if msg is None
+            else {"label": msg.label, "message": msg.message, "posted_at": msg.posted_at}
+        )
+
+    # Timestamps are datetime('now','localtime') strings, so lexicographic
+    # order matches chronological order; a missing timestamp sorts last.
+    newest_first = sorted(views.values(), key=lambda v: v["last_used_at"] or "", reverse=True)
+    running = [v for v in newest_first if v["state"] == STATE_RUNNING]
+    idle = [v for v in newest_first if v["state"] != STATE_RUNNING]
+    return running + idle

--- a/tests/test_session_observability.py
+++ b/tests/test_session_observability.py
@@ -1,0 +1,316 @@
+"""Tests for cross-session observability (Phase 1).
+
+Covers:
+- session_view.build_session_views() merge/order rules
+- ApiServer GET /api/sessions
+- ApiServer GET /api/threads/{thread_id}/messages
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from claude_discord.concurrency import ActiveSession, SessionRegistry
+from claude_discord.database.lounge_repo import LoungeMessage, LoungeRepository
+from claude_discord.database.models import init_db
+from claude_discord.database.notification_repo import NotificationRepository
+from claude_discord.database.repository import SessionRecord, SessionRepository
+from claude_discord.ext.api_server import ApiServer
+from claude_discord.session_view import build_session_views, latest_lounge_by_thread
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def db_path() -> str:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    await init_db(path)
+    yield path
+    os.unlink(path)
+
+
+def _record(thread_id: int, *, last_used_at: str, working_dir: str | None = None) -> SessionRecord:
+    return SessionRecord(
+        thread_id=thread_id,
+        session_id=f"sess-{thread_id}",
+        working_dir=working_dir,
+        model=None,
+        origin="discord",
+        summary=None,
+        created_at="2026-07-22 10:00:00",
+        last_used_at=last_used_at,
+    )
+
+
+def _lounge(thread_id: int, message: str, posted_at: str) -> LoungeMessage:
+    return LoungeMessage(
+        id=None,
+        label="tester",
+        message=message,
+        posted_at=posted_at,
+        thread_id=thread_id,
+    )
+
+
+def _fake_message(
+    msg_id: int, content: str, *, author: str = "ebi", is_bot: bool = False
+) -> MagicMock:
+    msg = MagicMock()
+    msg.id = msg_id
+    msg.content = content
+    msg.author.display_name = author
+    msg.author.bot = is_bot
+    msg.created_at = datetime(2026, 7, 22, 13, 0, 0, tzinfo=timezone.utc)
+    msg.jump_url = f"https://discord.com/channels/1/2/{msg_id}"
+    return msg
+
+
+def _thread_channel(name: str, messages: list[MagicMock]) -> MagicMock:
+    """A stand-in for discord.Thread whose history() is an async iterator."""
+
+    channel = MagicMock()
+    channel.name = name
+
+    def history(limit: int = 100):
+        async def gen():
+            for msg in list(reversed(messages))[:limit]:  # Discord: newest first
+                yield msg
+
+        return gen()
+
+    channel.history = history
+    return channel
+
+
+@pytest.fixture
+def bot() -> MagicMock:
+    b = MagicMock()
+    b.session_registry = SessionRegistry()
+    b.cogs = {}
+    b.get_channel.return_value = None
+    b.fetch_channel = AsyncMock(side_effect=RuntimeError("Unknown Channel"))
+    return b
+
+
+@pytest.fixture
+async def api_client(db_path: str, bot: MagicMock) -> TestClient:
+    notif_repo = NotificationRepository(db_path)
+    await notif_repo.init_db()
+    api = ApiServer(
+        repo=notif_repo,
+        bot=bot,
+        default_channel_id=12345,
+        host="127.0.0.1",
+        port=0,
+        session_repo=SessionRepository(db_path),
+        lounge_repo=LoungeRepository(db_path),
+    )
+    server = TestServer(api.app)
+    client = TestClient(server)
+    await client.start_server()
+    yield client
+    await client.close()
+
+
+# ---------------------------------------------------------------------------
+# build_session_views
+# ---------------------------------------------------------------------------
+
+
+def test_running_sessions_sort_before_idle_ones() -> None:
+    views = build_session_views(
+        records=[
+            _record(1, last_used_at="2026-07-22 13:00:00"),
+            _record(2, last_used_at="2026-07-22 12:00:00"),
+        ],
+        active=[],
+        running_thread_ids={2},
+        lounge_messages=[],
+    )
+
+    assert [v["thread_id"] for v in views] == [2, 1]
+    assert views[0]["state"] == "running"
+    assert views[1]["state"] == "idle"
+
+
+def test_registry_only_session_appears_without_db_record() -> None:
+    """A session's DB row is written after its first turn — it must still show."""
+    views = build_session_views(
+        records=[],
+        active=[ActiveSession(thread_id=9, description="Fixing the parser", working_dir="/tmp/wt")],
+        running_thread_ids={9},
+        lounge_messages=[],
+    )
+
+    assert len(views) == 1
+    assert views[0]["thread_id"] == 9
+    assert views[0]["session_id"] is None
+    assert views[0]["current_task"] == "Fixing the parser"
+    assert views[0]["working_dir"] == "/tmp/wt"
+
+
+def test_registry_working_dir_overrides_stale_db_value() -> None:
+    views = build_session_views(
+        records=[_record(5, last_used_at="2026-07-22 12:00:00", working_dir="/home/ebi")],
+        active=[
+            ActiveSession(thread_id=5, description="worktree work", working_dir="/home/ebi/wt")
+        ],
+        running_thread_ids=set(),
+        lounge_messages=[],
+    )
+
+    assert views[0]["working_dir"] == "/home/ebi/wt"
+
+
+def test_latest_lounge_message_wins_and_threadless_notes_are_ignored() -> None:
+    messages = [
+        _lounge(1, "starting", "2026-07-22 12:00:00"),
+        LoungeMessage(id=None, label="x", message="no thread", posted_at="...", thread_id=None),
+        _lounge(1, "halfway", "2026-07-22 12:30:00"),
+    ]
+
+    assert latest_lounge_by_thread(messages)[1].message == "halfway"
+
+    views = build_session_views(
+        records=[_record(1, last_used_at="2026-07-22 13:00:00")],
+        active=[],
+        running_thread_ids=set(),
+        lounge_messages=messages,
+    )
+    assert views[0]["latest_lounge"]["message"] == "halfway"
+
+
+def test_session_without_lounge_note_reports_none() -> None:
+    views = build_session_views(
+        records=[_record(1, last_used_at="2026-07-22 13:00:00")],
+        active=[],
+        running_thread_ids=set(),
+        lounge_messages=[],
+    )
+
+    assert views[0]["latest_lounge"] is None
+    assert views[0]["current_task"] is None
+
+
+# ---------------------------------------------------------------------------
+# GET /api/sessions
+# ---------------------------------------------------------------------------
+
+
+async def test_get_sessions_returns_live_and_stored_sessions(
+    api_client: TestClient, db_path: str, bot: MagicMock
+) -> None:
+    await SessionRepository(db_path).save(
+        thread_id=111, session_id="s-111", working_dir="/home/ebi"
+    )
+    await LoungeRepository(db_path).post(message="doing a thing", label="peer", thread_id=111)
+    bot.session_registry.register(222, "reviewing a PR", "/home/ebi/wt-222")
+
+    resp = await api_client.get("/api/sessions")
+    assert resp.status == 200
+    sessions = (await resp.json())["sessions"]
+
+    by_id = {s["thread_id"]: s for s in sessions}
+    assert by_id[111]["state"] == "idle"
+    assert by_id[111]["latest_lounge"]["message"] == "doing a thing"
+    assert by_id[222]["state"] == "running"
+    assert by_id[222]["current_task"] == "reviewing a PR"
+
+
+async def test_get_sessions_filters_by_state_and_excludes_caller(
+    api_client: TestClient, db_path: str, bot: MagicMock
+) -> None:
+    await SessionRepository(db_path).save(thread_id=111, session_id="s-111")
+    bot.session_registry.register(222, "busy", None)
+    bot.session_registry.register(333, "also busy", None)
+
+    resp = await api_client.get("/api/sessions?state=running&exclude_thread=333")
+    assert resp.status == 200
+    assert [s["thread_id"] for s in (await resp.json())["sessions"]] == [222]
+
+
+async def test_get_sessions_rejects_bad_limit(api_client: TestClient) -> None:
+    resp = await api_client.get("/api/sessions?limit=abc")
+    assert resp.status == 400
+
+
+async def test_get_sessions_without_session_repo_returns_503(db_path: str, bot: MagicMock) -> None:
+    notif_repo = NotificationRepository(db_path)
+    await notif_repo.init_db()
+    api = ApiServer(repo=notif_repo, bot=bot, host="127.0.0.1", port=0)
+    client = TestClient(TestServer(api.app))
+    await client.start_server()
+    try:
+        resp = await client.get("/api/sessions")
+        assert resp.status == 503
+    finally:
+        await client.close()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/threads/{thread_id}/messages
+# ---------------------------------------------------------------------------
+
+
+async def test_get_thread_messages_returns_oldest_first(
+    api_client: TestClient, bot: MagicMock
+) -> None:
+    bot.get_channel.return_value = _thread_channel(
+        "peer thread",
+        [
+            _fake_message(1, "start the work"),
+            _fake_message(2, "on it", author="EbiBot", is_bot=True),
+        ],
+    )
+
+    resp = await api_client.get("/api/threads/777/messages")
+    assert resp.status == 200
+    body = await resp.json()
+
+    assert body["thread_id"] == 777
+    assert body["thread_name"] == "peer thread"
+    assert [m["content"] for m in body["messages"]] == ["start the work", "on it"]
+    assert body["messages"][1]["is_bot"] is True
+    assert body["messages"][0]["created_at"].startswith("2026-07-22T13:00:00")
+
+
+async def test_get_thread_messages_truncates_long_content(
+    api_client: TestClient, bot: MagicMock
+) -> None:
+    bot.get_channel.return_value = _thread_channel("big", [_fake_message(1, "x" * 5000)])
+
+    body = await (await api_client.get("/api/threads/777/messages")).json()
+    assert body["messages"][0]["truncated"] is True
+    assert len(body["messages"][0]["content"]) == 2000
+
+
+async def test_get_thread_messages_honours_limit(api_client: TestClient, bot: MagicMock) -> None:
+    bot.get_channel.return_value = _thread_channel(
+        "many", [_fake_message(i, f"msg {i}") for i in range(10)]
+    )
+
+    body = await (await api_client.get("/api/threads/777/messages?limit=3")).json()
+    assert [m["content"] for m in body["messages"]] == ["msg 7", "msg 8", "msg 9"]
+
+
+async def test_get_thread_messages_unknown_thread_returns_404(
+    api_client: TestClient, bot: MagicMock
+) -> None:
+    resp = await api_client.get("/api/threads/777/messages")
+    assert resp.status == 404
+
+
+async def test_get_thread_messages_rejects_non_numeric_thread_id(
+    api_client: TestClient,
+) -> None:
+    resp = await api_client.get("/api/threads/abc/messages")
+    assert resp.status == 400

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "3.1.18"
+version = "3.1.21"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Why

Concurrent Claude sessions announce themselves in the AI Lounge, and that works — but a lounge note only carries a `thread_id`. A session that reads "another session is refactoring the parser" has no way to go and **look** at that thread. And a session that never posted to the lounge at all is invisible, even though the bot knows it exists.

This PR adds the read side. It is Phase 1 of a larger design (later phases: talking to another thread, and negotiating who stands down); everything here is read-only and has no side effects.

## What

| Endpoint | Purpose |
|---|---|
| `GET /api/sessions` | Every session — live and stored — with `state`, `working_dir`, `current_task` and its latest lounge note. Params: `limit`, `state=running`, `exclude_thread` |
| `GET /api/threads/{thread_id}/messages` | Another thread's conversation, oldest first, per-message truncated. Param: `limit` |

`/api/sessions` merges three sources of truth:

- the `sessions` table — `created_at`, `working_dir`, `backend`, `model`
- the in-memory `SessionRegistry` — what each live session is doing *right now* (registry entries exist only between turn start and turn end, so they double as the `running` signal)
- each thread's most recent AI Lounge message

A thread present only in the registry (no DB row yet — the session ID is minted after the first turn) still appears, because that is precisely the session most likely to collide with the caller.

Sessions have no Discord token of their own, so the bot performs the thread read; both endpoints live on the localhost control plane alongside `/api/spawn`.

## Design notes

- Merge rules live in `claude_discord/session_view.py` as a **pure function** — no Discord, no DB — so the ordering and precedence rules are testable without a bot.
- Registry values override DB values for `working_dir`: the DB row can predate a `/cd` or a worktree switch.
- Responses are bounded (`limit` caps, per-message truncation at 2000 chars) so one session peeking at another can never pull an unbounded amount of history into its own context window.
- The lounge prompt now tells sessions these endpoints exist — otherwise nothing would ever call them.

## Test plan

- [x] `tests/test_session_observability.py` — 14 tests: merge/order rules, registry-only sessions, lounge attachment, state filter, `exclude_thread`, limit validation, 503 without `session_repo`, thread read ordering/truncation/limit, 404/400 paths
- [x] `ruff check` + `ruff format` clean
- [x] Full suite: 1586 passed
- [ ] Live verification on the bot (needs a restart; deferred so concurrent sessions aren't disrupted)

### Pre-existing issues seen while testing (not caused by this PR)

- `tests/test_run_helper.py` hangs when run locally — **reproduced on a clean `origin/main` checkout**, so it predates this branch.
- `tests/test_backend_factory_api_port.py::test_no_api_port_means_no_env_var` fails when `CCDB_API_URL` is exported in the shell (env leak); passes under `env -u CCDB_API_URL`.