### PR TITLE
fix: serialize per-thread Claude runs to prevent parallel processes

### DIFF
--- a/claude_discord/cogs/claude_chat.py
+++ b/claude_discord/cogs/claude_chat.py
@@ -847,19 +847,11 @@ class ClaudeChatCog(commands.Cog):
         if record is not None and session_id:
             session_id = await self._session_id_for_current_backend(thread, record)
 
-        lock = self._thread_locks.setdefault(thread.id, asyncio.Lock())
-        async with lock:
-            existing_runner = self._active_runners.get(thread.id)
-            existing_task = self._active_tasks.get(thread.id)
-            if existing_runner is not None:
-                if interrupt:
-                    await thread.send("-# ⚡ Interrupted by another session's message...")
-                    await existing_runner.interrupt()
-                if existing_task is not None and not existing_task.done():
-                    with contextlib.suppress(Exception):
-                        await existing_task
-
         chat_only = (thread.parent_id or 0) in self._chat_only_channel_ids
+        # _run_claude serializes per thread: with interrupt=False it queues
+        # behind the current turn, with interrupt=True it preempts it. Either
+        # way eviction + registration is atomic under the per-thread lock, so a
+        # relayed message can never spawn a second parallel process here.
         await self._run_claude(
             seed_message,
             thread,
@@ -867,6 +859,8 @@ class ClaudeChatCog(commands.Cog):
             session_id=session_id,
             working_dir_override=record.working_dir if record else None,
             chat_only=chat_only,
+            interrupt_existing=interrupt,
+            interrupt_notice="-# ⚡ Interrupted by another session's message...",
         )
 
     async def cog_unload(self) -> None:
@@ -1046,19 +1040,12 @@ class ClaudeChatCog(commands.Cog):
                 if isinstance(_dashboard, ThreadStatusDashboard):
                     await _dashboard.refresh_inbox(_inbox_repo)
 
-        lock = self._thread_locks.setdefault(thread.id, asyncio.Lock())
-        async with lock:
-            existing_runner = self._active_runners.get(thread.id)
-            existing_task = self._active_tasks.get(thread.id)
-            if existing_runner is not None:
-                await thread.send("-# ⚡ Interrupted. Starting with new instruction...")
-                await existing_runner.interrupt()
-                if existing_task is not None and not existing_task.done():
-                    with contextlib.suppress(Exception):
-                        await existing_task
-
         # Determine chat_only from the parent channel of this thread.
         chat_only = (thread.parent_id or 0) in self._chat_only_channel_ids
+        # A human reply preempts whatever is running in this thread. _run_claude
+        # is the single serialization point: it interrupts the in-flight run and
+        # registers the replacement atomically under the per-thread lock, so two
+        # fast replies can never spawn parallel CLI processes.
         await self._run_claude(
             message,
             thread,
@@ -1067,6 +1054,7 @@ class ClaudeChatCog(commands.Cog):
             images=images,
             working_dir_override=record.working_dir if record else None,
             chat_only=chat_only,
+            interrupt_existing=True,
         )
 
     async def _session_id_for_current_backend(
@@ -1141,6 +1129,43 @@ class ClaudeChatCog(commands.Cog):
             logger.debug("Failed to fetch seed message for thread %d", thread.id, exc_info=True)
             return None
 
+    async def _evict_active_run(
+        self,
+        thread: discord.Thread | discord.TextChannel,
+        *,
+        interrupt: bool,
+        notice: str,
+    ) -> None:
+        """Clear the thread's active run so the caller can register a new one.
+
+        Must be called while holding ``self._thread_locks[thread.id]``. When
+        ``interrupt`` is True the in-flight runner is SIGINT'd (the ``notice`` is
+        posted first); otherwise we simply wait for it to finish — queue
+        semantics. Either way we await the run's task so its cleanup (its own
+        ``finally``) completes before the caller registers a replacement, which
+        is what keeps at most one runner per thread.
+
+        No deadlock: a task is only in ``_active_tasks`` after it finished its
+        own phase 1 and released the lock, so it never blocks on the lock we
+        hold here.
+        """
+        existing_runner = self._active_runners.get(thread.id)
+        if existing_runner is None:
+            return
+        existing_task = self._active_tasks.get(thread.id)
+        if interrupt:
+            with contextlib.suppress(discord.HTTPException):
+                await thread.send(notice)
+            with contextlib.suppress(Exception):
+                await existing_runner.interrupt()
+        if (
+            existing_task is not None
+            and existing_task is not asyncio.current_task()
+            and not existing_task.done()
+        ):
+            with contextlib.suppress(Exception):
+                await existing_task
+
     async def _run_claude(
         self,
         user_message: discord.Message,
@@ -1152,63 +1177,93 @@ class ClaudeChatCog(commands.Cog):
         working_dir_override: str | None = None,
         chat_only: bool = False,
         result_sink: Callable[[str | None, str | None], Awaitable[None]] | None = None,
+        interrupt_existing: bool = False,
+        interrupt_notice: str = "-# ⚡ Interrupted. Starting with new instruction...",
     ) -> None:
-        """Execute Claude Code CLI and stream results to the thread."""
+        """Execute Claude Code CLI and stream results to the thread.
+
+        This is the single serialization point for a thread: at most one Claude
+        run may be active per thread at any time. Under the thread's per-thread
+        lock it evicts whatever run is already in flight — interrupting it when
+        ``interrupt_existing`` is set, otherwise waiting for it to finish (queue
+        semantics) — then builds and *registers* the new runner, and only then
+        releases the lock and starts the subprocess.
+
+        Registering the runner under the *same* lock that checks for an existing
+        one is what closes the race: without it, two near-simultaneous messages
+        both pass the "nothing is running" check during the awaits below (model
+        lookup, runner build) and both spawn parallel CLI processes in the same
+        thread. The subprocess itself runs *outside* the lock so a later message
+        can still interrupt this run.
+        """
         dashboard = self._get_dashboard()
         description = prompt[:100].replace("\n", " ")
 
-        # Register the current asyncio Task so _handle_thread_reply can
-        # await it after sending SIGINT to the runner.
         current_task = asyncio.current_task()
-        if current_task is not None:
-            self._active_tasks[thread.id] = current_task
+        lock = self._thread_locks.setdefault(thread.id, asyncio.Lock())
 
-        # Mark thread as PROCESSING when Claude starts
-        if dashboard is not None:
-            await dashboard.set_state(
-                thread.id,
-                ThreadState.PROCESSING,
-                description,
-                thread=thread,
+        # --- Phase 1: atomically take the thread's single run slot -----------
+        # Everything from evicting the previous run through registering this one
+        # happens under the lock, so no concurrent _run_claude can observe an
+        # empty slot and spawn a parallel process.
+        async with lock:
+            await self._evict_active_run(
+                thread, interrupt=interrupt_existing, notice=interrupt_notice
             )
 
-        model_override = await self._get_current_model()
-        effective_model = model_override or self.runner.model
+            # Mark thread as PROCESSING when Claude starts
+            if dashboard is not None:
+                await dashboard.set_state(
+                    thread.id,
+                    ThreadState.PROCESSING,
+                    description,
+                    thread=thread,
+                )
 
-        async def _notify_stall() -> None:
-            threshold = status._stall_hard
-            await thread.send(
-                f"-# \u26a0\ufe0f No activity for {threshold}s — could be extended thinking "
-                "or context compression. Will resume automatically."
+            model_override = await self._get_current_model()
+            effective_model = model_override or self.runner.model
+
+            async def _notify_stall() -> None:
+                threshold = status._stall_hard
+                await thread.send(
+                    f"-# ⚠️ No activity for {threshold}s — could be extended thinking "
+                    "or context compression. Will resume automatically."
+                )
+
+            status = StatusManager(
+                user_message,
+                on_hard_stall=_notify_stall,
+                model=effective_model,
             )
+            await status.set_thinking()
 
-        status = StatusManager(
-            user_message,
-            on_hard_stall=_notify_stall,
-            model=effective_model,
-        )
-        await status.set_thinking()
+            tools_override = await self._get_allowed_tools()
+            effort_override = await self._get_current_effort()
 
-        tools_override = await self._get_allowed_tools()
-        effort_override = await self._get_current_effort()
+            runner = await self._build_runner_for_thread(
+                thread_id=thread.id,
+                model_override=model_override,
+                tools_override=tools_override,
+                fork_session=fork,
+                working_dir_override=working_dir_override,
+                effort_override=effort_override,
+            )
+            # Register as the sole active run BEFORE releasing the lock. Track
+            # the task too so a later eviction can await our cleanup.
+            self._active_runners[thread.id] = runner
+            if current_task is not None:
+                self._active_tasks[thread.id] = current_task
 
-        runner = await self._build_runner_for_thread(
-            thread_id=thread.id,
-            model_override=model_override,
-            tools_override=tools_override,
-            fork_session=fork,
-            working_dir_override=working_dir_override,
-            effort_override=effort_override,
-        )
-        self._active_runners[thread.id] = runner
+            # In chat_only mode, skip the "Session running" message and stop button.
+            stop_view: StopView | None = None
+            if not chat_only:
+                stop_view = StopView(runner)
+                stop_msg = await thread.send("-# ⏺ Session running", view=stop_view)
+                stop_view.set_message(stop_msg)
 
-        # In chat_only mode, skip the "Session running" message and stop button.
-        stop_view: StopView | None = None
-        if not chat_only:
-            stop_view = StopView(runner)
-            stop_msg = await thread.send("-# ⏺ Session running", view=stop_view)
-            stop_view.set_message(stop_msg)
-
+        # --- Phase 2: run the subprocess OUTSIDE the lock --------------------
+        # The lock is released so a later message can interrupt this run. The
+        # runner is already registered, so that message will find and evict it.
         try:
             await run_claude_with_config(
                 RunConfig(
@@ -1241,9 +1296,16 @@ class ClaudeChatCog(commands.Cog):
         finally:
             if stop_view is not None:
                 await stop_view.disable()
-            self._active_runners.pop(thread.id, None)
-            self._active_tasks.pop(thread.id, None)
-            self._thread_locks.pop(thread.id, None)
+            # Identity-guarded cleanup: only clear our own entries. A successor
+            # that evicted us may already have registered its runner/task, and
+            # we must not delete it. _thread_locks is intentionally NOT popped:
+            # the lock must stay stable for the thread's lifetime, or a later
+            # message could create a fresh Lock and run concurrently with one
+            # still holding the old object.
+            if self._active_runners.get(thread.id) is runner:
+                self._active_runners.pop(thread.id, None)
+            if self._active_tasks.get(thread.id) is current_task:
+                self._active_tasks.pop(thread.id, None)
 
             # Transition to WAITING_INPUT so owner knows a reply is needed
             if dashboard is not None:

--- a/tests/test_claude_chat.py
+++ b/tests/test_claude_chat.py
@@ -12,6 +12,25 @@ from claude_discord.cogs.claude_chat import ClaudeChatCog
 from claude_discord.concurrency import SessionRegistry
 
 
+class _StubStatus:
+    """Minimal StatusManager stand-in for _run_claude serialization tests."""
+
+    _stall_hard = 300
+
+    async def set_thinking(self) -> None:
+        return None
+
+
+class _StubStopView:
+    """Minimal StopView stand-in — no Discord interaction."""
+
+    def set_message(self, message: object) -> None:
+        return None
+
+    async def disable(self, message: object | None = None) -> None:
+        return None
+
+
 def _make_cog() -> ClaudeChatCog:
     """Return a ClaudeChatCog with minimal mocked dependencies."""
     bot = MagicMock()
@@ -202,69 +221,69 @@ class TestInterruptOnNewMessage:
         return msg
 
     @pytest.mark.asyncio
-    async def test_interrupt_called_when_runner_active(self) -> None:
-        """When a runner is active for a thread, _handle_thread_reply must interrupt it."""
+    async def test_handle_thread_reply_delegates_interrupt_to_run_claude(self) -> None:
+        """_handle_thread_reply must ask _run_claude to preempt the running turn.
+
+        Serialization + interrupt now live in _run_claude (the single run slot),
+        so the reply path only needs to pass interrupt_existing=True.
+        """
         cog = _make_cog()
         thread_id = 42
         message = self._make_thread_message(thread_id)
 
-        # Plant an active runner in the cog
+        cog._run_claude = AsyncMock()
+
+        await cog._handle_thread_reply(message)
+
+        cog._run_claude.assert_called_once()
+        _, kwargs = cog._run_claude.call_args
+        assert kwargs.get("interrupt_existing") is True
+
+    @pytest.mark.asyncio
+    async def test_evict_active_run_interrupts_and_notifies(self) -> None:
+        """_evict_active_run(interrupt=True) posts the notice and SIGINTs the runner."""
+        cog = _make_cog()
+        thread_id = 42
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = thread_id
+        thread.send = AsyncMock()
+
         existing_runner = MagicMock()
         existing_runner.interrupt = AsyncMock()
         cog._active_runners[thread_id] = existing_runner
 
-        # Stub _run_claude so we don't actually spawn Claude
-        cog._run_claude = AsyncMock()
-
-        await cog._handle_thread_reply(message)
+        await cog._evict_active_run(thread, interrupt=True, notice="-# ⚡ stop")
 
         existing_runner.interrupt.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_interrupt_message_sent_to_thread(self) -> None:
-        """The thread should receive a notification when the session is interrupted."""
-        cog = _make_cog()
-        thread_id = 42
-        message = self._make_thread_message(thread_id)
-        thread = message.channel
-
-        existing_runner = MagicMock()
-        existing_runner.interrupt = AsyncMock()
-        cog._active_runners[thread_id] = existing_runner
-        cog._run_claude = AsyncMock()
-
-        await cog._handle_thread_reply(message)
-
         thread.send.assert_called_once()
         sent_text: str = thread.send.call_args.args[0]
-        assert "interrupted" in sent_text.lower() or "⚡" in sent_text
+        assert "⚡" in sent_text or "interrupted" in sent_text.lower()
 
     @pytest.mark.asyncio
-    async def test_no_interrupt_when_no_active_runner(self) -> None:
-        """When no runner is active, _handle_thread_reply skips interrupt."""
+    async def test_evict_active_run_noop_when_idle(self) -> None:
+        """_evict_active_run does nothing (no notice) when no runner is active."""
         cog = _make_cog()
-        message = self._make_thread_message(thread_id=42)
-        thread = message.channel
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = 42
+        thread.send = AsyncMock()
 
-        cog._run_claude = AsyncMock()
+        await cog._evict_active_run(thread, interrupt=True, notice="-# ⚡ stop")
 
-        await cog._handle_thread_reply(message)
-
-        # No notification message sent for interruption
         thread.send.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_awaits_existing_task_before_new_session(self) -> None:
-        """_handle_thread_reply must await the existing task to ensure cleanup completes."""
+    async def test_evict_active_run_queue_mode_waits_without_interrupt(self) -> None:
+        """interrupt=False must wait out the existing task without SIGINT (queue)."""
         cog = _make_cog()
         thread_id = 42
-        message = self._make_thread_message(thread_id)
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = thread_id
+        thread.send = AsyncMock()
 
         existing_runner = MagicMock()
         existing_runner.interrupt = AsyncMock()
         cog._active_runners[thread_id] = existing_runner
 
-        # A future that we can control to simulate a running task
         cleanup_done = asyncio.Event()
         call_order: list[str] = []
 
@@ -274,18 +293,15 @@ class TestInterruptOnNewMessage:
 
         task = asyncio.ensure_future(slow_task())
         cog._active_tasks[thread_id] = task
-
-        async def run_claude_stub(*args, **kwargs) -> None:
-            call_order.append("new_session_started")
-
-        cog._run_claude = run_claude_stub
-
-        # Let cleanup complete so the await resolves
         cleanup_done.set()
 
-        await cog._handle_thread_reply(message)
+        await cog._evict_active_run(thread, interrupt=False, notice="-# ⚡ stop")
+        call_order.append("evict_returned")
 
-        assert call_order == ["task_done", "new_session_started"]
+        # Queue mode: no interrupt, no notice, but the prior task is awaited.
+        existing_runner.interrupt.assert_not_called()
+        thread.send.assert_not_called()
+        assert call_order == ["task_done", "evict_returned"]
 
     @pytest.mark.asyncio
     async def test_run_claude_called_with_session_id_after_interrupt(self) -> None:
@@ -327,22 +343,27 @@ class TestInterruptOnNewMessage:
         assert len(cog._thread_locks) == 0
 
     @pytest.mark.asyncio
-    async def test_concurrent_messages_only_spawn_one_session(self) -> None:
-        """Two near-simultaneous messages should not both spawn CLI processes."""
+    async def test_concurrent_messages_both_reach_run_claude(self) -> None:
+        """Two near-simultaneous replies both delegate to _run_claude (interrupt=True).
+
+        The actual "never overlaps" guarantee is proven by
+        test_real_run_claude_never_overlaps_same_thread, which exercises the
+        real _run_claude. Here we only confirm both replies are handled and each
+        asks to preempt the running turn.
+        """
         cog = _make_cog()
         thread_id = 42
 
         call_count = 0
+        flags: list[object] = []
 
-        async def slow_run_claude(*args: object, **kwargs: object) -> None:
+        async def spy_run_claude(*args: object, **kwargs: object) -> None:
             nonlocal call_count
             call_count += 1
-            runner = MagicMock()
-            runner.interrupt = AsyncMock()
-            cog._active_runners[thread_id] = runner
-            await asyncio.sleep(0.05)
+            flags.append(kwargs.get("interrupt_existing"))
+            await asyncio.sleep(0.01)
 
-        cog._run_claude = slow_run_claude
+        cog._run_claude = spy_run_claude
 
         msg1 = self._make_thread_message(thread_id)
         msg2 = self._make_thread_message(thread_id)
@@ -354,9 +375,71 @@ class TestInterruptOnNewMessage:
         await asyncio.gather(t1, t2, return_exceptions=True)
 
         assert call_count == 2
-        thread = msg2.channel
-        send_calls = [c.args[0] for c in thread.send.call_args_list]
-        assert any("⚡" in s for s in send_calls)
+        assert flags == [True, True]
+
+    @pytest.mark.asyncio
+    async def test_real_run_claude_never_overlaps_same_thread(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The real _run_claude must never run two CLI subprocesses at once per thread.
+
+        This exercises the actual serialization inside _run_claude (not a stub).
+        Runner registration happens *after* several awaits (model lookup, runner
+        build), so two near-simultaneous messages can slip past a naive
+        "is anything running?" check and both spawn. The per-thread lock must
+        make eviction + registration atomic so the two runs are serialized.
+        """
+        import claude_discord.cogs.claude_chat as chat_mod
+
+        cog = _make_cog()
+        thread_id = 42
+
+        concurrency = 0
+        max_concurrency = 0
+        run_count = 0
+
+        async def fake_run(config: object) -> None:
+            nonlocal concurrency, max_concurrency, run_count
+            run_count += 1
+            concurrency += 1
+            max_concurrency = max(max_concurrency, concurrency)
+            await asyncio.sleep(0.02)
+            concurrency -= 1
+
+        monkeypatch.setattr(chat_mod, "run_claude_with_config", fake_run)
+        # StatusManager / StopView touch Discord; stub them to no-ops.
+        monkeypatch.setattr(chat_mod, "StatusManager", lambda *a, **k: _StubStatus())
+        monkeypatch.setattr(chat_mod, "StopView", lambda *a, **k: _StubStopView())
+        cog._get_dashboard = lambda: None  # type: ignore[method-assign]
+
+        async def slow_build_runner(**kwargs: object) -> MagicMock:
+            # The await here is the gap the race exploits: registration into
+            # _active_runners happens only *after* this returns.
+            await asyncio.sleep(0.005)
+            runner = MagicMock()
+            runner.interrupt = AsyncMock()
+            runner.command = "claude"
+            return runner
+
+        cog._build_runner_for_thread = slow_build_runner  # type: ignore[method-assign]
+        cog._get_current_model = AsyncMock(return_value=None)
+        cog._get_allowed_tools = AsyncMock(return_value=None)
+        cog._get_current_effort = AsyncMock(return_value=None)
+
+        msg1 = self._make_thread_message(thread_id)
+        msg2 = self._make_thread_message(thread_id)
+
+        t1 = asyncio.create_task(cog._handle_thread_reply(msg1))
+        await asyncio.sleep(0)
+        t2 = asyncio.create_task(cog._handle_thread_reply(msg2))
+
+        await asyncio.gather(t1, t2, return_exceptions=True)
+
+        # Both messages ran, but never simultaneously in the same thread.
+        assert run_count == 2
+        assert max_concurrency == 1
+        # No orphaned runner left registered after both finished.
+        assert thread_id not in cog._active_runners
 
 
 class TestSpawnSession:

--- a/tests/test_thread_relay.py
+++ b/tests/test_thread_relay.py
@@ -276,7 +276,13 @@ async def test_delivery_posts_the_message_so_humans_can_see_it() -> None:
     cog._run_claude.assert_awaited_once()
 
 
-async def test_interrupt_true_stops_the_turn_in_flight() -> None:
+async def test_interrupt_true_delegates_preemption_to_run_claude() -> None:
+    """interrupt=True must ask _run_claude to preempt the in-flight turn.
+
+    Eviction/interrupt now lives in _run_claude (the single per-thread run
+    slot); deliver_relayed_message only forwards the intent. The actual SIGINT
+    is covered by test_claude_chat's _evict_active_run tests.
+    """
     cog = _make_cog()
     thread = _make_target_thread()
     running = MagicMock()
@@ -286,34 +292,27 @@ async def test_interrupt_true_stops_the_turn_in_flight() -> None:
 
     await cog.deliver_relayed_message(thread, "stop now", interrupt=True)
 
-    running.interrupt.assert_awaited_once()
+    cog._run_claude.assert_awaited_once()
+    _, kwargs = cog._run_claude.call_args
+    assert kwargs.get("interrupt_existing") is True
 
 
-async def test_queue_mode_never_interrupts_a_running_turn() -> None:
-    """The default must not cost the receiver its in-flight work."""
+async def test_queue_mode_forwards_no_preemption() -> None:
+    """The default must not cost the receiver its in-flight work.
+
+    deliver_relayed_message forwards interrupt_existing=False; _run_claude then
+    queues behind the current turn (proven by test_claude_chat's queue-mode
+    _evict_active_run test and the real-overlap test).
+    """
     cog = _make_cog()
     thread = _make_target_thread()
     running = MagicMock()
     running.interrupt = AsyncMock()
     cog._active_runners[thread.id] = running
-
-    finished = asyncio.Event()
-
-    async def existing_turn() -> None:
-        await finished.wait()
-
-    task = asyncio.create_task(existing_turn())
-    cog._active_tasks[thread.id] = task
     cog._run_claude = AsyncMock()
 
-    delivery = asyncio.create_task(
-        cog.deliver_relayed_message(thread, "when you get a moment", interrupt=False)
-    )
-    await asyncio.sleep(0.05)
+    await cog.deliver_relayed_message(thread, "when you get a moment", interrupt=False)
 
-    running.interrupt.assert_not_awaited()
-    cog._run_claude.assert_not_awaited()  # still waiting for the current turn
-
-    finished.set()
-    await delivery
     cog._run_claude.assert_awaited_once()
+    _, kwargs = cog._run_claude.call_args
+    assert kwargs.get("interrupt_existing") is False


### PR DESCRIPTION
## Problem

Sending two messages to the same Discord thread in quick succession — a human reply while a turn is running, a relayed message from another session, or two fast replies — could spawn **two (or more) Claude CLI subprocesses in the same thread at once**. One would finish while the other kept running, matching the reported "3 processes running in parallel, one ends but another is still going" behaviour.

## Root cause

`_handle_thread_reply` / `deliver_relayed_message` checked `_active_runners` under the per-thread lock, then **released the lock before calling `_run_claude`**. `_run_claude` registered its runner only *after* several awaits (model lookup, `_build_runner_for_thread`). A second message acquiring the lock in that window saw an empty slot and started a parallel run — a classic check-then-act (TOCTOU) race.

Two aggravating bugs made state corruption worse:
- The run's `finally` did `self._thread_locks.pop(thread.id, None)`, **discarding the mutex mid-flight** — a later message then created a *fresh* `Lock`, so two handlers could hold two different locks for the same thread (no mutual exclusion).
- `finally` unconditionally popped `_active_runners`/`_active_tasks`, so a finishing run could **delete a still-running successor's runner**, orphaning it (untrackable by `/stop`, invisible to the next interrupt check).

## Fix

`_run_claude` becomes the single serialization point:

1. Take a **stable** per-thread lock (never popped).
2. Under the lock, **evict** any in-flight run — SIGINT it when `interrupt_existing` is set, otherwise wait for it (queue semantics) — then build and **register** the new runner. Registration is now atomic with the check, so two messages can never both spawn.
3. **Release the lock** and run the subprocess outside it, so a later message can still interrupt this run (the runner is already registered, so it will be found and evicted).
4. `finally` cleanup is **identity-guarded** (only clears our own entries).

`_handle_thread_reply` and `deliver_relayed_message` now just forward `interrupt_existing` (+ a custom `interrupt_notice` for relays) instead of holding the lock themselves.

Deadlock-free by construction: a task is registered in `_active_tasks` only *after* it finishes its own lock-held registration phase, so awaiting it during eviction never blocks on the lock we currently hold.

## Tests

- **New:** `test_real_run_claude_never_overlaps_same_thread` drives the *real* `_run_claude` (collaborators stubbed, but the runner-build await preserved) with two concurrent replies and asserts max concurrency == 1 and no orphaned runner. It **fails on the old code** (observed `max_concurrency == 2`) and passes after the fix.
- Refocused the interrupt/relay tests onto the new eviction seam (`_evict_active_run`, `interrupt_existing` delegation), covering interrupt mode, idle no-op, and queue mode (waits without SIGINT).

## Verification

- `ruff check` / `ruff format --check`: clean
- `pyright claude_discord/`: 0 errors
- Full suite on Python 3.10 (matches the maintainer's local venv): **1754 passed**

> Note: `tests/test_run_helper.py::TestDrainAllowsResultEvent::test_non_result_events_still_drained` hangs under Python 3.12 on a fresh venv, but this reproduces with my change reverted to `HEAD` — it is a pre-existing 3.12-specific issue, unrelated to this PR.