### PR TITLE
feat: advisory resource claims (POST/GET/DELETE /api/claims)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,29 @@ curl "$CCDB_API_URL/api/threads/1529338965000192110/messages?limit=30"
 
 `/api/sessions` merges three sources: the `sessions` table (created_at, working dir, backend), the in-memory registry (what each live session is doing *right now*), and each thread's latest lounge note. A session appears with `"state": "running"` while a turn is in flight — including sessions that never posted to the lounge at all, which is exactly when this matters. Sessions have no Discord token of their own, so the bot performs the read and the endpoints stay on the localhost control plane.
 
+### Resource Claims
+
+Observability tells a session that a collision *happened*. A claim prevents it — no reading, no negotiating, no LLM round trip. A session claims what it is about to work on; the next session asking for the same thing is refused before it does any work.
+
+```bash
+# Before starting: claim it
+curl -X POST "$CCDB_API_URL/api/claims" \
+  -H "Content-Type: application/json" \
+  -d '{"resource": "repo:ccdb#issue-123", "thread_id": "'$DISCORD_THREAD_ID'", "note": "fixing the parser"}'
+# 201 {"status": "acquired", ...}
+
+# A second session asking for the same resource:
+# 409 {"status": "held", "claim": {"thread_id": ..., "note": "fixing the parser",
+#      "holder_state": "running", "holder_thread_name": "..."}}
+
+# When done
+curl -X DELETE "$CCDB_API_URL/api/claims?resource=repo:ccdb%23issue-123&thread_id=$DISCORD_THREAD_ID"
+```
+
+Claims are **advisory** — nothing enforces them at the git or filesystem level — and every claim carries a TTL (default 2h, max 24h) so a session that dies cannot pin a resource forever. The 409 body reports whether the holder is still running, which is how a caller decides whether to wait, work on something else, or take over with `force=true`. Resource names are free-form and normalized (case and whitespace), so `repo:ccdb` and `Repo: CCDB` are the same claim.
+
+The lounge prompt tells every session to claim before starting and to release when finished.
+
 ### Programmatic Session Creation
 
 Spawn new Claude Code sessions from scripts, GitHub Actions, or other Claude sessions — without Discord message interaction.
@@ -903,6 +926,9 @@ uv add "claude-code-discord-bridge[api]"
 | POST | `/api/lounge` | Post a message to the AI Lounge (with optional `label`) |
 | GET | `/api/sessions` | List every session — live and stored — with state, working dir and latest lounge note (`state=running`, `exclude_thread`, `limit`) |
 | GET | `/api/threads/{thread_id}/messages` | Read another thread's conversation, oldest first (`limit`) |
+| POST | `/api/claims` | Claim a resource before working on it — 201 when acquired, 409 with the holder when taken |
+| GET | `/api/claims` | List live claims (optional `resource` filter) |
+| DELETE | `/api/claims` | Release a claim (`resource`, `thread_id`, optional `force=true`) |
 
 ```bash
 # Send notification (embed format, default)

--- a/claude_discord/database/claims_repo.py
+++ b/claude_discord/database/claims_repo.py
@@ -1,0 +1,186 @@
+"""Resource claim repository — advisory locks between concurrent sessions.
+
+Two sessions that start the same task waste each other's work.  The AI Lounge
+catches this after the fact (a session reads a note and realises the overlap);
+a claim catches it *before* any work happens and without an LLM round trip:
+the second session asks for the same resource, gets 409, and steps aside.
+
+Claims are advisory — nothing enforces them at the filesystem or git level.
+They are also short-lived: every claim carries a TTL so a session that dies
+mid-task cannot lock a resource forever.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+# A claim is a hint for the next few hours of work, not a lease on a resource.
+DEFAULT_TTL_SECONDS = 2 * 60 * 60
+MAX_TTL_SECONDS = 24 * 60 * 60
+MAX_RESOURCE_LENGTH = 200
+MAX_NOTE_LENGTH = 500
+
+
+@dataclass(frozen=True)
+class Claim:
+    """A live advisory claim on a named resource."""
+
+    id: int
+    resource: str
+    thread_id: int
+    note: str | None
+    created_at: str
+    expires_at: str
+
+
+def normalize_resource(raw: object) -> str:
+    """Reduce a caller-supplied resource name to its canonical form.
+
+    Names are free-form strings agreed on by convention (``repo:ccdb``,
+    ``repo:ccdb#issue-123``, ``file:claude_discord/bot.py``).  Case and
+    surrounding whitespace are not meaningful, so they are normalized away —
+    otherwise ``Repo:CCDB`` and ``repo:ccdb`` would be two separate claims on
+    the same thing, which defeats the point.
+    """
+    return " ".join(str(raw or "").split()).lower()
+
+
+class ClaimRepository:
+    """CRUD for the ``resource_claims`` table.
+
+    Every method opens a short-lived connection, matching the other
+    repositories in this package.
+    """
+
+    def __init__(self, db_path: str) -> None:
+        self._db_path = db_path
+
+    async def acquire(
+        self,
+        resource: str,
+        thread_id: int,
+        *,
+        ttl_seconds: int = DEFAULT_TTL_SECONDS,
+        note: str | None = None,
+    ) -> tuple[bool, Claim]:
+        """Claim *resource* for *thread_id*, or report who already holds it.
+
+        Re-claiming a resource the caller already holds renews it — a long task
+        can extend its own claim without releasing it first (which would open a
+        window for another session to grab it).
+
+        Returns:
+            ``(True, claim)`` when acquired or renewed, ``(False, holder)``
+            when another live thread holds it.
+        """
+        ttl = max(1, min(MAX_TTL_SECONDS, ttl_seconds))
+        async with aiosqlite.connect(self._db_path) as db:
+            db.row_factory = aiosqlite.Row
+            # IMMEDIATE takes the write lock up front so two sessions racing for
+            # the same resource cannot both read "unclaimed" and both insert.
+            await db.execute("BEGIN IMMEDIATE")
+            await self._delete_expired(db)
+
+            cursor = await db.execute(
+                "SELECT * FROM resource_claims WHERE resource = ?",
+                (resource,),
+            )
+            existing = await cursor.fetchone()
+            if existing is not None and existing["thread_id"] != thread_id:
+                await db.commit()
+                return False, _row_to_claim(existing)
+
+            await db.execute(
+                """
+                INSERT INTO resource_claims (resource, thread_id, note, expires_at)
+                VALUES (?, ?, ?, datetime('now', 'localtime', ?))
+                ON CONFLICT(resource) DO UPDATE SET
+                    thread_id = excluded.thread_id,
+                    note = COALESCE(excluded.note, resource_claims.note),
+                    expires_at = excluded.expires_at
+                """,
+                (resource, thread_id, note, f"+{ttl} seconds"),
+            )
+            cursor = await db.execute(
+                "SELECT * FROM resource_claims WHERE resource = ?",
+                (resource,),
+            )
+            row = await cursor.fetchone()
+            await db.commit()
+
+        if row is None:  # pragma: no cover — the INSERT above guarantees a row
+            raise RuntimeError(f"Failed to read back claim for {resource!r}")
+        return True, _row_to_claim(row)
+
+    async def list_active(self, resource: str | None = None) -> list[Claim]:
+        """Return unexpired claims, most recently created first."""
+        async with aiosqlite.connect(self._db_path) as db:
+            db.row_factory = aiosqlite.Row
+            await self._delete_expired(db)
+            await db.commit()
+            sql = "SELECT * FROM resource_claims WHERE expires_at > datetime('now', 'localtime')"
+            params: tuple[object, ...] = ()
+            if resource is not None:
+                sql += " AND resource = ?"
+                params = (resource,)
+            sql += " ORDER BY created_at DESC, id DESC"
+            rows = await db.execute_fetchall(sql, params)
+        return [_row_to_claim(row) for row in rows]
+
+    async def release(self, resource: str, thread_id: int, *, force: bool = False) -> bool:
+        """Release a claim.
+
+        Only the holder may release its own claim; ``force`` overrides that so a
+        session can reclaim a resource pinned by a peer that died (the 409 body
+        reports whether the holder is still running, which is how a caller
+        decides that forcing is justified).
+
+        Returns:
+            True when a row was removed.
+        """
+        async with aiosqlite.connect(self._db_path) as db:
+            if force:
+                cursor = await db.execute(
+                    "DELETE FROM resource_claims WHERE resource = ?",
+                    (resource,),
+                )
+            else:
+                cursor = await db.execute(
+                    "DELETE FROM resource_claims WHERE resource = ? AND thread_id = ?",
+                    (resource, thread_id),
+                )
+            await db.commit()
+            return cursor.rowcount > 0
+
+    async def release_all_for_thread(self, thread_id: int) -> int:
+        """Drop every claim held by a thread.  Returns the number removed."""
+        async with aiosqlite.connect(self._db_path) as db:
+            cursor = await db.execute(
+                "DELETE FROM resource_claims WHERE thread_id = ?",
+                (thread_id,),
+            )
+            await db.commit()
+            return cursor.rowcount
+
+    @staticmethod
+    async def _delete_expired(db: aiosqlite.Connection) -> None:
+        """Drop claims whose TTL has passed (lazy pruning, no background job)."""
+        await db.execute(
+            "DELETE FROM resource_claims WHERE expires_at <= datetime('now', 'localtime')"
+        )
+
+
+def _row_to_claim(row: aiosqlite.Row) -> Claim:
+    return Claim(
+        id=row["id"],
+        resource=row["resource"],
+        thread_id=row["thread_id"],
+        note=row["note"],
+        created_at=row["created_at"],
+        expires_at=row["expires_at"],
+    )

--- a/claude_discord/database/models.py
+++ b/claude_discord/database/models.py
@@ -82,6 +82,21 @@ CREATE TABLE IF NOT EXISTS usage_stats (
     is_using_overage INTEGER NOT NULL DEFAULT 0,
     recorded_at TEXT NOT NULL DEFAULT (datetime('now', 'localtime'))
 );
+
+-- Advisory resource claims: a session announces "I am working on X" so a
+-- second session asking for the same X is told to step aside *before* it
+-- starts. Advisory only — nothing enforces them. Every claim has a TTL so a
+-- session that dies cannot pin a resource forever.
+CREATE TABLE IF NOT EXISTS resource_claims (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    resource TEXT NOT NULL UNIQUE,
+    thread_id INTEGER NOT NULL,
+    note TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now', 'localtime')),
+    expires_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_resource_claims_thread ON resource_claims(thread_id);
 """
 
 # Migrations for existing databases that lack new columns.
@@ -138,6 +153,17 @@ _MIGRATIONS = [
     ),
     # thread_id column on lounge_messages — tracks which Discord thread posted the message
     "ALTER TABLE lounge_messages ADD COLUMN thread_id INTEGER",
+    # resource_claims added in v3.2 — advisory cross-session locks
+    (
+        "CREATE TABLE IF NOT EXISTS resource_claims ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "resource TEXT NOT NULL UNIQUE, "
+        "thread_id INTEGER NOT NULL, "
+        "note TEXT, "
+        "created_at TEXT NOT NULL DEFAULT (datetime('now', 'localtime')), "
+        "expires_at TEXT NOT NULL)"
+    ),
+    "CREATE INDEX IF NOT EXISTS idx_resource_claims_thread ON resource_claims(thread_id)",
 ]
 
 

--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -31,11 +31,13 @@ from typing import TYPE_CHECKING, Any
 from aiohttp import web
 
 from ..discord_ui.file_sender import send_file_blobs
+from ..session_view import STATE_IDLE, STATE_RUNNING, build_session_views
 
 if TYPE_CHECKING:
     import discord
     from discord.ext.commands import Bot
 
+    from ..database.claims_repo import ClaimRepository
     from ..database.ingest_repo import IngestResultRepository
     from ..database.lounge_repo import LoungeRepository
     from ..database.notification_repo import NotificationRepository
@@ -213,6 +215,7 @@ class ApiServer:
         resume_repo: PendingResumeRepository | None = None,
         session_repo: SessionRepository | None = None,
         ingest_repo: IngestResultRepository | None = None,
+        claims_repo: ClaimRepository | None = None,
     ) -> None:
         self.repo = repo
         self.bot = bot
@@ -230,6 +233,7 @@ class ApiServer:
         self.resume_repo = resume_repo
         self.session_repo = session_repo
         self.ingest_repo = ingest_repo
+        self.claims_repo = claims_repo
         # Fall back to COORDINATION_CHANNEL_ID so lounge shares the same channel
         if lounge_channel_id is None:
             ch_str = os.getenv("COORDINATION_CHANNEL_ID", "")
@@ -262,6 +266,10 @@ class ApiServer:
         # AI Lounge routes (requires lounge_repo)
         self.app.router.add_get("/api/lounge", self.get_lounge)
         self.app.router.add_post("/api/lounge", self.post_lounge)
+        # Advisory resource claims (requires claims_repo)
+        self.app.router.add_post("/api/claims", self.create_claim)
+        self.app.router.add_get("/api/claims", self.list_claims)
+        self.app.router.add_delete("/api/claims", self.delete_claim)
         # Cross-session observability routes (requires session_repo)
         self.app.router.add_get("/api/sessions", self.list_sessions)
         self.app.router.add_get("/api/threads/{thread_id}/messages", self.get_thread_messages)
@@ -774,6 +782,161 @@ class ApiServer:
     # Session spawn endpoint (/api/spawn)
     # ------------------------------------------------------------------
 
+    def _require_claims_repo(self) -> web.Response | None:
+        """Return a 503 response if claims_repo is not configured."""
+        if self.claims_repo is None:
+            return web.json_response(
+                {"error": "claims_repo is not configured"},
+                status=503,
+            )
+        return None
+
+    def _claim_json(self, claim: object) -> dict[str, object]:
+        """Serialize a Claim, annotating the holder so 409s are actionable."""
+        thread_id = getattr(claim, "thread_id", None)
+        return {
+            "resource": getattr(claim, "resource", None),
+            "thread_id": thread_id,
+            "note": getattr(claim, "note", None),
+            "created_at": getattr(claim, "created_at", None),
+            "expires_at": getattr(claim, "expires_at", None),
+            "holder_state": (
+                STATE_RUNNING if thread_id in self._running_thread_ids() else STATE_IDLE
+            ),
+            "holder_thread_name": self._thread_names({thread_id}).get(thread_id)
+            if isinstance(thread_id, int)
+            else None,
+        }
+
+    async def create_claim(self, request: web.Request) -> web.Response:
+        """POST /api/claims — claim a resource, or learn who already holds it.
+
+        The cheap half of cross-session coordination: no LLM round trip, no
+        negotiation.  A session claims what it is about to work on; a second
+        session asking for the same thing gets 409 and steps aside before doing
+        any work.  Claims are advisory and expire.
+
+        Body (JSON):
+            resource: Free-form name agreed by convention, e.g. ``repo:ccdb``,
+                ``repo:ccdb#issue-123``, ``file:claude_discord/bot.py``.
+            thread_id: The claiming session's Discord thread ID.
+            ttl_seconds: Optional lifetime (default 2h, max 24h).
+            note: Optional human-readable intent shown to whoever collides.
+
+        Returns 201 when acquired or renewed, 409 when another live thread
+        holds it (body carries the holder, its state and its note).
+        """
+        if err := self._require_claims_repo():
+            return err
+        try:
+            data = await request.json()
+        except json.JSONDecodeError:
+            return web.json_response({"error": "Invalid JSON"}, status=400)
+
+        from ..database.claims_repo import (
+            DEFAULT_TTL_SECONDS,
+            MAX_NOTE_LENGTH,
+            MAX_RESOURCE_LENGTH,
+            normalize_resource,
+        )
+
+        resource = normalize_resource(data.get("resource"))
+        if not resource:
+            return web.json_response({"error": "resource is required"}, status=400)
+        if len(resource) > MAX_RESOURCE_LENGTH:
+            return web.json_response(
+                {"error": f"resource must be at most {MAX_RESOURCE_LENGTH} characters"},
+                status=400,
+            )
+
+        try:
+            thread_id = int(data["thread_id"])
+        except (KeyError, TypeError, ValueError):
+            return web.json_response({"error": "thread_id is required (integer)"}, status=400)
+
+        try:
+            ttl_seconds = int(data.get("ttl_seconds", DEFAULT_TTL_SECONDS))
+        except (TypeError, ValueError):
+            return web.json_response({"error": "ttl_seconds must be an integer"}, status=400)
+
+        note = data.get("note")
+        note = str(note)[:MAX_NOTE_LENGTH] if note else None
+
+        acquired, claim = await self.claims_repo.acquire(  # type: ignore[union-attr]
+            resource, thread_id, ttl_seconds=ttl_seconds, note=note
+        )
+        if not acquired:
+            logger.info(
+                "Claim denied: %s wanted by thread %s, held by thread %s",
+                _sanitize_log(resource),
+                thread_id,
+                claim.thread_id,
+            )
+            return web.json_response(
+                {"status": "held", "claim": self._claim_json(claim)},
+                status=409,
+            )
+        return web.json_response(
+            {"status": "acquired", "claim": self._claim_json(claim)},
+            status=201,
+        )
+
+    async def list_claims(self, request: web.Request) -> web.Response:
+        """GET /api/claims — list live claims.
+
+        Query params:
+            resource: Exact resource name to look up (optional).
+        """
+        if err := self._require_claims_repo():
+            return err
+
+        from ..database.claims_repo import normalize_resource
+
+        raw = request.rel_url.query.get("resource")
+        resource = normalize_resource(raw) if raw else None
+        claims = await self.claims_repo.list_active(resource)  # type: ignore[union-attr]
+        return web.json_response({"claims": [self._claim_json(c) for c in claims]})
+
+    async def delete_claim(self, request: web.Request) -> web.Response:
+        """DELETE /api/claims?resource=X&thread_id=Y[&force=true] — release a claim.
+
+        A session releases what it finished.  ``force=true`` lets a session take
+        over a resource pinned by a peer that is no longer running (the 409 body
+        from ``POST /api/claims`` reports the holder's state, which is how a
+        caller justifies forcing).
+        """
+        if err := self._require_claims_repo():
+            return err
+
+        from ..database.claims_repo import normalize_resource
+
+        resource = normalize_resource(request.rel_url.query.get("resource"))
+        if not resource:
+            return web.json_response({"error": "resource is required"}, status=400)
+
+        force = request.rel_url.query.get("force", "").lower() in ("1", "true", "yes")
+        raw_thread = request.rel_url.query.get("thread_id")
+        thread_id = 0
+        if raw_thread:
+            try:
+                thread_id = int(raw_thread)
+            except ValueError:
+                return web.json_response({"error": "thread_id must be an integer"}, status=400)
+        elif not force:
+            return web.json_response(
+                {"error": "thread_id is required unless force=true"}, status=400
+            )
+
+        released = await self.claims_repo.release(  # type: ignore[union-attr]
+            resource, thread_id, force=force
+        )
+        if not released:
+            return web.json_response(
+                {"error": "No matching claim (not held, expired, or held by another thread)"},
+                status=404,
+            )
+        return web.json_response({"status": "released", "resource": resource})
+
     def _require_session_repo(self) -> web.Response | None:
         """Return a 503 response if session_repo is not configured."""
         if self.session_repo is None:
@@ -852,8 +1015,6 @@ class ApiServer:
             if self.lounge_repo is not None
             else []
         )
-
-        from ..session_view import STATE_RUNNING, build_session_views
 
         active = self._active_sessions()
         thread_ids = {r.thread_id for r in records} | {s.thread_id for s in active}

--- a/claude_discord/lounge.py
+++ b/claude_discord/lounge.py
@@ -64,6 +64,30 @@ shared repo, or when you suspect a session that never posted here. Sessions with
 ``"state": "running"`` have a turn in flight right now; ``working_dir`` tells you
 whether you would collide. Reading is free and has no side effects — when in
 doubt, look before you edit.
+
+[CLAIM WHAT YOU ARE ABOUT TO WORK ON]
+Before starting substantial work on a repo, issue, or file, claim it. This is
+cheaper than discovering the collision later — no reading, no negotiating:
+
+```bash
+curl -s -X POST "$CCDB_API_URL/api/claims" -H "Content-Type: application/json" \\
+  -d '{{"resource": "repo:my-repo#issue-42", "thread_id": "'$DISCORD_THREAD_ID'", \\
+       "note": "what you intend to do"}}'
+```
+
+- 201 → it is yours; go ahead. Claims expire on their own (default 2h).
+- 409 → another session holds it. The response tells you which thread, what it
+  is doing and whether it is still running. Read that thread, then pick
+  different work or tell the human — do NOT start the same task anyway.
+
+Release when you are done (or when you stop early):
+```bash
+curl -s -X DELETE \\
+  "$CCDB_API_URL/api/claims?resource=repo:my-repo%23issue-42&thread_id=$DISCORD_THREAD_ID"
+```
+
+Resource names are free-form; use `repo:<name>`, `repo:<name>#issue-<n>`, or
+`file:<path>`. Claim the narrowest thing that would actually conflict.
 """
 
 _RECENT_HEADER = "\nRecent lounge messages:\n"

--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
     from .backend_factory import BackendFactory
     from .backend_settings import BackendSettings
+    from .database.claims_repo import ClaimRepository
     from .database.ingest_repo import IngestResultRepository
     from .database.lounge_repo import LoungeRepository
     from .database.repository import SessionRepository
@@ -46,6 +47,7 @@ class BridgeComponents:
     session_repo: SessionRepository
     task_repo: TaskRepository | None = None
     lounge_repo: LoungeRepository | None = None
+    claims_repo: ClaimRepository | None = None
     resume_repo: PendingResumeRepository | None = None
     ingest_repo: IngestResultRepository | None = None
     backend_factory: BackendFactory | None = None
@@ -64,6 +66,8 @@ class BridgeComponents:
             api_server.task_repo = self.task_repo
         if self.lounge_repo is not None:
             api_server.lounge_repo = self.lounge_repo
+        if self.claims_repo is not None:
+            api_server.claims_repo = self.claims_repo
         if self.resume_repo is not None:
             api_server.resume_repo = self.resume_repo
         if self.ingest_repo is not None:
@@ -157,6 +161,7 @@ async def setup_bridge(
     from .cogs.session_manage import SessionManageCog
     from .cogs.skill_command import SkillCommandCog
     from .database.ask_repo import PendingAskRepository
+    from .database.claims_repo import ClaimRepository
     from .database.inbox_repo import ThreadInboxRepository
     from .database.ingest_repo import IngestResultRepository
     from .database.lounge_repo import LoungeRepository
@@ -246,6 +251,7 @@ async def setup_bridge(
     settings_repo = SettingsRepository(session_db_path)
     ask_repo = PendingAskRepository(session_db_path)
     lounge_repo = LoungeRepository(session_db_path)
+    claims_repo = ClaimRepository(session_db_path)
     resume_repo = PendingResumeRepository(session_db_path)
     usage_repo = UsageStatsRepository(session_db_path)
     ingest_repo = IngestResultRepository(session_db_path)
@@ -378,6 +384,7 @@ async def setup_bridge(
         session_repo=session_repo,
         task_repo=task_repo,
         lounge_repo=lounge_repo,
+        claims_repo=claims_repo,
         resume_repo=resume_repo,
         ingest_repo=ingest_repo,
         backend_factory=backend_factory,

--- a/tests/test_resource_claims.py
+++ b/tests/test_resource_claims.py
@@ -1,0 +1,252 @@
+"""Tests for advisory resource claims.
+
+Covers:
+- ClaimRepository acquire / renew / conflict / release / expiry
+- ApiServer POST, GET and DELETE /api/claims
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from claude_discord.concurrency import SessionRegistry
+from claude_discord.database.claims_repo import ClaimRepository, normalize_resource
+from claude_discord.database.models import init_db
+from claude_discord.database.notification_repo import NotificationRepository
+from claude_discord.ext.api_server import ApiServer
+
+RESOURCE = "repo:ccdb#issue-123"
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def db_path() -> str:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    await init_db(path)
+    yield path
+    os.unlink(path)
+
+
+@pytest.fixture
+async def claims_repo(db_path: str) -> ClaimRepository:
+    return ClaimRepository(db_path)
+
+
+@pytest.fixture
+def bot() -> MagicMock:
+    b = MagicMock()
+    b.session_registry = SessionRegistry()
+    b.cogs = {}
+    b.get_channel.return_value = None
+    return b
+
+
+@pytest.fixture
+async def api_client(db_path: str, bot: MagicMock) -> TestClient:
+    notif_repo = NotificationRepository(db_path)
+    await notif_repo.init_db()
+    api = ApiServer(
+        repo=notif_repo,
+        bot=bot,
+        host="127.0.0.1",
+        port=0,
+        claims_repo=ClaimRepository(db_path),
+    )
+    client = TestClient(TestServer(api.app))
+    await client.start_server()
+    yield client
+    await client.close()
+
+
+# ---------------------------------------------------------------------------
+# ClaimRepository
+# ---------------------------------------------------------------------------
+
+
+async def test_first_claim_is_acquired(claims_repo: ClaimRepository) -> None:
+    acquired, claim = await claims_repo.acquire(RESOURCE, 111, note="fixing it")
+
+    assert acquired is True
+    assert claim.thread_id == 111
+    assert claim.note == "fixing it"
+
+
+async def test_second_thread_is_refused_and_learns_the_holder(
+    claims_repo: ClaimRepository,
+) -> None:
+    await claims_repo.acquire(RESOURCE, 111, note="fixing it")
+    acquired, holder = await claims_repo.acquire(RESOURCE, 222)
+
+    assert acquired is False
+    assert holder.thread_id == 111
+    assert holder.note == "fixing it"
+
+
+async def test_holder_can_renew_its_own_claim(claims_repo: ClaimRepository) -> None:
+    _, first = await claims_repo.acquire(RESOURCE, 111, ttl_seconds=60, note="first")
+    acquired, renewed = await claims_repo.acquire(RESOURCE, 111, ttl_seconds=3600)
+
+    assert acquired is True
+    assert renewed.expires_at > first.expires_at
+    assert renewed.note == "first"  # a renewal without a note keeps the original
+
+
+async def test_expired_claim_does_not_block_another_thread(
+    claims_repo: ClaimRepository,
+) -> None:
+    """A session that dies must not pin a resource forever."""
+    await claims_repo.acquire(RESOURCE, 111, ttl_seconds=1)
+    # Rewrite expiry into the past rather than sleeping.
+    import aiosqlite
+
+    async with aiosqlite.connect(claims_repo._db_path) as db:
+        await db.execute(
+            "UPDATE resource_claims SET expires_at = datetime('now', 'localtime', '-1 hour')"
+        )
+        await db.commit()
+
+    acquired, claim = await claims_repo.acquire(RESOURCE, 222)
+    assert acquired is True
+    assert claim.thread_id == 222
+    assert await claims_repo.list_active() == [claim]
+
+
+async def test_release_requires_ownership_unless_forced(
+    claims_repo: ClaimRepository,
+) -> None:
+    await claims_repo.acquire(RESOURCE, 111)
+
+    assert await claims_repo.release(RESOURCE, 222) is False
+    assert await claims_repo.release(RESOURCE, 222, force=True) is True
+    assert await claims_repo.list_active() == []
+
+
+async def test_release_all_for_thread(claims_repo: ClaimRepository) -> None:
+    await claims_repo.acquire("repo:a", 111)
+    await claims_repo.acquire("repo:b", 111)
+    await claims_repo.acquire("repo:c", 222)
+
+    assert await claims_repo.release_all_for_thread(111) == 2
+    assert [c.resource for c in await claims_repo.list_active()] == ["repo:c"]
+
+
+def test_resource_names_are_normalized() -> None:
+    assert normalize_resource("  Repo:CCDB#Issue-1  ") == "repo:ccdb#issue-1"
+    assert normalize_resource("repo:ccdb   file:x") == "repo:ccdb file:x"
+    assert normalize_resource(None) == ""
+
+
+# ---------------------------------------------------------------------------
+# API
+# ---------------------------------------------------------------------------
+
+
+async def test_post_claim_returns_201_then_409(api_client: TestClient, bot: MagicMock) -> None:
+    bot.session_registry.register(111, "fixing issue 123", "/home/ebi")
+
+    first = await api_client.post(
+        "/api/claims", json={"resource": RESOURCE, "thread_id": 111, "note": "fixing it"}
+    )
+    assert first.status == 201
+    assert (await first.json())["status"] == "acquired"
+
+    second = await api_client.post("/api/claims", json={"resource": RESOURCE, "thread_id": 222})
+    assert second.status == 409
+    body = await second.json()
+    assert body["status"] == "held"
+    assert body["claim"]["thread_id"] == 111
+    assert body["claim"]["note"] == "fixing it"
+    # The 409 must be actionable: is the holder still alive?
+    assert body["claim"]["holder_state"] == "running"
+
+
+async def test_post_claim_reports_idle_holder(api_client: TestClient) -> None:
+    await api_client.post("/api/claims", json={"resource": RESOURCE, "thread_id": 111})
+    resp = await api_client.post("/api/claims", json={"resource": RESOURCE, "thread_id": 222})
+
+    assert (await resp.json())["claim"]["holder_state"] == "idle"
+
+
+async def test_post_claim_matches_regardless_of_case_and_spacing(
+    api_client: TestClient,
+) -> None:
+    await api_client.post("/api/claims", json={"resource": RESOURCE, "thread_id": 111})
+    resp = await api_client.post(
+        "/api/claims", json={"resource": "  REPO:CCDB#Issue-123 ", "thread_id": 222}
+    )
+
+    assert resp.status == 409
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"thread_id": 111},
+        {"resource": "   ", "thread_id": 111},
+        {"resource": RESOURCE},
+        {"resource": RESOURCE, "thread_id": "not-an-int"},
+        {"resource": RESOURCE, "thread_id": 111, "ttl_seconds": "soon"},
+        {"resource": "x" * 201, "thread_id": 111},
+    ],
+)
+async def test_post_claim_rejects_bad_input(api_client: TestClient, payload: dict) -> None:
+    resp = await api_client.post("/api/claims", json=payload)
+    assert resp.status == 400
+
+
+async def test_get_claims_lists_and_filters(api_client: TestClient) -> None:
+    await api_client.post("/api/claims", json={"resource": "repo:a", "thread_id": 111})
+    await api_client.post("/api/claims", json={"resource": "repo:b", "thread_id": 222})
+
+    all_claims = (await (await api_client.get("/api/claims")).json())["claims"]
+    assert {c["resource"] for c in all_claims} == {"repo:a", "repo:b"}
+
+    filtered = (await (await api_client.get("/api/claims?resource=repo:a")).json())["claims"]
+    assert [c["thread_id"] for c in filtered] == [111]
+
+
+async def test_delete_claim_releases_and_frees_the_resource(api_client: TestClient) -> None:
+    await api_client.post("/api/claims", json={"resource": "repo:a", "thread_id": 111})
+
+    resp = await api_client.delete("/api/claims?resource=repo:a&thread_id=111")
+    assert resp.status == 200
+
+    again = await api_client.post("/api/claims", json={"resource": "repo:a", "thread_id": 222})
+    assert again.status == 201
+
+
+async def test_delete_claim_by_non_holder_is_404_but_force_works(
+    api_client: TestClient,
+) -> None:
+    await api_client.post("/api/claims", json={"resource": "repo:a", "thread_id": 111})
+
+    assert (await api_client.delete("/api/claims?resource=repo:a&thread_id=222")).status == 404
+    assert (await api_client.delete("/api/claims?resource=repo:a&force=true")).status == 200
+
+
+async def test_delete_claim_requires_thread_id_unless_forced(api_client: TestClient) -> None:
+    resp = await api_client.delete("/api/claims?resource=repo:a")
+    assert resp.status == 400
+
+
+async def test_claims_endpoints_return_503_without_repo(db_path: str, bot: MagicMock) -> None:
+    notif_repo = NotificationRepository(db_path)
+    await notif_repo.init_db()
+    api = ApiServer(repo=notif_repo, bot=bot, host="127.0.0.1", port=0)
+    client = TestClient(TestServer(api.app))
+    await client.start_server()
+    try:
+        assert (await client.get("/api/claims")).status == 503
+        assert (await client.post("/api/claims", json={})).status == 503
+        assert (await client.delete("/api/claims?resource=x")).status == 503
+    finally:
+        await client.close()

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "3.1.21"
+version = "3.1.22"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Why

#493 gave sessions the ability to *see* each other. That catches a collision after it has already happened — both sessions have done work, and now something has to be thrown away.

A claim catches it before any work happens, and costs nothing: no thread reading, no negotiation, no LLM round trip. The second session asks for the resource, gets a 409, and picks different work.

## What

| Endpoint | Behaviour |
|---|---|
| `POST /api/claims` | 201 when acquired or renewed; **409 with the holder** when taken |
| `GET /api/claims` | Live claims, optional `resource` filter |
| `DELETE /api/claims` | Release (`resource` + `thread_id`, or `force=true`) |

```jsonc
// 409 body — a refusal that tells you what to do next
{"status": "held",
 "claim": {"thread_id": 1529…, "note": "fixing the parser",
           "holder_state": "running", "holder_thread_name": "parser bug",
           "expires_at": "2026-07-22 19:04:11"}}
```

## Design notes

- **Advisory, never enforced.** Nothing blocks git or the filesystem. The value is that the second session is told *before* it starts.
- **Every claim expires** (default 2h, max 24h), pruned lazily on read/write. A session that dies cannot pin a resource forever — that failure mode would be worse than having no claims at all.
- **The 409 is actionable**: it reports whether the holder is still `running` (from the same registry signal as `/api/sessions`). That is what justifies `force=true` when a peer has died, instead of a blanket steal.
- **Re-claiming renews.** A long task extends its own claim without releasing first, which would open a window for another session to grab it.
- **Names are normalized** (case + whitespace collapsed), so `repo:ccdb` and `Repo: CCDB` cannot become two claims on the same thing.
- **`BEGIN IMMEDIATE`** in `acquire()` — two sessions racing for the same resource cannot both read "unclaimed" and both insert.
- Wired through `BridgeComponents.apply_to_api_server()`, so consumers get it by updating the package (zero-config).
- The lounge prompt now instructs sessions to claim before starting and release when done. An endpoint nobody calls is worth nothing.

## Test plan

- [x] `tests/test_resource_claims.py` — 21 tests: acquire/renew/conflict, expiry does not block, ownership-checked release, `force`, `release_all_for_thread`, name normalization, 201→409 flow, holder-state reporting, input validation (6 cases), list + filter, 503 without repo
- [x] `ruff check` / `ruff format --check` / `pyright` clean
- [x] Suite: 1607 passed (excluding the two pre-existing issues noted in #493: the local `test_run_helper.py` hang that reproduces on clean `origin/main`, and `test_backend_factory_api_port` failing when `CCDB_API_URL` is exported in the shell)