### PR TITLE
docs: sync README (EN+JA) with body search (#507)

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Behind the scenes:
 - **Built-in help** — `/help` shows all available slash commands and basic usage (ephemeral, only visible to the caller)
 - **Session sync** — Import CLI sessions as Discord threads (`/sync-sessions`); `/sync-settings` to view or change sync preferences (thread style, time window, minimum results)
 - **Session list** — `/sessions` with filtering by origin (Discord / CLI / all) and time window
-- **Thread search** — `/search <query>` finds a past thread by keyword, matching the persistent per-thread summary (the opening prompt) and working directory; renders hits as a scannable embed with a Discord deep-link that reopens even an archived (sidebar-hidden) thread; optional `origin` filter (Discord / CLI). The same lookup is exposed as `GET /api/search` for other sessions and skills. No AI tokens — a `LIKE` query over data ccdb already keeps
+- **Thread search** — `/search <query>` finds a past thread by keyword, matching the persistent per-thread summary (the opening prompt) and working directory; renders hits as a scannable embed with a Discord deep-link that reopens even an archived (sidebar-hidden) thread; optional `origin` filter (Discord / CLI). Add `body:True` to also grep the full local Claude transcripts (`~/.claude/projects`), so keywords that appear only mid-conversation are found too — each body hit shows the matching snippet with a `💬` badge, and a transcript with no Discord thread offers a `claude --resume <id>` hint instead of a link. The same lookup is exposed as `GET /api/search` (add `body=1`) for other sessions and skills. No AI tokens — a `LIKE` query over data ccdb already keeps, plus a safe `grep` (never `shell=True`) over the transcripts on disk
 - **Session resume** — `/resume` shows a select menu of recent sessions (up to 25) and resumes the selected one in a new thread; optional `query` parameter for keyword search (matches summary and working directory); optional `filter=orphaned` to show only sessions from deleted threads; works from any channel or thread — always creates a new thread in the configured main channel
 - **Resume info** — `/resume-info` shows the CLI command to continue the current session in a terminal (thread-only)
 - **Clear session** — `/clear` resets the Claude Code session for the current thread, starting fresh without creating a new thread
@@ -725,7 +725,7 @@ In chat-only mode, permission requests and `AskUserQuestion` prompts are **alway
 | `INLINE_REPLY_CHANNEL_IDS` | Comma-separated channel IDs where the bot replies inline (no thread created) | (optional) |
 | `CHAT_ONLY_CHANNEL_IDS` | Comma-separated channel IDs in chat-only mode — only Claude's text responses are shown; all technical embeds (tools, thinking, session info, todos) are hidden | (optional) |
 | `WORKTREE_BASE_DIR` | Base directory to scan for session worktrees (enables automatic cleanup) | (optional) |
-| `CLI_SESSIONS_PATH` | Path to `~/.claude/projects` for CLI session discovery (enables `/sync-sessions`) | (optional) |
+| `CLI_SESSIONS_PATH` | Path to `~/.claude/projects` for CLI session discovery (enables `/sync-sessions`) and transcript body search (`/search body:True`, `GET /api/search?body=1`). Defaults to the standard `~/.claude/projects`, so body search stays Zero-Config wherever Claude Code has run | (optional) |
 | `CUSTOM_COGS_DIR` | Directory containing custom Cog files to load at startup (see [Custom Cogs](#custom-cogs-extend-without-forking)) | (optional) |
 | `CLAUDE_ALLOWED_TOOLS` | Comma-separated list of allowed tools for Claude CLI (legacy — prefer `CCDB_ALLOWED_TOOLS`) | (optional) |
 | `CLAUDE_CHANNEL_IDS` | Additional channel IDs (comma-separated) for multi-channel setup (legacy — prefer `CCDB_CHANNEL_IDS`) | (optional) |
@@ -968,7 +968,7 @@ uv add "claude-code-discord-bridge[api]"
 | GET | `/api/lounge` | Read recent AI Lounge messages |
 | POST | `/api/lounge` | Post a message to the AI Lounge (with optional `label`) |
 | GET | `/api/sessions` | List every session — live and stored — with state, working dir and latest lounge note (`state=running`, `exclude_thread`, `limit`) |
-| GET | `/api/search` | Find a past thread by keyword — `LIKE` over summary and working dir; returns each hit with a Discord `deep_link` (`q` required, optional `origin`, `limit` max 50) |
+| GET | `/api/search` | Find a past thread by keyword — `LIKE` over summary and working dir; add `body=1` to also grep local Claude transcripts (each hit then carries a `snippet` and `source`); returns each hit with a Discord `deep_link` (`q` required, optional `origin`, `limit` max 50) |
 | GET | `/api/threads/{thread_id}/messages` | Read another thread's conversation, oldest first (`limit`) |
 | POST | `/api/claims` | Claim a resource before working on it — 201 when acquired, 409 with the holder when taken |
 | GET | `/api/claims` | List live claims (optional `resource` filter) |
@@ -1022,6 +1022,8 @@ claude_code_core/          # Shared core library (backend-agnostic)
   types.py                 # Type definitions for SDK messages
   models.py                # SQLite schema
   session_repo.py          # Session CRUD
+  thread_search.py         # /search orchestration — summary + body merge, dedupe by thread
+  transcript_search.py     # grep/scan of ~/.claude/projects transcripts + snippet extraction
   lounge_repo.py           # AI Lounge message CRUD
   rewind.py                # Session rewind helpers
 claude_discord/

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -361,7 +361,7 @@ ccdb がバックエンド情報を記録する前に作成されたレコード
 - **組み込みヘルプ** — `/help` で利用可能な全スラッシュコマンドと基本的な使い方を表示（エフェメラル表示、呼び出し者のみ表示）
 - **セッション同期** — CLI セッションを Discord スレッドにインポート（`/sync-sessions`）。`/sync-settings` で同期設定（スレッドスタイル、時間範囲、最小件数）の表示・変更が可能
 - **セッション一覧** — 起動元（Discord / CLI / 全て）と時間範囲でフィルタリング（`/sessions`）
-- **スレッド検索** — `/search <query>` でキーワードから過去のスレッドを検索。スレッドごとに永続保存されたサマリー（最初のプロンプト）と作業ディレクトリにマッチし、ヒットを一覧しやすい embed で表示。アーカイブされて（サイドバーから消えた）スレッドもワンクリックで開き直せる Discord ディープリンク付き。任意の `origin` フィルタ（Discord / CLI）に対応。同じ検索を `GET /api/search` として他セッション・スキルにも公開。AI トークン不要 — ccdb が既に保持しているデータへの `LIKE` クエリのみ
+- **スレッド検索** — `/search <query>` でキーワードから過去のスレッドを検索。スレッドごとに永続保存されたサマリー（最初のプロンプト）と作業ディレクトリにマッチし、ヒットを一覧しやすい embed で表示。アーカイブされて（サイドバーから消えた）スレッドもワンクリックで開き直せる Discord ディープリンク付き。任意の `origin` フィルタ（Discord / CLI）に対応。`body:True` を付けるとローカルの Claude トランスクリプト（`~/.claude/projects`）全体も grep し、会話の途中にしか出てこないキーワードも見つけられる — body ヒットには一致したスニペットが `💬` バッジ付きで表示され、Discord スレッドのないトランスクリプトはリンクの代わりに `claude --resume <id>` のヒントを表示。同じ検索を `GET /api/search`（`body=1` を付ける）として他セッション・スキルにも公開。AI トークン不要 — ccdb が既に保持しているデータへの `LIKE` クエリと、ディスク上のトランスクリプトへの安全な `grep`（`shell=True` は不使用）のみ
 - **セッションリジューム** — `/resume` で直近のセッション一覧（最大 25 件）をセレクトメニューで表示し、選択したセッションを新スレッドで再開。オプションの `query` パラメータでキーワード検索（サマリーと作業ディレクトリにマッチ）、`filter=orphaned` で削除済みスレッドのセッションのみ表示。任意のチャンネルやスレッドから実行可能 — 常に設定されたメインチャンネルに新スレッドを作成
 - **リジューム情報** — 現在のセッションをターミナルで継続する CLI コマンドを表示（`/resume-info`、スレッド内限定）
 - **セッションクリア** — `/clear` で現在のスレッドの Claude Code セッションをリセットし、新スレッドを作成せずにゼロから再開
@@ -727,7 +727,7 @@ CHAT_ONLY_CHANNEL_IDS=444,555
 | `INLINE_REPLY_CHANNEL_IDS` | インライン返信チャンネル ID（カンマ区切り、スレッドを作成しない） | （オプション） |
 | `CHAT_ONLY_CHANNEL_IDS` | チャットのみモードのチャンネル ID（カンマ区切り）— Claude のテキスト応答のみ表示。ツール embed・思考・セッション情報・Todo はすべて非表示 | （オプション） |
 | `WORKTREE_BASE_DIR` | セッション Worktree のスキャン対象ディレクトリ（自動クリーンアップを有効化） | （オプション） |
-| `CLI_SESSIONS_PATH` | CLI セッション検出用のパス（`~/.claude/projects`）。`/sync-sessions` の有効化に必要 | （オプション） |
+| `CLI_SESSIONS_PATH` | CLI セッション検出用のパス（`~/.claude/projects`）。`/sync-sessions` の有効化と、トランスクリプトの本文検索（`/search body:True`、`GET /api/search?body=1`）に使用。デフォルトは標準の `~/.claude/projects` なので、Claude Code を実行した環境ならゼロコンフィグで本文検索が使える | （オプション） |
 | `CUSTOM_COGS_DIR` | 起動時に読み込むカスタム Cog ファイルを含むディレクトリ（[カスタム Cog](#カスタム-cogフォーク不要で機能拡張) 参照） | （オプション） |
 | `CLAUDE_ALLOWED_TOOLS` | Claude CLI に許可するツールのカンマ区切りリスト（旧名 — `CCDB_ALLOWED_TOOLS` を推奨） | （オプション） |
 | `CLAUDE_CHANNEL_IDS` | マルチチャンネル設定用の追加チャンネル ID（旧名 — `CCDB_CHANNEL_IDS` を推奨） | （オプション） |
@@ -970,7 +970,7 @@ uv add "claude-code-discord-bridge[api]"
 | GET | `/api/lounge` | AI Lounge の最近のメッセージを取得 |
 | POST | `/api/lounge` | AI Lounge にメッセージを投稿（`label` オプション） |
 | GET | `/api/sessions` | すべてのセッション（ライブ・保存済み）を状態・作業ディレクトリ・最新のラウンジメモ付きで一覧（`state=running`、`exclude_thread`、`limit`） |
-| GET | `/api/search` | キーワードから過去のスレッドを検索 — サマリーと作業ディレクトリへの `LIKE` クエリ。各ヒットを Discord `deep_link` 付きで返す（`q` 必須、任意の `origin`、`limit` は最大 50） |
+| GET | `/api/search` | キーワードから過去のスレッドを検索 — サマリーと作業ディレクトリへの `LIKE` クエリ。`body=1` を付けるとローカルの Claude トランスクリプトも grep（各ヒットに `snippet` と `source` が付く）。各ヒットを Discord `deep_link` 付きで返す（`q` 必須、任意の `origin`、`limit` は最大 50） |
 | GET | `/api/threads/{thread_id}/messages` | 他スレッドの会話を古い順に取得（`limit`） |
 | POST | `/api/claims` | 作業開始前にリソースを宣言 — 取得成功で 201、取得済みなら保持者情報付きで 409 |
 | GET | `/api/claims` | 有効なクレームの一覧（`resource` フィルター任意） |
@@ -1024,6 +1024,8 @@ claude_code_core/          # バックエンド非依存のコアライブラリ
   types.py                 # SDK メッセージの型定義
   models.py                # SQLite スキーマ
   session_repo.py          # セッション CRUD
+  thread_search.py         # /search のオーケストレーション — サマリー + 本文をマージしスレッド単位で重複排除
+  transcript_search.py     # ~/.claude/projects トランスクリプトの grep/スキャン + スニペット抽出
   lounge_repo.py           # AI Lounge メッセージ CRUD
   rewind.py                # セッションリワインドヘルパー
 claude_discord/


### PR DESCRIPTION
## Summary / 概要

Sync README documentation (English + Japanese) with the **body search** feature landed in #507 (`feat: body search over local Claude transcripts`).

#507 でマージされた **本文検索** 機能（`/search body:True` / `GET /api/search?body=1`）に合わせて、README（英語＋日本語）を同期します。#507 は CHANGELOG のみ更新しており、README は未反映でした。

## Changes / 変更点

Both `README.md` and `docs/ja/README.md` updated symmetrically in 4 places:

- **Thread search feature bullet** — document the `body:True` option: greps local Claude transcripts (`~/.claude/projects`) for keywords that appear only mid-conversation, shows a snippet with a `💬` badge, and offers a `claude --resume <id>` hint when a transcript has no Discord thread. Token-free (`grep`, never `shell=True`).
- **`CLI_SESSIONS_PATH` env var** — note it now also drives transcript body search and defaults to `~/.claude/projects` (Zero-Config).
- **`GET /api/search` API table** — document the `body=1` query param and the added `snippet` / `source` fields.
- **Project structure** — add the two new core files `claude_code_core/thread_search.py` and `claude_code_core/transcript_search.py`.

英語・日本語の両 README を上記4箇所で対称的に更新しています。

## Test plan / テスト

- [x] Docs-only change — no code touched
- [x] English and Japanese kept in sync (same 4 sections)
- [x] Markdown formatting, code blocks, links, and badges preserved
