### PR TITLE
feat: session-to-session relay (POST /api/threads/{id}/message)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,28 @@ Claims are **advisory** — nothing enforces them at the git or filesystem level
 
 The lounge prompt tells every session to claim before starting and to release when finished.
 
+### Session-to-Session Relay
+
+Observability lets a session see a peer; a claim keeps them apart. When two sessions have already collided, they need to actually talk — and one of them needs to stop.
+
+```bash
+curl -X POST "$CCDB_API_URL/api/threads/<their_thread_id>/message" \
+  -H "Content-Type: application/json" \
+  -d '{"text": "I started this at 13:02 on branch fix/parser and already pushed 3 commits.",
+       "from_thread": "'$DISCORD_THREAD_ID'", "mode": "queue", "hop": 0}'
+```
+
+`on_message` ignores anything a bot wrote — that guard is what stops the bot from talking to itself — so relays go through this endpoint instead, the same way `/api/spawn` does.
+
+- **`mode: "queue"`** (default) waits for the receiver's current turn to finish.
+- **`mode: "interrupt"`** SIGINTs the turn in flight, so "stop now" lands within seconds. It can cost the receiver uncommitted work, so it is reserved for real conflicts.
+- The relayed text is **posted into the thread** before it reaches Claude, so the humans watching see the whole AI-to-AI exchange. A relay is never a back channel.
+- Every message is **wrapped in a marker** naming the sending thread and stating that it is not from the human — an unmarked instruction would be obeyed as if the owner had written it.
+
+Loops are the real risk (two sessions answering each other burn tokens and interrupt each other indefinitely), so a guard bounds every chain: **max 2 hops**, a 60s cooldown per thread pair, 5 relays per sender per 10 minutes, and no self-sends. Refusals come back as 429 with the reason.
+
+The lounge prompt also gives sessions a tie-break rule so the conversation converges instead of ending in mutual politeness: whoever has commits or a PR beats whoever is still investigating; otherwise the earlier session continues; ties go to the lower thread ID. Whoever stands down pushes its branch first and hands over what it learned.
+
 ### Programmatic Session Creation
 
 Spawn new Claude Code sessions from scripts, GitHub Actions, or other Claude sessions — without Discord message interaction.
@@ -929,6 +951,7 @@ uv add "claude-code-discord-bridge[api]"
 | POST | `/api/claims` | Claim a resource before working on it — 201 when acquired, 409 with the holder when taken |
 | GET | `/api/claims` | List live claims (optional `resource` filter) |
 | DELETE | `/api/claims` | Release a claim (`resource`, `thread_id`, optional `force=true`) |
+| POST | `/api/threads/{thread_id}/message` | Relay a message from one session to another (`text`, `from_thread`, `mode`, `hop`) |
 
 ```bash
 # Send notification (embed format, default)

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -812,6 +812,62 @@ class ClaudeChatCog(commands.Cog):
             )
         return thread
 
+    async def deliver_relayed_message(
+        self,
+        thread: discord.Thread,
+        text: str,
+        *,
+        interrupt: bool,
+    ) -> None:
+        """Feed a message from another session into this thread's Claude session.
+
+        The API-initiated equivalent of a human reply, and the sibling of
+        ``spawn_session``: ``on_message`` drops anything a bot wrote, so a
+        relayed message would never reach Claude through the normal path.
+
+        The text is posted into the thread first, so the humans watching see the
+        AI-to-AI exchange — a relay must never become a back channel.
+
+        Args:
+            thread: The receiving thread.
+            text: Already-wrapped message (see ``relay.build_relay_prompt``).
+            interrupt: When True, SIGINT the turn in flight so a "stop, I have
+                this" reaches Claude within seconds. When False, wait for the
+                current turn to finish — the right default, because a message
+                that preempts a turn can cost the receiver uncommitted work.
+        """
+        chunks = chunk_message(text) or [text]
+        seed_message = await thread.send(chunks[0])
+        for chunk in chunks[1:]:
+            seed_message = await thread.send(chunk)
+
+        record = await self.repo.get(thread.id)
+        session_id = record.session_id if record else None
+        if record is not None and session_id:
+            session_id = await self._session_id_for_current_backend(thread, record)
+
+        lock = self._thread_locks.setdefault(thread.id, asyncio.Lock())
+        async with lock:
+            existing_runner = self._active_runners.get(thread.id)
+            existing_task = self._active_tasks.get(thread.id)
+            if existing_runner is not None:
+                if interrupt:
+                    await thread.send("-# ⚡ Interrupted by another session's message...")
+                    await existing_runner.interrupt()
+                if existing_task is not None and not existing_task.done():
+                    with contextlib.suppress(Exception):
+                        await existing_task
+
+        chat_only = (thread.parent_id or 0) in self._chat_only_channel_ids
+        await self._run_claude(
+            seed_message,
+            thread,
+            text,
+            session_id=session_id,
+            working_dir_override=record.working_dir if record else None,
+            chat_only=chat_only,
+        )
+
     async def cog_unload(self) -> None:
         """Mark all mid-run Claude sessions for auto-resume on the next bot startup.
 

--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -13,6 +13,7 @@ Security:
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import binascii
 import contextlib
@@ -21,6 +22,7 @@ import json
 import logging
 import os
 import re
+import time
 import uuid
 import zipfile
 from collections.abc import Awaitable, Callable
@@ -31,6 +33,7 @@ from typing import TYPE_CHECKING, Any
 from aiohttp import web
 
 from ..discord_ui.file_sender import send_file_blobs
+from ..relay import MODE_INTERRUPT, MODE_QUEUE, VALID_MODES, RelayGuard, build_relay_prompt
 from ..session_view import STATE_IDLE, STATE_RUNNING, build_session_views
 
 if TYPE_CHECKING:
@@ -74,6 +77,9 @@ _MAX_THREAD_MESSAGE_LIMIT = 100
 _LOUNGE_LOOKBACK = 50
 # Per-message cap; a single Claude reply can be many KB of code.
 _MAX_THREAD_MESSAGE_CHARS = 2000
+# Cap on a relayed message. A relay is a short coordination note ("I started at
+# 13:02 on branch X, stand down"), not a payload channel.
+_MAX_RELAY_TEXT_CHARS = 4000
 
 
 def _serialize_thread_message(message: Any) -> dict[str, object]:
@@ -234,6 +240,9 @@ class ApiServer:
         self.session_repo = session_repo
         self.ingest_repo = ingest_repo
         self.claims_repo = claims_repo
+        # Loop/rate brake for thread-to-thread relays. Process-local by design:
+        # after a restart there are no in-flight relay chains to protect.
+        self.relay_guard = RelayGuard()
         # Fall back to COORDINATION_CHANNEL_ID so lounge shares the same channel
         if lounge_channel_id is None:
             ch_str = os.getenv("COORDINATION_CHANNEL_ID", "")
@@ -273,6 +282,7 @@ class ApiServer:
         # Cross-session observability routes (requires session_repo)
         self.app.router.add_get("/api/sessions", self.list_sessions)
         self.app.router.add_get("/api/threads/{thread_id}/messages", self.get_thread_messages)
+        self.app.router.add_post("/api/threads/{thread_id}/message", self.relay_thread_message)
         # Session spawn route
         self.app.router.add_post("/api/spawn", self.spawn)
         # Authenticated external ingest route (browser extension / webhooks)
@@ -781,6 +791,110 @@ class ApiServer:
     # ------------------------------------------------------------------
     # Session spawn endpoint (/api/spawn)
     # ------------------------------------------------------------------
+
+    async def relay_thread_message(self, request: web.Request) -> web.Response:
+        """POST /api/threads/{thread_id}/message — talk to another live session.
+
+        The write side of cross-session coordination: a session that has seen a
+        peer working on the same task can say so, and ask it to stand down.
+
+        ``on_message`` ignores anything a bot wrote (that guard is what stops
+        the bot from talking to itself), so relays go through this endpoint —
+        the same shape as ``/api/spawn``, which also bypasses it deliberately.
+
+        Body (JSON):
+            text: What to say. Wrapped in a marker so the receiver cannot
+                mistake it for its human's instruction.
+            from_thread: The sending session's thread ID (required — a relay
+                without an origin is not answerable).
+            mode: ``queue`` (default) waits for the receiver's current turn to
+                finish; ``interrupt`` SIGINTs it. Use ``interrupt`` only for
+                "stop now", since it can cost the receiver uncommitted work.
+            hop: Chain depth, 0 for a fresh conversation. A reply passes
+                ``hop + 1``; the guard refuses beyond MAX_HOP.
+
+        Returns 202 when delivered (Claude runs in the background), 429 when
+        the relay guard refuses (loop/cooldown/rate), 404 for unknown threads.
+        """
+        try:
+            thread_id = int(request.match_info["thread_id"])
+        except (ValueError, KeyError):
+            return web.json_response({"error": "Invalid thread_id"}, status=400)
+
+        try:
+            data = await request.json()
+        except json.JSONDecodeError:
+            return web.json_response({"error": "Invalid JSON"}, status=400)
+
+        text = str(data.get("text") or "").strip()
+        if not text:
+            return web.json_response({"error": "text is required"}, status=400)
+        if len(text) > _MAX_RELAY_TEXT_CHARS:
+            return web.json_response(
+                {"error": f"text must be at most {_MAX_RELAY_TEXT_CHARS} characters"},
+                status=400,
+            )
+
+        try:
+            from_thread = int(data["from_thread"])
+        except (KeyError, TypeError, ValueError):
+            return web.json_response({"error": "from_thread is required (integer)"}, status=400)
+
+        mode = str(data.get("mode") or MODE_QUEUE).lower()
+        if mode not in VALID_MODES:
+            return web.json_response(
+                {"error": f"mode must be one of {', '.join(VALID_MODES)}"}, status=400
+            )
+
+        try:
+            hop = int(data.get("hop", 0))
+        except (TypeError, ValueError):
+            return web.json_response({"error": "hop must be an integer"}, status=400)
+
+        now = time.monotonic()
+        refusal = self.relay_guard.check(
+            from_thread=from_thread, to_thread=thread_id, hop=hop, now=now
+        )
+        if refusal is not None:
+            logger.info("Relay refused (%s → %s): %s", from_thread, thread_id, refusal)
+            return web.json_response({"error": refusal}, status=429)
+
+        from ..cogs.claude_chat import ClaudeChatCog
+
+        cog: ClaudeChatCog | None = self.bot.cogs.get("ClaudeChatCog")  # type: ignore[assignment]
+        if cog is None:
+            return web.json_response({"error": "ClaudeChatCog is not loaded"}, status=503)
+
+        import discord as _discord
+
+        thread = self.bot.get_channel(thread_id)
+        if thread is None:
+            try:
+                thread = await self.bot.fetch_channel(thread_id)
+            except Exception as exc:
+                return web.json_response({"error": str(exc)}, status=404)
+        if not isinstance(thread, _discord.Thread):
+            return web.json_response({"error": "Target must be a thread"}, status=400)
+
+        prompt = build_relay_prompt(text=text, from_thread=from_thread, hop=hop)
+        self.relay_guard.record(from_thread=from_thread, to_thread=thread_id, now=now)
+
+        # Run in the background so the sender is not blocked for the length of
+        # the receiver's turn.
+        asyncio.create_task(
+            cog.deliver_relayed_message(thread, prompt, interrupt=mode == MODE_INTERRUPT)
+        )
+        logger.info(
+            "Relayed message: thread %s → thread %s (mode=%s, hop=%s)",
+            from_thread,
+            thread_id,
+            mode,
+            hop,
+        )
+        return web.json_response(
+            {"status": "delivered", "thread_id": thread_id, "mode": mode, "hop": hop},
+            status=202,
+        )
 
     def _require_claims_repo(self) -> web.Response | None:
         """Return a 503 response if claims_repo is not configured."""

--- a/claude_discord/lounge.py
+++ b/claude_discord/lounge.py
@@ -88,6 +88,31 @@ curl -s -X DELETE \\
 
 Resource names are free-form; use `repo:<name>`, `repo:<name>#issue-<n>`, or
 `file:<path>`. Claim the narrowest thing that would actually conflict.
+
+[TALK TO ANOTHER SESSION, AND DECIDE WHO STOPS]
+When you find a session genuinely duplicating your work, say so directly:
+
+```bash
+curl -s -X POST "$CCDB_API_URL/api/threads/<their_thread_id>/message" \\
+  -H "Content-Type: application/json" \\
+  -d '{{"text": "your message", "from_thread": "'$DISCORD_THREAD_ID'", \\
+       "mode": "queue", "hop": 0}}'
+```
+
+`mode: "queue"` waits for their current turn to finish — use it by default.
+`mode: "interrupt"` stops their turn within seconds; only for "stop now",
+because it can cost them uncommitted work. Chains are capped at 2 hops, so
+settle it in one exchange.
+
+Decide who continues by evidence, in this order — both sides computing it get
+the same answer, so there is nothing to argue about:
+1. Whoever already has commits or an open PR beats whoever is still investigating
+2. Otherwise the session that started earlier continues
+3. Still tied? The lower thread ID continues
+
+If you are the one standing down: **push your branch first**, tell the other
+session where it is and what you learned, post it to the lounge, then stop.
+Never abandon uncommitted work to be polite.
 """
 
 _RECENT_HEADER = "\nRecent lounge messages:\n"

--- a/claude_discord/relay.py
+++ b/claude_discord/relay.py
@@ -1,0 +1,107 @@
+"""Thread-to-thread relay — one Claude session speaking to another.
+
+Sessions can already see each other (``GET /api/sessions``) and read each
+other's threads.  This is the write side: a session that finds a peer working
+on the same task can say so, and ask it to stand down.
+
+The dangerous part is not the delivery, it is the *loop*.  Two sessions that
+answer each other burn tokens and interrupt each other indefinitely, and each
+message can preempt a running turn.  ``RelayGuard`` is the brake: it bounds how
+far a chain of relayed messages can travel (hops), how often a pair may talk
+(cooldown), and how much one sender may emit (rate limit).  It is pure,
+in-memory and clock-injected so the rules are testable without a bot.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+
+# A relayed message may trigger a reply, and that reply may trigger one more
+# acknowledgement — then the conversation must reach a conclusion on its own.
+MAX_HOP = 2
+# Minimum gap between two messages travelling the same direction between the
+# same pair of threads.
+PAIR_COOLDOWN_SECONDS = 60.0
+# Ceiling on how many messages one thread may relay in a rolling window.
+SENDER_WINDOW_SECONDS = 600.0
+MAX_MESSAGES_PER_WINDOW = 5
+
+MODE_QUEUE = "queue"
+MODE_INTERRUPT = "interrupt"
+VALID_MODES = (MODE_QUEUE, MODE_INTERRUPT)
+
+
+@dataclass
+class RelayGuard:
+    """In-memory rate/loop limits for thread-to-thread messages.
+
+    One instance per bot process.  State is intentionally not persisted: after
+    a restart there are no in-flight conversations to protect against.
+    """
+
+    _last_sent: dict[tuple[int, int], float] = field(default_factory=dict)
+    _sender_history: dict[int, deque[float]] = field(default_factory=dict)
+
+    def check(self, *, from_thread: int, to_thread: int, hop: int, now: float) -> str | None:
+        """Return a rejection reason, or None when the message may be delivered.
+
+        ``now`` is a monotonic timestamp supplied by the caller.
+        """
+        if from_thread == to_thread:
+            return "A thread cannot relay a message to itself"
+        if hop < 0:
+            return "hop must be zero or greater"
+        if hop > MAX_HOP:
+            return (
+                f"Hop limit reached (max {MAX_HOP}) — the conversation must conclude "
+                "in the threads themselves, not by relaying further"
+            )
+
+        last = self._last_sent.get((from_thread, to_thread))
+        if last is not None and now - last < PAIR_COOLDOWN_SECONDS:
+            wait = int(PAIR_COOLDOWN_SECONDS - (now - last))
+            return f"Cooldown between these two threads — retry in {wait}s"
+
+        history = self._prune(from_thread, now)
+        if len(history) >= MAX_MESSAGES_PER_WINDOW:
+            return (
+                f"Rate limit: a thread may relay at most {MAX_MESSAGES_PER_WINDOW} messages "
+                f"per {int(SENDER_WINDOW_SECONDS)}s"
+            )
+        return None
+
+    def record(self, *, from_thread: int, to_thread: int, now: float) -> None:
+        """Record a delivered message so later checks see it."""
+        self._last_sent[(from_thread, to_thread)] = now
+        self._prune(from_thread, now).append(now)
+
+    def _prune(self, thread_id: int, now: float) -> deque[float]:
+        history = self._sender_history.setdefault(thread_id, deque())
+        while history and now - history[0] > SENDER_WINDOW_SECONDS:
+            history.popleft()
+        return history
+
+
+def build_relay_prompt(*, text: str, from_thread: int, hop: int) -> str:
+    """Wrap a relayed message so the receiver cannot mistake it for the human.
+
+    This framing is the whole safety story on the receiving side: a session that
+    reads an unmarked instruction will treat it as its owner's request. The
+    marker states who is speaking, how far the chain has travelled, and that a
+    reply must go back through the API rather than into the void.
+    """
+    remaining = max(0, MAX_HOP - hop)
+    return (
+        f"[MESSAGE FROM ANOTHER CLAUDE SESSION — thread {from_thread}]\n"
+        "This is NOT from your human. Another Claude Code session is relaying it, "
+        "most likely because it believes you are both working on the same thing.\n"
+        f"Hop {hop} of {MAX_HOP} ({remaining} relay(s) left in this chain).\n"
+        "Judge it on evidence, not politeness: compare start times, branches and "
+        "commits before deciding who continues. If you stand down, push your work "
+        "first and say where it is.\n"
+        "To answer, POST to "
+        f"$CCDB_API_URL/api/threads/{from_thread}/message with hop={hop + 1}.\n"
+        "---\n"
+        f"{text}"
+    )

--- a/tests/test_thread_relay.py
+++ b/tests/test_thread_relay.py
@@ -1,0 +1,319 @@
+"""Tests for thread-to-thread relay (one session talking to another).
+
+Covers:
+- RelayGuard loop/cooldown/rate rules
+- build_relay_prompt framing
+- ApiServer POST /api/threads/{thread_id}/message
+- ClaudeChatCog.deliver_relayed_message queue vs interrupt behaviour
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from claude_discord.database.models import init_db
+from claude_discord.database.notification_repo import NotificationRepository
+from claude_discord.ext.api_server import ApiServer
+from claude_discord.relay import (
+    MAX_HOP,
+    MAX_MESSAGES_PER_WINDOW,
+    PAIR_COOLDOWN_SECONDS,
+    SENDER_WINDOW_SECONDS,
+    RelayGuard,
+    build_relay_prompt,
+)
+
+A, B = 111, 222
+
+# ---------------------------------------------------------------------------
+# RelayGuard
+# ---------------------------------------------------------------------------
+
+
+def test_first_message_between_two_threads_is_allowed() -> None:
+    assert RelayGuard().check(from_thread=A, to_thread=B, hop=0, now=0.0) is None
+
+
+def test_a_thread_cannot_talk_to_itself() -> None:
+    reason = RelayGuard().check(from_thread=A, to_thread=A, hop=0, now=0.0)
+    assert reason is not None and "itself" in reason
+
+
+def test_hop_limit_stops_an_endless_chain() -> None:
+    guard = RelayGuard()
+    assert guard.check(from_thread=A, to_thread=B, hop=MAX_HOP, now=0.0) is None
+    reason = guard.check(from_thread=A, to_thread=B, hop=MAX_HOP + 1, now=0.0)
+    assert reason is not None and "Hop limit" in reason
+
+
+def test_negative_hop_is_rejected() -> None:
+    assert RelayGuard().check(from_thread=A, to_thread=B, hop=-1, now=0.0) is not None
+
+
+def test_pair_cooldown_blocks_rapid_back_to_back_messages() -> None:
+    guard = RelayGuard()
+    guard.record(from_thread=A, to_thread=B, now=0.0)
+
+    assert guard.check(from_thread=A, to_thread=B, hop=0, now=1.0) is not None
+    assert guard.check(from_thread=A, to_thread=B, hop=0, now=PAIR_COOLDOWN_SECONDS + 1) is None
+
+
+def test_cooldown_is_per_direction_and_per_pair() -> None:
+    guard = RelayGuard()
+    guard.record(from_thread=A, to_thread=B, now=0.0)
+
+    # The reply travels the other way and must not be blocked by A's cooldown.
+    assert guard.check(from_thread=B, to_thread=A, hop=1, now=1.0) is None
+    # A different recipient is a different conversation.
+    assert guard.check(from_thread=A, to_thread=999, hop=0, now=1.0) is None
+
+
+def test_sender_rate_limit_and_window_expiry() -> None:
+    guard = RelayGuard()
+    for i in range(MAX_MESSAGES_PER_WINDOW):
+        guard.record(from_thread=A, to_thread=1000 + i, now=float(i))
+
+    reason = guard.check(from_thread=A, to_thread=2000, hop=0, now=10.0)
+    assert reason is not None and "Rate limit" in reason
+
+    # Once the window rolls past, the sender is allowed again.
+    assert (
+        guard.check(from_thread=A, to_thread=2000, hop=0, now=SENDER_WINDOW_SECONDS + 100) is None
+    )
+
+
+def test_relay_prompt_marks_the_sender_and_the_reply_path() -> None:
+    prompt = build_relay_prompt(text="please stand down", from_thread=A, hop=1)
+
+    assert "please stand down" in prompt
+    assert str(A) in prompt
+    assert "NOT from your human" in prompt
+    assert "hop=2" in prompt  # tells the receiver what to send back
+
+
+# ---------------------------------------------------------------------------
+# API
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def db_path() -> str:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    await init_db(path)
+    yield path
+    os.unlink(path)
+
+
+@pytest.fixture
+def cog() -> MagicMock:
+    c = MagicMock()
+    c.deliver_relayed_message = AsyncMock()
+    return c
+
+
+@pytest.fixture
+def thread() -> MagicMock:
+    t = MagicMock(spec=discord.Thread)
+    t.id = B
+    return t
+
+
+@pytest.fixture
+def bot(cog: MagicMock, thread: MagicMock) -> MagicMock:
+    b = MagicMock()
+    b.cogs = {"ClaudeChatCog": cog}
+    b.get_channel.return_value = thread
+    b.fetch_channel = AsyncMock(side_effect=RuntimeError("Unknown Channel"))
+    return b
+
+
+@pytest.fixture
+async def api_client(db_path: str, bot: MagicMock) -> TestClient:
+    notif_repo = NotificationRepository(db_path)
+    await notif_repo.init_db()
+    api = ApiServer(repo=notif_repo, bot=bot, host="127.0.0.1", port=0)
+    client = TestClient(TestServer(api.app))
+    await client.start_server()
+    yield client
+    await client.close()
+
+
+async def test_relay_delivers_wrapped_message_in_queue_mode_by_default(
+    api_client: TestClient, cog: MagicMock, thread: MagicMock
+) -> None:
+    resp = await api_client.post(
+        f"/api/threads/{B}/message", json={"text": "I started first", "from_thread": A}
+    )
+
+    assert resp.status == 202
+    assert (await resp.json())["mode"] == "queue"
+
+    await asyncio.sleep(0)  # let the background delivery task run
+    cog.deliver_relayed_message.assert_awaited_once()
+    args, kwargs = cog.deliver_relayed_message.call_args
+    assert args[0] is thread
+    assert "I started first" in args[1]
+    assert str(A) in args[1]
+    assert kwargs["interrupt"] is False
+
+
+async def test_interrupt_mode_is_passed_through(api_client: TestClient, cog: MagicMock) -> None:
+    resp = await api_client.post(
+        f"/api/threads/{B}/message",
+        json={"text": "stop now, I have this", "from_thread": A, "mode": "interrupt"},
+    )
+
+    assert resp.status == 202
+    await asyncio.sleep(0)
+    assert cog.deliver_relayed_message.call_args.kwargs["interrupt"] is True
+
+
+async def test_second_relay_to_same_thread_is_rate_limited(
+    api_client: TestClient, cog: MagicMock
+) -> None:
+    first = await api_client.post(
+        f"/api/threads/{B}/message", json={"text": "hello", "from_thread": A}
+    )
+    second = await api_client.post(
+        f"/api/threads/{B}/message", json={"text": "hello again", "from_thread": A}
+    )
+
+    assert first.status == 202
+    assert second.status == 429
+    await asyncio.sleep(0)
+    assert cog.deliver_relayed_message.await_count == 1
+
+
+async def test_relay_beyond_hop_limit_is_refused(api_client: TestClient, cog: MagicMock) -> None:
+    resp = await api_client.post(
+        f"/api/threads/{B}/message",
+        json={"text": "still talking", "from_thread": A, "hop": MAX_HOP + 1},
+    )
+
+    assert resp.status == 429
+    await asyncio.sleep(0)
+    cog.deliver_relayed_message.assert_not_awaited()
+
+
+async def test_relay_to_self_is_refused(api_client: TestClient) -> None:
+    resp = await api_client.post(
+        f"/api/threads/{B}/message", json={"text": "hi me", "from_thread": B}
+    )
+    assert resp.status == 429
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"from_thread": A},
+        {"text": "  ", "from_thread": A},
+        {"text": "hi"},
+        {"text": "hi", "from_thread": "abc"},
+        {"text": "hi", "from_thread": A, "mode": "shout"},
+        {"text": "hi", "from_thread": A, "hop": "far"},
+        {"text": "x" * 4001, "from_thread": A},
+    ],
+)
+async def test_relay_rejects_bad_input(api_client: TestClient, payload: dict) -> None:
+    resp = await api_client.post(f"/api/threads/{B}/message", json=payload)
+    assert resp.status == 400
+
+
+async def test_relay_to_unknown_thread_returns_404(api_client: TestClient, bot: MagicMock) -> None:
+    bot.get_channel.return_value = None
+    resp = await api_client.post(f"/api/threads/{B}/message", json={"text": "hi", "from_thread": A})
+    assert resp.status == 404
+
+
+async def test_relay_to_non_thread_channel_is_rejected(
+    api_client: TestClient, bot: MagicMock
+) -> None:
+    bot.get_channel.return_value = MagicMock(spec=discord.TextChannel)
+    resp = await api_client.post(f"/api/threads/{B}/message", json={"text": "hi", "from_thread": A})
+    assert resp.status == 400
+
+
+# ---------------------------------------------------------------------------
+# ClaudeChatCog.deliver_relayed_message
+# ---------------------------------------------------------------------------
+
+
+def _make_cog() -> MagicMock:
+    from claude_discord.cogs.claude_chat import ClaudeChatCog
+
+    bot = MagicMock()
+    repo = MagicMock()
+    repo.get = AsyncMock(return_value=None)
+    runner = MagicMock()
+    runner.clone = MagicMock(return_value=MagicMock())
+    return ClaudeChatCog(bot=bot, repo=repo, runner=runner)
+
+
+def _make_target_thread(thread_id: int = B) -> MagicMock:
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = thread_id
+    thread.parent_id = 999
+    thread.send = AsyncMock()
+    return thread
+
+
+async def test_delivery_posts_the_message_so_humans_can_see_it() -> None:
+    cog = _make_cog()
+    thread = _make_target_thread()
+    cog._run_claude = AsyncMock()
+
+    await cog.deliver_relayed_message(thread, "relayed text", interrupt=False)
+
+    assert "relayed text" in thread.send.call_args_list[0].args[0]
+    cog._run_claude.assert_awaited_once()
+
+
+async def test_interrupt_true_stops_the_turn_in_flight() -> None:
+    cog = _make_cog()
+    thread = _make_target_thread()
+    running = MagicMock()
+    running.interrupt = AsyncMock()
+    cog._active_runners[thread.id] = running
+    cog._run_claude = AsyncMock()
+
+    await cog.deliver_relayed_message(thread, "stop now", interrupt=True)
+
+    running.interrupt.assert_awaited_once()
+
+
+async def test_queue_mode_never_interrupts_a_running_turn() -> None:
+    """The default must not cost the receiver its in-flight work."""
+    cog = _make_cog()
+    thread = _make_target_thread()
+    running = MagicMock()
+    running.interrupt = AsyncMock()
+    cog._active_runners[thread.id] = running
+
+    finished = asyncio.Event()
+
+    async def existing_turn() -> None:
+        await finished.wait()
+
+    task = asyncio.create_task(existing_turn())
+    cog._active_tasks[thread.id] = task
+    cog._run_claude = AsyncMock()
+
+    delivery = asyncio.create_task(
+        cog.deliver_relayed_message(thread, "when you get a moment", interrupt=False)
+    )
+    await asyncio.sleep(0.05)
+
+    running.interrupt.assert_not_awaited()
+    cog._run_claude.assert_not_awaited()  # still waiting for the current turn
+
+    finished.set()
+    await delivery
+    cog._run_claude.assert_awaited_once()

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "3.1.22"
+version = "3.1.23"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Why

#493 let a session **see** its peers. #496 lets it **avoid** them. This is the third case: the collision already happened, both sessions are mid-task, and someone has to stop.

Until now there was no way to tell the other session anything — `on_message` ignores every bot-authored message (the guard that stops the bot from talking to itself), so a relayed note would never reach Claude.

## What

```bash
curl -X POST "$CCDB_API_URL/api/threads/<their_thread_id>/message" \
  -H "Content-Type: application/json" \
  -d '{"text": "I started at 13:02 on fix/parser and already pushed 3 commits.",
       "from_thread": "'$DISCORD_THREAD_ID'", "mode": "queue", "hop": 0}'
```

- **`mode: "queue"`** (default) waits for the receiver's current turn to finish.
- **`mode: "interrupt"`** SIGINTs the turn in flight via the existing `runner.interrupt()` path, so "stop now" lands within seconds. It can cost the receiver uncommitted work, so it is deliberately not the default.
- The text is **posted into the thread** before it reaches Claude — humans see the whole AI-to-AI exchange in Discord. A relay must never become a back channel.
- Every message is **wrapped in a marker** naming the sending thread and stating plainly that it is not from the human, plus how to reply. An unmarked instruction would be treated as the thread owner's request.

## The loop is the actual risk

Two sessions answering each other burn tokens and preempt each other's turns indefinitely, and `interrupt` mode makes that destructive rather than merely expensive. `RelayGuard` (pure, in-memory, clock-injected so it is testable) bounds every chain:

| Rule | Value |
|---|---|
| Hops per chain | 2 |
| Cooldown per (sender → receiver) pair | 60s |
| Messages per sender | 5 per 10 min |
| Self-sends | refused |

Refusals return **429 with the reason**, so the sender learns why rather than retrying blindly.

## Making the negotiation converge

Delivery alone would produce two sessions politely deferring to each other, or neither yielding. The lounge prompt now carries a tie-break rule that both sides compute identically:

1. Commits or an open PR beat "still investigating"
2. Otherwise the session that started earlier continues
3. Still tied → lower thread ID

…and whoever stands down **pushes its branch first** and hands over what it learned. Never abandon uncommitted work to be polite.

## Security notes

- The endpoint is on the localhost control plane only, alongside `/api/spawn`. A caller who can reach it can already spawn arbitrary Claude sessions, so `from_thread` being self-declared does not widen the trust boundary — it is a label for the receiver, not an authentication claim.
- No new subprocess/shell surface: delivery reuses the existing `_run_claude` path.
- The marker wrapping is a clarity measure for the receiving model, not a security boundary — stated explicitly in the code comment so nobody mistakes it for one.

## Test plan

- [x] `tests/test_thread_relay.py` — 25 tests: guard rules (hop limit, negative hop, per-pair/per-direction cooldown, sender window + expiry, self-send), prompt framing, API delivery in both modes, 429 on rate limit and hop overflow, 400 input validation (7 cases), 404 unknown thread, 400 non-thread target, and cog-level behaviour: queue mode waits for the in-flight turn and never interrupts, interrupt mode calls `runner.interrupt()`
- [x] `ruff check` / `ruff format --check` / `pyright` clean
- [x] Suite: 1632 passed (excluding the two pre-existing issues noted in #493)