### PR TITLE
feat: /search command and GET /api/search for finding past threads by keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Find a past thread by keyword — `/search` slash command and `GET /api/search`** — Discord threads drop out of the sidebar once they auto-archive (they are never deleted, just hidden), and their titles are often vague, so a conversation you remember having becomes impossible to relocate. ccdb already stores a persistent per-thread `summary` (the opening prompt) for every session, so search needs no new storage, no re-indexing, and — crucially — no AI tokens: it is a `LIKE` query over `summary` and `working_dir` (the existing `SessionRepository.search()`), returning each hit with a **Discord deep-link** (`https://discord.com/channels/{guild}/{thread}`) that reopens even an archived thread with one click. The `/search <query>` slash command renders the hits as a scannable embed (origin icon, truncated summary, last-used time, working dir, jump link) and takes an optional `origin` filter (Discord/CLI); `GET /api/search?q=&origin=&limit=` exposes the same lookup on the localhost control plane for other Claude sessions and skills (JSON results with `deep_link`). Both cap results (embed 15, API max 50) and reject a blank query. Zero-Config: auto-wired, works against data ccdb already keeps. This is the lightweight "tier 0" of a search design — body-level search over local Claude transcripts is a deliberate follow-up, kept out to stay token-free.
+
 ## [3.2.0] - 2026-07-22
 
 ### Added

--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -69,6 +69,7 @@ _HELP_CATEGORY: dict[str, str | None] = {
     "context": "📌 Session",
     "usage": "📌 Session",
     "sessions": "📌 Session",
+    "search": "📌 Session",
     "resume": "📌 Session",
     "resume-info": "📌 Session",
     "sync-sessions": "📌 Session",

--- a/claude_discord/cogs/session_manage.py
+++ b/claude_discord/cogs/session_manage.py
@@ -17,7 +17,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from ..database.repository import SessionRepository, UsageStatsRepository
+from ..database.repository import SessionRecord, SessionRepository, UsageStatsRepository
 from ..database.settings_repo import SettingsRepository
 from ..discord_ui.embeds import COLOR_ERROR, COLOR_INFO, COLOR_SUCCESS, COLOR_TOOL
 from ..discord_ui.views import ResumeSelectView, ToolSelectView
@@ -82,6 +82,48 @@ KNOWN_TOOLS: list[str] = [
 
 
 _AUTOCOMPACT_THRESHOLD = 0.835  # Claude Code's default autocompact threshold
+
+# Max results shown by /search. Kept small so the embed stays scannable on mobile.
+_SEARCH_RESULT_LIMIT = 15
+
+
+def build_search_embed(
+    query: str,
+    records: list[SessionRecord],
+    *,
+    guild_id: int | None,
+) -> discord.Embed:
+    """Render /search hits as an embed with a Discord deep-link per thread.
+
+    The deep-link reopens even an archived (sidebar-hidden) thread, which is the
+    whole point: threads are never deleted, just hard to find again.
+    """
+    if not records:
+        return discord.Embed(
+            title=f"\U0001f50d Search: {query}",
+            description="No threads matched. Try a different keyword.",
+            color=COLOR_INFO,
+        )
+
+    embed = discord.Embed(
+        title=f"\U0001f50d Search: {query} ({len(records)})",
+        color=COLOR_INFO,
+    )
+    for record in records:
+        icon = _ORIGIN_ICON.get(record.origin, "❓")
+        summary = (record.summary or "(no summary)").replace("\n", " ")
+        name = f"{icon} {summary[:60]}"
+
+        parts: list[str] = []
+        if guild_id is not None:
+            link = f"https://discord.com/channels/{guild_id}/{record.thread_id}"
+            parts.append(f"[\U0001f517 open thread]({link})")
+        parts.append(record.last_used_at)
+        if record.working_dir:
+            parts.append(f"`{record.working_dir.rsplit('/', 1)[-1]}`")
+
+        embed.add_field(name=name, value=" · ".join(parts), inline=False)
+    return embed
 
 
 def _progress_bar(ratio: float, width: int = 20) -> str:
@@ -496,6 +538,36 @@ class SessionManageCog(commands.Cog):
 
             embed.add_field(name=name, value=value, inline=False)
 
+        await interaction.response.send_message(embed=embed)
+
+    @app_commands.command(
+        name="search",
+        description="Find a past thread by keyword (searches summaries)",
+    )
+    @app_commands.describe(
+        query="Keyword to look for in thread summaries",
+        origin="Filter by session origin",
+    )
+    @app_commands.choices(origin=_ORIGIN_CHOICES)
+    async def search_command(
+        self,
+        interaction: discord.Interaction,
+        query: str,
+        origin: str | None = None,
+    ) -> None:
+        """Search past threads by keyword and return clickable deep-links."""
+        query = (query or "").strip()
+        if not query:
+            await interaction.response.send_message(
+                "❌ Enter a keyword to search for.", ephemeral=True
+            )
+            return
+
+        origin_filter = None if origin in (None, "all") else origin
+        records = await self.repo.search(
+            query=query, origin=origin_filter, limit=_SEARCH_RESULT_LIMIT
+        )
+        embed = build_search_embed(query, records, guild_id=interaction.guild_id)
         await interaction.response.send_message(embed=embed)
 
     @app_commands.command(

--- a/claude_discord/ext/api_server.py
+++ b/claude_discord/ext/api_server.py
@@ -73,6 +73,8 @@ _DEFAULT_SESSION_LIMIT = 20
 _MAX_SESSION_LIMIT = 100
 _DEFAULT_THREAD_MESSAGE_LIMIT = 30
 _MAX_THREAD_MESSAGE_LIMIT = 100
+_DEFAULT_SEARCH_LIMIT = 15
+_MAX_SEARCH_LIMIT = 50
 # How far back to scan the lounge when attaching each thread's latest note.
 _LOUNGE_LOOKBACK = 50
 # Per-message cap; a single Claude reply can be many KB of code.
@@ -281,6 +283,7 @@ class ApiServer:
         self.app.router.add_delete("/api/claims", self.delete_claim)
         # Cross-session observability routes (requires session_repo)
         self.app.router.add_get("/api/sessions", self.list_sessions)
+        self.app.router.add_get("/api/search", self.search_sessions)
         self.app.router.add_get("/api/threads/{thread_id}/messages", self.get_thread_messages)
         self.app.router.add_post("/api/threads/{thread_id}/message", self.relay_thread_message)
         # Session spawn route
@@ -1146,6 +1149,82 @@ class ApiServer:
             views = [v for v in views if v["thread_id"] != exclude_thread]
 
         return web.json_response({"sessions": views})
+
+    async def search_sessions(self, request: web.Request) -> web.Response:
+        """GET /api/search — find a past thread by keyword.
+
+        Discord threads vanish from the sidebar once they auto-archive, and
+        their titles are often vague.  This searches the persistent per-thread
+        ``summary`` (the opening prompt, already stored for every session) plus
+        the working directory, and returns a Discord deep-link so an archived
+        thread can be reopened with one click.  No AI tokens, no new storage —
+        just a ``LIKE`` query over data ccdb already keeps.
+
+        Query params:
+            q: Keyword (required, non-blank). Matched against summary and
+               working_dir (case-insensitive substring).
+            origin: ``discord`` or ``cli`` to filter by session origin.
+            limit: Max results (default 15, max 50).
+        """
+        if err := self._require_session_repo():
+            return err
+
+        query = (request.rel_url.query.get("q") or "").strip()
+        if not query:
+            return web.json_response({"error": "q must be a non-blank string"}, status=400)
+
+        try:
+            raw_limit = request.rel_url.query.get("limit", str(_DEFAULT_SEARCH_LIMIT))
+            limit = max(1, min(_MAX_SEARCH_LIMIT, int(raw_limit)))
+        except ValueError:
+            return web.json_response({"error": "limit must be an integer"}, status=400)
+
+        origin = request.rel_url.query.get("origin")
+        if origin not in (None, "discord", "cli"):
+            return web.json_response({"error": "origin must be 'discord' or 'cli'"}, status=400)
+
+        records = await self.session_repo.search(  # type: ignore[union-attr]
+            query=query, origin=origin, limit=limit
+        )
+        names = self._thread_names({r.thread_id for r in records})
+        guild_id = self._guild_id()
+
+        results = [
+            {
+                "thread_id": r.thread_id,
+                "session_id": r.session_id,
+                "thread_name": names.get(r.thread_id),
+                "summary": r.summary,
+                "working_dir": r.working_dir,
+                "origin": r.origin,
+                "last_used_at": r.last_used_at,
+                "deep_link": (
+                    f"https://discord.com/channels/{guild_id}/{r.thread_id}"
+                    if guild_id is not None
+                    else None
+                ),
+            }
+            for r in records
+        ]
+        return web.json_response({"query": query, "results": results})
+
+    def _guild_id(self) -> int | None:
+        """Best-effort guild ID for building thread deep-links.
+
+        Tries the configured default channel's guild first, then any guild the
+        bot is a member of.  Deep-links work for archived threads too, so this
+        does not depend on the thread being in the channel cache.
+        """
+        if self.default_channel_id is not None:
+            channel = self.bot.get_channel(self.default_channel_id)
+            gid = getattr(getattr(channel, "guild", None), "id", None)
+            if isinstance(gid, int):
+                return gid
+        for guild in getattr(self.bot, "guilds", None) or []:
+            gid = getattr(guild, "id", None)
+            if isinstance(gid, int):
+                return gid
+        return None
 
     def _thread_names(self, thread_ids: set[int]) -> dict[int, str]:
         """Resolve Discord thread titles from the bot's cache (no API calls)."""

--- a/tests/test_api_search.py
+++ b/tests/test_api_search.py
@@ -1,0 +1,131 @@
+"""Tests for GET /api/search — lightweight thread/conversation lookup.
+
+The endpoint lets a human (via the /search slash command) or another Claude
+session find a past thread by keyword, using the persistent per-thread
+``summary`` (opening prompt) already stored in the sessions DB. No AI tokens,
+no new storage — just a LIKE query plus a Discord deep-link so archived
+threads can be reopened.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from claude_discord.database.lounge_repo import LoungeRepository
+from claude_discord.database.models import init_db
+from claude_discord.database.notification_repo import NotificationRepository
+from claude_discord.database.repository import SessionRepository
+from claude_discord.ext.api_server import ApiServer
+
+
+@pytest.fixture
+async def db_path() -> str:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    await init_db(path)
+    yield path
+    os.unlink(path)
+
+
+@pytest.fixture
+def bot() -> MagicMock:
+    b = MagicMock()
+    b.cogs = {}
+    # No cached channels (mirrors archived threads not being in cache), but the
+    # bot is in one guild, so deep-links can still be built.
+    b.get_channel.return_value = None
+    b.fetch_channel = AsyncMock(side_effect=RuntimeError("Unknown Channel"))
+    b.guilds = [MagicMock(id=111)]
+    return b
+
+
+@pytest.fixture
+async def seeded_repo(db_path: str) -> SessionRepository:
+    repo = SessionRepository(db_path)
+    await repo.save(
+        thread_id=1001,
+        session_id="sess-aaa",
+        summary="Fix Substack sync failure for the note automation",
+        working_dir="/home/ebi",
+        origin="discord",
+    )
+    await repo.save(
+        thread_id=1002,
+        session_id="sess-bbb",
+        summary="Design a lightweight search feature for ccdb threads",
+        working_dir="/home/ebi",
+        origin="discord",
+    )
+    await repo.save(
+        thread_id=1003,
+        session_id="sess-ccc",
+        summary="Deploy JAIX dashboard to production",
+        working_dir="/home/ebi/infra",
+        origin="cli",
+    )
+    return repo
+
+
+@pytest.fixture
+async def api_client(db_path: str, bot: MagicMock, seeded_repo: SessionRepository) -> TestClient:
+    notif_repo = NotificationRepository(db_path)
+    await notif_repo.init_db()
+    api = ApiServer(
+        repo=notif_repo,
+        bot=bot,
+        default_channel_id=12345,
+        host="127.0.0.1",
+        port=0,
+        session_repo=seeded_repo,
+        lounge_repo=LoungeRepository(db_path),
+    )
+    server = TestServer(api.app)
+    client = TestClient(server)
+    await client.start_server()
+    yield client
+    await client.close()
+
+
+async def test_search_matches_summary_keyword(api_client: TestClient) -> None:
+    resp = await api_client.get("/api/search", params={"q": "substack"})
+    assert resp.status == 200
+    body = await resp.json()
+    assert body["query"] == "substack"
+    thread_ids = [r["thread_id"] for r in body["results"]]
+    assert thread_ids == [1001]
+    hit = body["results"][0]
+    assert hit["deep_link"] == "https://discord.com/channels/111/1001"
+    assert "Substack" in hit["summary"]
+
+
+async def test_search_matches_working_dir(api_client: TestClient) -> None:
+    resp = await api_client.get("/api/search", params={"q": "infra"})
+    body = await resp.json()
+    assert [r["thread_id"] for r in body["results"]] == [1003]
+
+
+async def test_search_origin_filter(api_client: TestClient) -> None:
+    resp = await api_client.get("/api/search", params={"q": "home", "origin": "cli"})
+    body = await resp.json()
+    assert [r["thread_id"] for r in body["results"]] == [1003]
+
+
+async def test_search_empty_query_is_rejected(api_client: TestClient) -> None:
+    resp = await api_client.get("/api/search", params={"q": "  "})
+    assert resp.status == 400
+
+
+async def test_search_no_matches_returns_empty_list(api_client: TestClient) -> None:
+    resp = await api_client.get("/api/search", params={"q": "nonexistentzzz"})
+    body = await resp.json()
+    assert body["results"] == []
+
+
+async def test_search_limit_is_capped(api_client: TestClient) -> None:
+    resp = await api_client.get("/api/search", params={"q": "home", "limit": "99999"})
+    assert resp.status == 200

--- a/tests/test_search_command.py
+++ b/tests/test_search_command.py
@@ -1,0 +1,79 @@
+"""Tests for the /search slash command (SessionManageCog)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+
+from claude_discord.cogs.session_manage import SessionManageCog, build_search_embed
+from claude_discord.database.repository import SessionRecord
+
+
+def _record(thread_id: int, summary: str, *, origin: str = "discord") -> SessionRecord:
+    return SessionRecord(
+        thread_id=thread_id,
+        session_id=f"sess-{thread_id}",
+        working_dir="/home/ebi",
+        model=None,
+        origin=origin,
+        summary=summary,
+        created_at="2026-07-22 10:00:00",
+        last_used_at="2026-07-23 09:00:00",
+    )
+
+
+def test_build_search_embed_includes_deep_link() -> None:
+    embed = build_search_embed(
+        "substack",
+        [_record(1001, "Fix Substack sync failure")],
+        guild_id=111,
+    )
+    body = "\n".join(f.value for f in embed.fields)
+    assert "https://discord.com/channels/111/1001" in body
+
+
+def test_build_search_embed_no_results() -> None:
+    embed = build_search_embed("zzz", [], guild_id=111)
+    assert embed.description is not None
+    assert "No" in embed.description or "見つかりません" in embed.description
+
+
+def test_build_search_embed_without_guild_omits_link() -> None:
+    embed = build_search_embed("x", [_record(1, "something")], guild_id=None)
+    body = "\n".join(f.value for f in embed.fields)
+    assert "discord.com/channels" not in body
+
+
+def _make_cog() -> SessionManageCog:
+    bot = MagicMock()
+    repo = MagicMock()
+    repo.search = AsyncMock(return_value=[_record(1001, "Fix Substack sync failure")])
+    return SessionManageCog(bot=bot, repo=repo)
+
+
+async def test_search_command_queries_repo_and_replies() -> None:
+    cog = _make_cog()
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.guild_id = 111
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+
+    await cog.search_command.callback(cog, interaction, query="substack", origin=None)
+
+    cog.repo.search.assert_awaited_once()
+    assert cog.repo.search.await_args.kwargs["query"] == "substack"
+    interaction.response.send_message.assert_awaited_once()
+
+
+async def test_search_command_rejects_blank_query() -> None:
+    cog = _make_cog()
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.guild_id = 111
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+
+    await cog.search_command.callback(cog, interaction, query="   ", origin=None)
+
+    cog.repo.search.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()


### PR DESCRIPTION
## Why

Discord threads drop out of the sidebar once they auto-archive — they are never deleted, just hidden — and their auto-generated titles are often vague. A conversation you *remember* having becomes impossible to relocate. This is "tier 0" of a lightweight search design: find the thread cheaply, then jump to it.

## What

ccdb already stores a persistent per-thread `summary` (the opening prompt) for **every** session. So search needs:
- **no new storage**, **no re-indexing**, and **no AI tokens** — it's a `LIKE` query over `summary` + `working_dir` (the existing `SessionRepository.search()`).

Two surfaces:
- **`/search <query>` slash command** — renders hits as a scannable embed (origin icon, truncated summary, last-used time, working dir, **jump link**). Optional `origin` filter (Discord/CLI).
- **`GET /api/search?q=&origin=&limit=`** — same lookup on the localhost control plane, for other Claude sessions/skills. JSON results each carry a `deep_link` (`https://discord.com/channels/{guild}/{thread}`) that **reopens even an archived thread** with one click.

Both cap results (embed 15, API max 50) and reject a blank query. Zero-Config: auto-wired, works against data ccdb already keeps.

## Deliberately out of scope

Body-level search (grepping the middle of conversations) is a planned follow-up via local Claude transcripts — kept out here to stay token-free and light.

## Test plan

- [x] `tests/test_api_search.py` — endpoint: summary match, working_dir match, origin filter, blank-query 400, no-match empty, limit cap, deep-link shape
- [x] `tests/test_search_command.py` — `build_search_embed` (deep-link present / omitted when no guild / empty state) + command callback (queries repo, rejects blank)
- [x] 130 related tests pass (`test_api_search`, `test_search_command`, `test_session_manage`, `test_session_search`, `test_session_observability`, `test_api_server`)
- [x] ruff check + ruff format + pyright clean on changed files
- [x] Verified read-only against the real 454-thread DB — Japanese and English keywords both hit
- [ ] Live `/search` in Discord (needs a bot restart; deferred to a quiet window so concurrent sessions aren't interrupted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)