### PR TITLE
feat: detect collisions between sessions from what they actually edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,23 @@ Loops are the real risk (two sessions answering each other burn tokens and inter
 
 The lounge prompt also gives sessions a tie-break rule so the conversation converges instead of ending in mutual politeness: whoever has commits or a PR beats whoever is still investigating; otherwise the earlier session continues; ties go to the lower thread ID. Whoever stands down pushes its branch first and hands over what it learned.
 
+### Automatic Collision Detection
+
+The lounge and claims both depend on a session *saying* something. This catches the overlaps nobody announced, from what the sessions actually did: if two live sessions write to the same file within 15 minutes, they are working on the same thing whether or not either mentioned it.
+
+`EventProcessor` records the path of every write-type tool call (`Write`, `Edit`, `MultiEdit`, `NotebookEdit`); `CollisionWatchCog` compares those sets across live sessions once a minute.
+
+> Why file paths and not working directories: on a single-user host every session tends to start in the same home directory, so `working_dir` equality flags every pair and means nothing. A shared *edited file* is almost never a coincidence. Reads are deliberately ignored — two sessions reading the same file is normal and would drown the signal.
+
+When an overlap is found, the watcher posts:
+
+- a line in the **AI Lounge**, which is injected into every session's next turn at no token cost and without interrupting anything, and
+- a message in **each colliding thread**, naming the peer, the shared files, and the endpoints that resolve it.
+
+It never relays into a running session — preempting a turn on a mere suspicion would cost more than the collision. Escalating is the sessions' decision, using the relay endpoint above. Each pair is announced at most once every 30 minutes, because a warning repeated every minute is a warning everyone learns to ignore.
+
+Enabled automatically; it stays dormant until two sessions actually overlap.
+
 ### Programmatic Session Creation
 
 Spawn new Claude Code sessions from scripts, GitHub Actions, or other Claude sessions — without Discord message interaction.

--- a/claude_discord/__init__.py
+++ b/claude_discord/__init__.py
@@ -14,6 +14,7 @@ from .claude.types import MessageType, StreamEvent, ToolCategory, ToolUseEvent
 from .cog_loader import load_custom_cogs
 from .cogs.auto_upgrade import AutoUpgradeCog, UpgradeConfig
 from .cogs.claude_chat import ClaudeChatCog
+from .cogs.collision_watch import CollisionWatchCog
 from .cogs.context_links import ContextLinksCog
 from .cogs.event_processor import EventProcessor
 from .cogs.run_config import RunConfig
@@ -49,6 +50,7 @@ __all__ = [
     "ActiveSession",
     "SessionRegistry",
     "SessionManageCog",
+    "CollisionWatchCog",
     "SkillCommandCog",
     "SessionRepository",
     "SettingsRepository",

--- a/claude_discord/bot.py
+++ b/claude_discord/bot.py
@@ -9,6 +9,7 @@ import discord
 from discord.ext import commands
 
 from .claude.types import AskOption, AskQuestion
+from .collision import FileActivityTracker
 from .concurrency import SessionRegistry
 from .discord_ui.ask_bus import ask_bus
 from .discord_ui.ask_view import AskView
@@ -46,6 +47,9 @@ class ClaudeDiscordBot(commands.Bot):
         self.channel_id = channel_id
         self.owner_id = owner_id
         self.session_registry = SessionRegistry()
+        # Which files each live session writes — CollisionWatchCog compares
+        # these to spot two sessions editing the same file.
+        self.file_activity = FileActivityTracker()
         # Optional repo for AskUserQuestion restart recovery
         self.ask_repo: PendingAskRepository | None = ask_repo
         # Populated after on_ready when the channel is resolved

--- a/claude_discord/cogs/__init__.py
+++ b/claude_discord/cogs/__init__.py
@@ -2,6 +2,7 @@
 
 from .auto_upgrade import AutoUpgradeCog
 from .claude_chat import ClaudeChatCog
+from .collision_watch import CollisionWatchCog
 from .context_links import ContextLinksCog
 from .event_processor import EventProcessor
 from .run_config import RunConfig
@@ -13,6 +14,7 @@ from .webhook_trigger import WebhookTriggerCog
 __all__ = [
     "AutoUpgradeCog",
     "ClaudeChatCog",
+    "CollisionWatchCog",
     "ContextLinksCog",
     "EventProcessor",
     "RunConfig",

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -1220,6 +1220,7 @@ class ClaudeChatCog(commands.Cog):
                     registry=self._registry,
                     ask_repo=self._ask_repo,
                     lounge_repo=self._lounge_repo,
+                    file_activity=getattr(self.bot, "file_activity", None),
                     stop_view=stop_view,
                     worktree_manager=getattr(self.bot, "worktree_manager", None),
                     images=images,

--- a/claude_discord/cogs/collision_watch.py
+++ b/claude_discord/cogs/collision_watch.py
@@ -1,0 +1,139 @@
+"""CollisionWatchCog — notice when two live sessions edit the same files.
+
+The lounge depends on sessions announcing themselves; a session that forgets is
+invisible, and those are exactly the ones that collide.  This Cog watches what
+sessions actually write (recorded by ``EventProcessor`` into a
+``FileActivityTracker``) and speaks up when two live threads touch the same
+file.
+
+Delivery is deliberately cheap:
+
+* a line in the **AI Lounge**, which is injected into every session's next turn
+  at no token cost and with no interruption, and
+* a message in **each colliding thread**, so the human watching sees it now.
+
+It never relays into a running session — that would preempt a turn on a mere
+suspicion.  Escalating is the sessions' decision, using the relay endpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING
+
+import discord
+from discord.ext import commands, tasks
+
+from ..collision import (
+    AlertLedger,
+    Collision,
+    FileActivityTracker,
+    build_collision_notice,
+    build_lounge_notice,
+    find_collisions,
+)
+
+if TYPE_CHECKING:
+    from ..concurrency import SessionRegistry
+    from ..database.lounge_repo import LoungeRepository
+
+logger = logging.getLogger(__name__)
+
+# Fast enough to catch an overlap while both sessions are still working, slow
+# enough to stay invisible in the bot's workload.
+POLL_INTERVAL_SECONDS = 60
+
+
+class CollisionWatchCog(commands.Cog):
+    """Poll the activity tracker and announce collisions between live sessions."""
+
+    def __init__(
+        self,
+        bot: commands.Bot,
+        *,
+        tracker: FileActivityTracker | None = None,
+        registry: SessionRegistry | None = None,
+        lounge_repo: LoungeRepository | None = None,
+        lounge_channel_id: int | None = None,
+    ) -> None:
+        self.bot = bot
+        self._tracker = tracker or getattr(bot, "file_activity", None)
+        self._registry = registry or getattr(bot, "session_registry", None)
+        self._lounge_repo = lounge_repo
+        self._lounge_channel_id = lounge_channel_id
+        self._ledger = AlertLedger()
+        if self._tracker is not None and self._registry is not None:
+            self.watch.start()
+
+    async def cog_unload(self) -> None:
+        self.watch.cancel()
+
+    @tasks.loop(seconds=POLL_INTERVAL_SECONDS)
+    async def watch(self) -> None:
+        """One detection pass. Never raises — a watcher must not kill the bot."""
+        try:
+            await self._check_once(time.monotonic())
+        except Exception:
+            logger.exception("Collision watch pass failed")
+
+    @watch.before_loop
+    async def _before(self) -> None:
+        await self.bot.wait_until_ready()
+
+    async def _check_once(self, now: float) -> None:
+        if self._tracker is None or self._registry is None:
+            return
+
+        live = {s.thread_id for s in self._registry.list_active()}
+        if len(live) < 2:
+            return
+
+        for collision in find_collisions(self._tracker.snapshot(live, now)):
+            if not self._ledger.should_alert(collision, now):
+                continue
+            self._ledger.record(collision, now)
+            logger.info(
+                "Collision detected between threads %s and %s on %s",
+                collision.threads[0],
+                collision.threads[1],
+                ", ".join(collision.shared_paths[:5]),
+            )
+            await self._announce(collision)
+
+    async def _announce(self, collision: Collision) -> None:
+        """Post to the lounge (reaches both sessions' next turn) and both threads."""
+        if self._lounge_repo is not None:
+            try:
+                await self._lounge_repo.post(
+                    message=build_lounge_notice(collision),
+                    label="collision-watch",
+                    thread_id=None,
+                )
+            except Exception:
+                logger.exception("Failed to post collision notice to the lounge")
+            await self._mirror_to_lounge_channel(build_lounge_notice(collision))
+
+        for thread_id in collision.threads:
+            channel = self.bot.get_channel(thread_id)
+            if not isinstance(channel, discord.Thread):
+                continue
+            try:
+                await channel.send(build_collision_notice(collision, for_thread=thread_id))
+            except Exception:
+                logger.exception("Failed to warn thread %s about a collision", thread_id)
+
+    async def _mirror_to_lounge_channel(self, text: str) -> None:
+        """Mirror the notice into the human-visible lounge channel, when configured."""
+        if self._lounge_channel_id is None:
+            return
+        channel = self.bot.get_channel(self._lounge_channel_id)
+        # discord.py's channel union has no common send(); category and private
+        # channels lack it, so probe at runtime and keep the handle untyped.
+        send = getattr(channel, "send", None)
+        if send is None:
+            return
+        try:
+            await send(f"**[collision-watch]** {text}")
+        except Exception:
+            logger.exception("Failed to mirror collision notice to the lounge channel")

--- a/claude_discord/cogs/event_processor.py
+++ b/claude_discord/cogs/event_processor.py
@@ -12,11 +12,13 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import time
 from pathlib import Path
 
 import discord
 
-from ..claude.types import AskQuestion, MessageType, SessionState, StreamEvent
+from ..claude.types import AskQuestion, MessageType, SessionState, StreamEvent, ToolUseEvent
+from ..collision import extract_written_path
 from ..discord_ui.chunker import _wrap_tables_in_fences, chunk_message
 from ..discord_ui.elicitation_view import ElicitationFormView, ElicitationUrlView
 from ..discord_ui.embeds import (
@@ -373,6 +375,11 @@ class EventProcessor:
         if event.tool_use and event.tool_use.tool_name == "ScheduleWakeup":
             self._pending_wakeup = dict(event.tool_use.tool_input)
 
+        # Remember files this session writes so collisions with other live
+        # sessions can be detected from behaviour, not from announcements.
+        if event.tool_use is not None:
+            self._record_file_activity(event.tool_use)
+
         # Tool use — post embed and start live timer. Skip in chat_only mode.
         if event.tool_use:
             if self._chat_only:
@@ -656,6 +663,15 @@ class EventProcessor:
             self._state.accumulated_text = event.text
             self._assistant_text_sent = True
             await self._bump_stop()
+
+    def _record_file_activity(self, tool_use: ToolUseEvent) -> None:
+        """Note a file write for cross-session collision detection (no-op when unwired)."""
+        tracker = self._config.file_activity
+        if tracker is None:
+            return
+        path = extract_written_path(tool_use.tool_name, tool_use.tool_input)
+        if path is not None:
+            tracker.record(self._config.thread.id, path, time.monotonic())
 
     async def _handle_tool_use(self, event: StreamEvent) -> None:
         """Post tool use embed and start the live timer."""

--- a/claude_discord/cogs/run_config.py
+++ b/claude_discord/cogs/run_config.py
@@ -25,6 +25,7 @@ from ..discord_ui.status import StatusManager
 
 if TYPE_CHECKING:
     from ..backend_settings import BackendSettings
+    from ..collision import FileActivityTracker
     from ..database.inbox_repo import ThreadInboxRepository
     from ..database.repository import UsageStatsRepository
     from ..discord_ui.thread_dashboard import ThreadStatusDashboard
@@ -80,6 +81,9 @@ class RunConfig:
     inbox_repo: ThreadInboxRepository | None = None
     inbox_dashboard: ThreadStatusDashboard | None = None
     usage_repo: UsageStatsRepository | None = None
+    # Records which files this session writes, so CollisionWatchCog can notice
+    # two live sessions editing the same file without either announcing it.
+    file_activity: FileActivityTracker | None = None
     claude_command: str = "claude"
     # When True, a compact guardrail was already injected into --append-system-prompt
     # for this run. Prevents infinite interrupt→rerun loops if compact fires again.

--- a/claude_discord/collision.py
+++ b/claude_discord/collision.py
@@ -1,0 +1,167 @@
+"""Structural collision detection between concurrent sessions.
+
+The AI Lounge only catches overlaps a session bothered to announce.  This
+module catches the ones nobody mentioned, from what the sessions actually did:
+if two live sessions have written to the same file in the last few minutes,
+they are working on the same thing whether or not either of them said so.
+
+Why file paths rather than working directories: on a single-user host every
+session tends to start in the same home directory, so ``working_dir`` equality
+flags every pair and means nothing.  A shared *edited file* is a signal that is
+almost never a coincidence.
+
+Everything here is pure and clock-injected — the bot supplies ``now`` — so the
+rules are testable without a running loop.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# Tools that change a file. Read/Grep/Glob are deliberately excluded: two
+# sessions reading the same file is normal and would drown the real signal.
+WRITE_TOOL_NAMES = frozenset({"Write", "Edit", "MultiEdit", "NotebookEdit"})
+
+# How long a write keeps counting as "current work".
+ACTIVITY_WINDOW_SECONDS = 15 * 60.0
+# Per pair of threads: never re-alert about the same collision this often.
+ALERT_COOLDOWN_SECONDS = 30 * 60.0
+# Bound on remembered paths per thread, so a long session cannot grow unbounded.
+MAX_PATHS_PER_THREAD = 200
+# Shared paths listed in a notice; the rest are summarised as a count.
+MAX_LISTED_PATHS = 5
+
+
+def extract_written_path(tool_name: str, tool_input: dict) -> str | None:
+    """Return the file path a tool is about to modify, if it modifies one."""
+    if tool_name not in WRITE_TOOL_NAMES:
+        return None
+    path = tool_input.get("file_path") or tool_input.get("notebook_path")
+    if not isinstance(path, str):
+        return None
+    path = path.strip()
+    return path or None
+
+
+@dataclass
+class FileActivityTracker:
+    """Remembers which files each thread wrote to, and when.
+
+    In-memory and process-local: after a restart there is no in-flight work to
+    compare, and persisting would resurrect stale collisions.
+    """
+
+    _writes: dict[int, dict[str, float]] = field(default_factory=dict)
+
+    def record(self, thread_id: int, path: str, now: float) -> None:
+        """Note that *thread_id* wrote *path* at *now* (monotonic seconds)."""
+        paths = self._writes.setdefault(thread_id, {})
+        paths[path] = now
+        if len(paths) > MAX_PATHS_PER_THREAD:
+            oldest = min(paths, key=lambda p: paths[p])
+            del paths[oldest]
+
+    def forget(self, thread_id: int) -> None:
+        """Drop a thread's history (its session ended)."""
+        self._writes.pop(thread_id, None)
+
+    def recent_paths(self, thread_id: int, now: float) -> set[str]:
+        """Paths this thread wrote inside the activity window."""
+        paths = self._writes.get(thread_id, {})
+        return {p for p, at in paths.items() if now - at <= ACTIVITY_WINDOW_SECONDS}
+
+    def snapshot(self, thread_ids: set[int], now: float) -> dict[int, set[str]]:
+        """Recent paths per thread, omitting threads with no recent writes."""
+        result = {}
+        for thread_id in thread_ids:
+            paths = self.recent_paths(thread_id, now)
+            if paths:
+                result[thread_id] = paths
+        return result
+
+
+@dataclass(frozen=True)
+class Collision:
+    """Two live threads that recently wrote to the same file(s)."""
+
+    threads: tuple[int, int]
+    shared_paths: tuple[str, ...]
+
+    def other(self, thread_id: int) -> int:
+        """The counterpart thread in this pair."""
+        first, second = self.threads
+        return second if thread_id == first else first
+
+
+def find_collisions(snapshot: dict[int, set[str]]) -> list[Collision]:
+    """Return every pair of threads sharing at least one recently written file.
+
+    Pairs are ordered (lower thread id first) so the same collision always has
+    the same identity, which is what makes de-duplication possible.
+    """
+    collisions: list[Collision] = []
+    thread_ids = sorted(snapshot)
+    for i, first in enumerate(thread_ids):
+        for second in thread_ids[i + 1 :]:
+            shared = snapshot[first] & snapshot[second]
+            if shared:
+                collisions.append(
+                    Collision(threads=(first, second), shared_paths=tuple(sorted(shared)))
+                )
+    return collisions
+
+
+@dataclass
+class AlertLedger:
+    """Remembers which collisions were already announced.
+
+    Without this, a 60-second watcher would repeat the same warning every minute
+    for as long as the overlap lasts — the fastest way to make sessions (and the
+    human reading the channel) learn to ignore it.
+    """
+
+    _last_alert: dict[tuple[int, int], float] = field(default_factory=dict)
+
+    def should_alert(self, collision: Collision, now: float) -> bool:
+        last = self._last_alert.get(collision.threads)
+        return last is None or now - last >= ALERT_COOLDOWN_SECONDS
+
+    def record(self, collision: Collision, now: float) -> None:
+        self._last_alert[collision.threads] = now
+
+
+def format_paths(paths: tuple[str, ...]) -> str:
+    """Render shared paths for a notice, capping the list length."""
+    listed = ", ".join(f"`{p}`" for p in paths[:MAX_LISTED_PATHS])
+    remaining = len(paths) - MAX_LISTED_PATHS
+    return f"{listed} (+{remaining} more)" if remaining > 0 else listed
+
+
+def build_collision_notice(collision: Collision, *, for_thread: int) -> str:
+    """The warning posted into a colliding thread.
+
+    It names the peer and the evidence, then points at the tools that resolve
+    it — a warning with no next step just becomes noise.
+    """
+    other = collision.other(for_thread)
+    return (
+        "⚠️ **Possible collision with another session**\n"
+        f"Thread `{other}` has written to the same file(s) in the last "
+        f"{int(ACTIVITY_WINDOW_SECONDS // 60)} minutes: {format_paths(collision.shared_paths)}\n"
+        "Neither of you announced this — it was detected from what you both actually edited.\n"
+        f"Look: `curl $CCDB_API_URL/api/threads/{other}/messages?limit=30` · "
+        f"talk: `POST $CCDB_API_URL/api/threads/{other}/message` · "
+        "claim next time: `POST $CCDB_API_URL/api/claims`"
+    )
+
+
+def build_lounge_notice(collision: Collision) -> str:
+    """The lounge line, which reaches every session's next turn for free."""
+    first, second = collision.threads
+    return (
+        f"⚠️ auto-detected collision: threads {first} and {second} both wrote "
+        f"{format_paths(collision.shared_paths)} in the last "
+        f"{int(ACTIVITY_WINDOW_SECONDS // 60)} minutes. "
+        "Whoever has commits or a PR continues; otherwise the earlier session continues. "
+        "The other should push its branch and stand down."
+    )

--- a/claude_discord/setup.py
+++ b/claude_discord/setup.py
@@ -156,6 +156,7 @@ async def setup_bridge(
         BridgeComponents with references to initialized repositories.
     """
     from .cogs.claude_chat import ClaudeChatCog
+    from .cogs.collision_watch import CollisionWatchCog
     from .cogs.context_links import ContextLinksCog
     from .cogs.scheduler import SchedulerCog
     from .cogs.session_manage import SessionManageCog
@@ -305,6 +306,16 @@ async def setup_bridge(
     )
     await bot.add_cog(chat_cog)
     logger.info("Registered ClaudeChatCog")
+
+    # --- CollisionWatchCog (auto-enabled; no-op until two sessions overlap) ---
+    await bot.add_cog(
+        CollisionWatchCog(
+            bot,
+            lounge_repo=lounge_repo,
+            lounge_channel_id=lounge_channel_id,
+        )
+    )
+    logger.info("Registered CollisionWatchCog")
 
     # --- SessionManageCog ---
     session_manage_cog = SessionManageCog(

--- a/tests/test_collision_detection.py
+++ b/tests/test_collision_detection.py
@@ -1,0 +1,304 @@
+"""Tests for structural collision detection between concurrent sessions.
+
+Covers:
+- extract_written_path (which tools count as a write)
+- FileActivityTracker windowing and bounding
+- find_collisions pairing
+- AlertLedger de-duplication
+- CollisionWatchCog end-to-end pass (lounge + both threads)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from claude_discord.cogs.collision_watch import CollisionWatchCog
+from claude_discord.collision import (
+    ACTIVITY_WINDOW_SECONDS,
+    ALERT_COOLDOWN_SECONDS,
+    MAX_PATHS_PER_THREAD,
+    AlertLedger,
+    Collision,
+    FileActivityTracker,
+    build_collision_notice,
+    extract_written_path,
+    find_collisions,
+)
+from claude_discord.concurrency import SessionRegistry
+
+A, B, C = 111, 222, 333
+SHARED = "/home/ebi/repo/parser.py"
+
+# ---------------------------------------------------------------------------
+# extract_written_path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tool", ["Write", "Edit", "MultiEdit"])
+def test_write_tools_yield_their_path(tool: str) -> None:
+    assert extract_written_path(tool, {"file_path": SHARED}) == SHARED
+
+
+def test_notebook_edit_uses_notebook_path() -> None:
+    assert extract_written_path("NotebookEdit", {"notebook_path": "/tmp/a.ipynb"}) == "/tmp/a.ipynb"
+
+
+@pytest.mark.parametrize("tool", ["Read", "Grep", "Glob", "Bash", "WebFetch"])
+def test_read_only_tools_are_ignored(tool: str) -> None:
+    """Two sessions reading the same file is normal — it must not be a signal."""
+    assert extract_written_path(tool, {"file_path": SHARED}) is None
+
+
+@pytest.mark.parametrize("payload", [{}, {"file_path": ""}, {"file_path": 42}])
+def test_missing_or_unusable_paths_yield_none(payload: dict) -> None:
+    assert extract_written_path("Edit", payload) is None
+
+
+# ---------------------------------------------------------------------------
+# FileActivityTracker
+# ---------------------------------------------------------------------------
+
+
+def test_recent_paths_respect_the_activity_window() -> None:
+    tracker = FileActivityTracker()
+    tracker.record(A, SHARED, now=0.0)
+
+    assert tracker.recent_paths(A, now=60.0) == {SHARED}
+    assert tracker.recent_paths(A, now=ACTIVITY_WINDOW_SECONDS + 1) == set()
+
+
+def test_snapshot_omits_threads_without_recent_writes() -> None:
+    tracker = FileActivityTracker()
+    tracker.record(A, SHARED, now=0.0)
+
+    assert tracker.snapshot({A, B}, now=10.0) == {A: {SHARED}}
+
+
+def test_forget_drops_a_threads_history() -> None:
+    tracker = FileActivityTracker()
+    tracker.record(A, SHARED, now=0.0)
+    tracker.forget(A)
+
+    assert tracker.snapshot({A}, now=1.0) == {}
+
+
+def test_tracker_is_bounded_and_evicts_the_oldest_path() -> None:
+    tracker = FileActivityTracker()
+    for i in range(MAX_PATHS_PER_THREAD + 10):
+        tracker.record(A, f"/tmp/f{i}.py", now=float(i))
+
+    paths = tracker.recent_paths(A, now=float(MAX_PATHS_PER_THREAD))
+    assert len(paths) <= MAX_PATHS_PER_THREAD
+    assert "/tmp/f0.py" not in paths
+
+
+# ---------------------------------------------------------------------------
+# find_collisions
+# ---------------------------------------------------------------------------
+
+
+def test_shared_path_produces_one_ordered_pair() -> None:
+    collisions = find_collisions({B: {SHARED, "/x.py"}, A: {SHARED}})
+
+    assert len(collisions) == 1
+    assert collisions[0].threads == (A, B)  # lower id first → stable identity
+    assert collisions[0].shared_paths == (SHARED,)
+    assert collisions[0].other(A) == B
+
+
+def test_disjoint_sessions_do_not_collide() -> None:
+    assert find_collisions({A: {"/a.py"}, B: {"/b.py"}}) == []
+
+
+def test_three_way_overlap_reports_every_pair() -> None:
+    collisions = find_collisions({A: {SHARED}, B: {SHARED}, C: {SHARED}})
+
+    assert {c.threads for c in collisions} == {(A, B), (A, C), (B, C)}
+
+
+# ---------------------------------------------------------------------------
+# AlertLedger
+# ---------------------------------------------------------------------------
+
+
+def test_ledger_suppresses_repeats_until_the_cooldown_passes() -> None:
+    ledger = AlertLedger()
+    collision = Collision(threads=(A, B), shared_paths=(SHARED,))
+
+    assert ledger.should_alert(collision, now=0.0) is True
+    ledger.record(collision, now=0.0)
+
+    assert ledger.should_alert(collision, now=60.0) is False
+    assert ledger.should_alert(collision, now=ALERT_COOLDOWN_SECONDS + 1) is True
+
+
+def test_notice_names_the_peer_the_files_and_what_to_do() -> None:
+    text = build_collision_notice(Collision(threads=(A, B), shared_paths=(SHARED,)), for_thread=A)
+
+    assert str(B) in text
+    assert SHARED in text
+    assert "/api/threads" in text and "/api/claims" in text
+
+
+# ---------------------------------------------------------------------------
+# CollisionWatchCog
+# ---------------------------------------------------------------------------
+
+
+def _make_bot(threads: dict[int, MagicMock]) -> MagicMock:
+    bot = MagicMock()
+    bot.file_activity = FileActivityTracker()
+    bot.session_registry = SessionRegistry()
+    bot.get_channel.side_effect = lambda cid: threads.get(cid)
+    return bot
+
+
+def _make_thread(thread_id: int) -> MagicMock:
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = thread_id
+    thread.send = AsyncMock()
+    return thread
+
+
+def _make_cog(bot: MagicMock) -> CollisionWatchCog:
+    lounge_repo = MagicMock()
+    lounge_repo.post = AsyncMock()
+    cog = CollisionWatchCog(bot, lounge_repo=lounge_repo)
+    cog.watch.cancel()  # drive _check_once by hand instead of on a timer
+    return cog
+
+
+async def test_watch_warns_both_threads_and_the_lounge() -> None:
+    threads = {A: _make_thread(A), B: _make_thread(B)}
+    bot = _make_bot(threads)
+    bot.session_registry.register(A, "task a", "/home/ebi")
+    bot.session_registry.register(B, "task b", "/home/ebi")
+    bot.file_activity.record(A, SHARED, now=0.0)
+    bot.file_activity.record(B, SHARED, now=1.0)
+    cog = _make_cog(bot)
+
+    await cog._check_once(now=2.0)
+
+    threads[A].send.assert_awaited_once()
+    threads[B].send.assert_awaited_once()
+    assert str(B) in threads[A].send.call_args.args[0]
+    assert str(A) in threads[B].send.call_args.args[0]
+    cog._lounge_repo.post.assert_awaited_once()
+
+
+async def test_repeat_pass_does_not_warn_twice() -> None:
+    threads = {A: _make_thread(A), B: _make_thread(B)}
+    bot = _make_bot(threads)
+    bot.session_registry.register(A, "task a", None)
+    bot.session_registry.register(B, "task b", None)
+    bot.file_activity.record(A, SHARED, now=0.0)
+    bot.file_activity.record(B, SHARED, now=0.0)
+    cog = _make_cog(bot)
+
+    await cog._check_once(now=1.0)
+    await cog._check_once(now=61.0)
+
+    assert threads[A].send.await_count == 1
+
+
+async def test_idle_peer_is_not_a_collision() -> None:
+    """A finished session's edits must not keep flagging a live one."""
+    threads = {A: _make_thread(A), B: _make_thread(B)}
+    bot = _make_bot(threads)
+    bot.session_registry.register(A, "task a", None)  # B is no longer running
+    bot.file_activity.record(A, SHARED, now=0.0)
+    bot.file_activity.record(B, SHARED, now=0.0)
+    cog = _make_cog(bot)
+
+    await cog._check_once(now=1.0)
+
+    threads[A].send.assert_not_awaited()
+    cog._lounge_repo.post.assert_not_awaited()
+
+
+async def test_thread_send_failure_does_not_stop_the_other_warning() -> None:
+    threads = {A: _make_thread(A), B: _make_thread(B)}
+    threads[A].send.side_effect = RuntimeError("Discord is having a day")
+    bot = _make_bot(threads)
+    bot.session_registry.register(A, "task a", None)
+    bot.session_registry.register(B, "task b", None)
+    bot.file_activity.record(A, SHARED, now=0.0)
+    bot.file_activity.record(B, SHARED, now=0.0)
+    cog = _make_cog(bot)
+
+    await cog._check_once(now=1.0)
+
+    threads[B].send.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# EventProcessor integration — the hook that feeds the tracker
+# ---------------------------------------------------------------------------
+
+
+def _tool_event(tool_name: str, tool_input: dict):
+    from claude_discord.claude.types import MessageType, StreamEvent, ToolCategory, ToolUseEvent
+
+    return StreamEvent(
+        message_type=MessageType.ASSISTANT,
+        tool_use=ToolUseEvent(
+            tool_id="t1",
+            tool_name=tool_name,
+            tool_input=tool_input,
+            category=ToolCategory.EDIT,
+        ),
+    )
+
+
+def _processor(tracker: FileActivityTracker, thread_id: int = A):
+    from claude_discord.cogs.event_processor import EventProcessor
+    from claude_discord.cogs.run_config import RunConfig
+
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = thread_id
+    thread.send = AsyncMock()
+    return EventProcessor(
+        RunConfig(
+            thread=thread,
+            runner=MagicMock(),
+            prompt="test prompt",
+            file_activity=tracker,
+            chat_only=True,  # skip embed posting; we only care about the recording
+        )
+    )
+
+
+async def test_event_processor_records_written_paths() -> None:
+    tracker = FileActivityTracker()
+    processor = _processor(tracker)
+
+    await processor.process(_tool_event("Edit", {"file_path": SHARED}))
+
+    assert tracker.recent_paths(A, now=0.0) == {SHARED}
+
+
+async def test_event_processor_ignores_reads() -> None:
+    tracker = FileActivityTracker()
+    processor = _processor(tracker)
+
+    await processor.process(_tool_event("Read", {"file_path": SHARED}))
+
+    assert tracker.recent_paths(A, now=0.0) == set()
+
+
+async def test_event_processor_without_tracker_is_a_noop() -> None:
+    """Consumers that never wire a tracker must not crash on tool use."""
+    from claude_discord.cogs.event_processor import EventProcessor
+    from claude_discord.cogs.run_config import RunConfig
+
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = A
+    thread.send = AsyncMock()
+    processor = EventProcessor(
+        RunConfig(thread=thread, runner=MagicMock(), prompt="p", chat_only=True)
+    )
+
+    await processor.process(_tool_event("Write", {"file_path": SHARED}))

--- a/uv.lock
+++ b/uv.lock
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-discord-bridge"
-version = "3.1.23"
+version = "3.1.24"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Why

#493 (see), #496 (claim), #498 (talk) all require a session to **say** something. The dangerous case is the session that says nothing — it is invisible to every mechanism built so far, and it is exactly the one that quietly edits the same file as its neighbour.

This detects that case from behaviour instead of announcements.

## What

- `EventProcessor` records the file path of every write-type tool call (`Write`, `Edit`, `MultiEdit`, `NotebookEdit`) into a per-thread `FileActivityTracker` on the bot.
- `CollisionWatchCog` polls once a minute: for every pair of **live** sessions sharing a recently written path, it announces the overlap.

### Why file paths, not working directories

On a single-user host every session tends to start in the same home directory — in this instance three concurrent sessions all reported `working_dir=/home/ebi`. Directory equality would flag every pair and therefore mean nothing. A shared *edited file* is almost never a coincidence.

Reads are excluded deliberately: two sessions reading the same file is normal, and including reads would drown the signal.

### How it announces

| Channel | Why |
|---|---|
| AI Lounge line | Injected into every session's next turn — no tokens, no interruption |
| Message in each colliding thread | The human watching sees it immediately, with the peer's thread id, the shared files, and the endpoints that resolve it |

It **never relays into a running session**. Preempting a turn on a mere suspicion costs more than the collision it would prevent; escalating is the sessions' own decision via `/api/threads/{id}/message`.

Each pair is announced at most **once per 30 minutes** — a warning repeated every 60 seconds is a warning everyone learns to filter out.

## Design notes

- All rules (`extract_written_path`, tracker windowing, `find_collisions`, `AlertLedger`) live in `claude_discord/collision.py` as pure, clock-injected code — testable with no bot and no timer.
- Pairs are ordered (lower thread id first) so a collision has a **stable identity**, which is what makes de-duplication possible at all.
- The tracker is in-memory and bounded (200 paths/thread, 15-minute window). Persisting it would resurrect stale collisions after a restart, when there is no in-flight work to compare.
- The watch loop swallows and logs exceptions: a watcher must never take the bot down.
- Auto-registered by `setup_bridge`; consumers that never wire a tracker get a silent no-op (`RunConfig.file_activity` defaults to `None`).

## Test plan

- [x] `tests/test_collision_detection.py` — 28 tests: which tools count as writes (incl. notebooks, and read-only tools ignored), tracker window/eviction/forget, pair discovery incl. three-way, ordered identity, ledger cooldown, notice content, and cog passes: warns both threads + lounge, does not warn twice, ignores an idle peer, survives a failing `thread.send`; plus EventProcessor integration (records writes, ignores reads, no-op without a tracker)
- [x] `ruff check` / `ruff format --check` / `pyright` clean
- [x] Suite: 1660 passed (excluding the two pre-existing issues noted in #493)