### PR TITLE
fix: warn agents that working directory does not persist between messages

### DIFF
--- a/claude_discord/concurrency.py
+++ b/claude_discord/concurrency.py
@@ -45,6 +45,13 @@ Check `git status` and recent file modification times before overwriting.
 3. **Ports & processes**: Shared network ports or lock files may already be in use.
 4. **Resources**: Shared databases, APIs with rate limits, or singleton processes \
 may be accessed concurrently.
+5. **Working directory does NOT persist between messages**: Each of your \
+Discord replies runs in a FRESH process that starts in the base working \
+directory. A `cd` only lasts for the current message — it is gone by your next \
+reply, and the shell resets. So a relative-path script you set up in one \
+message will silently run in the WRONG directory later. ALWAYS use absolute \
+paths (for scripts, `os.chdir` to an absolute path at startup); for long jobs \
+or large output, write results to an absolute-path log file and read it back.
 
 CRITICAL: If your target repository is the same as another active session's, \
 you MUST use a separate worktree or stop and warn the user. \

--- a/tests/test_session_registry.py
+++ b/tests/test_session_registry.py
@@ -154,3 +154,18 @@ class TestConcurrencyNotice:
         registry.register(1001, "my task")
         notice = registry.build_concurrency_notice(1001)
         assert "[this thread]" in notice
+
+    def test_notice_warns_cwd_not_persistent_across_messages(self) -> None:
+        """Each Discord message spawns a fresh subprocess, so the shell's
+        working directory does NOT survive between turns.
+
+        Agents that ``cd`` in one message and run a relative-path script in a
+        later message silently execute in the wrong directory. The notice must
+        warn about this and tell agents to use absolute paths.
+        """
+        registry = SessionRegistry()
+        registry.register(1001, "my task")
+        notice = registry.build_concurrency_notice(1001).lower()
+        # Warns that cwd / working directory is not preserved between messages
+        assert "cwd" in notice or "working directory" in notice
+        assert "absolute path" in notice


### PR DESCRIPTION
Each Discord reply spawns a **fresh** `claude -p --resume` subprocess (`runner.py:139`), started at `cwd = working_dir or os.getcwd()`. `--resume` restores the conversation transcript, but the Bash tool's persistent shell is a brand-new process every turn, so any `cd` from a previous message is gone and cwd resets to the base working directory.

This bites silently: an agent that `cd`s in one message and runs a relative-path script in a later message executes in the wrong directory and the failure looks like success.

This is inherent to the CLI-spawn + thread=session design (a dead shell's cwd cannot be restored), so rather than trying to restore cwd, this PR **warns** agents at session start.

## Change
Add rule 5 to the session-start concurrency notice: working directory does not persist between messages; always use absolute paths (`os.chdir` to an absolute path at script startup; write long-job output to an absolute-path log file and read it back).

## Test plan
- [x] New test `test_notice_warns_cwd_not_persistent_across_messages` (RED → GREEN)
- [x] `test_session_registry.py` + `test_lounge.py`: 53 passed
- [x] `ruff check` / `ruff format --check` / `pyright` clean