### PR TITLE
[docs-sync] Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,16 @@ curl "$CCDB_API_URL/api/ingest/ab12…" -H "Authorization: Bearer $CCDB_INGEST_T
 
 The endpoint is opt-in: with no `ingest_token` configured, `POST` responds `503`. When result retrieval is unavailable, `POST` simply omits `result_id` and `GET /api/ingest/{id}` returns `503` — the spawn behaviour is otherwise unchanged. The request body and attachments are **not** persisted in the result store (only status, the final text, and the thread id); results are capped at 200 rows.
 
+#### Running per-thread summaries for long ingest threads (`/api/ingest/summary`)
+
+An ingest client that keeps replying in one **upstream** thread for months (notably the Teams browser extension) would otherwise have to re-export the entire history on every run — ccdb's "Thread = Session" model spawns a *fresh* Discord thread + Claude session per ingest and remembers nothing about the upstream thread. Opt into a compact **running summary** keyed by a client-supplied stable `summary_key` (e.g. the upstream thread's root message id), stored in the new `thread_summaries` table, and the client can send only the **diff** while the session still gets full historical context:
+
+1. Before exporting, the client calls `GET /api/ingest/summary?key=…` (external, ingest-token gated) to read the stored `summary` + `marker`, and bounds its export to messages newer than `marker`.
+2. `POST /api/ingest` accepts `summary_key` + `latest_marker`; ccdb injects the stored summary into the prompt as context and asks the session to save an updated one.
+3. The session calls `POST /api/ingest/summary` (internal control plane, localhost — same trust model as `/api/tasks`) with its own `result_id` and the new `summary`; ccdb resolves the key and advances the `marker` **from the ingest row**, so the read position only moves forward when a summary is actually saved (a failed session re-exports the same diff, never skips messages).
+
+`DELETE /api/ingest/summary?key=…` forces a full re-summary. The marker is opaque to ccdb and never handled by the session, so it cannot drift. Fully backward-compatible and Zero-Config: omit `summary_key` and ingest behaves exactly as before. The external listener exposes only the `GET` (read) route; writing a summary is a localhost-only action. `ingest_results` gains `summary_key`/`pending_marker` columns (auto-migrated on existing DBs).
+
 ### Startup Resume
 
 If the bot restarts mid-session, interrupted Claude sessions are automatically resumed when the bot comes back online. Sessions are marked for resume in three ways:
@@ -964,6 +974,9 @@ uv add "claude-code-discord-bridge[api]"
 | POST | `/api/spawn` | Create a new Discord thread and start a Claude Code session (non-blocking); pass `auto_start: false` to defer Claude until the first user reply |
 | POST | `/api/ingest` | Authenticated external spawn (browser extension / webhook) with base64 attachments; returns a `result_id` when result retrieval is configured |
 | GET | `/api/ingest/{result_id}` | Poll the spawned session's final reply (`status`/`result`/`error`/`thread_id`) |
+| GET | `/api/ingest/summary` | Read the running summary + `marker` for a long ingest thread by `key` (ingest-token gated) so the client can export only the diff |
+| POST | `/api/ingest/summary` | Save an updated running summary (`result_id` + `summary`) from the session — localhost control plane; ccdb advances the `marker` from the ingest row |
+| DELETE | `/api/ingest/summary` | Clear the stored summary for `key`, forcing a full re-summary on the next ingest |
 | POST | `/api/mark-resume` | Mark a thread for automatic resume on next bot startup |
 | GET | `/api/lounge` | Read recent AI Lounge messages |
 | POST | `/api/lounge` | Post a message to the AI Lounge (with optional `label`) |

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -234,6 +234,16 @@ curl "$CCDB_API_URL/api/ingest/ab12…" -H "Authorization: Bearer $CCDB_INGEST_T
 
 このエンドポイントはオプトイン方式です。`ingest_token` が設定されていない場合、`POST` は `503` を返します。結果取得が利用できない場合、`POST` は `result_id` を省略し、`GET /api/ingest/{id}` は `503` を返します — スポーン動作は変わりません。リクエスト本文と添付ファイルは結果ストアに保存されません（状態、最終テキスト、スレッド ID のみ）。結果は最大 200 件です。
 
+#### 長時間続くインジェストスレッドの継続サマリー (`/api/ingest/summary`)
+
+上流スレッド（特に Teams ブラウザ拡張機能）で何ヶ月も返信し続けるインジェストクライアントは、本来なら実行のたびに全履歴を再エクスポートしなければなりません — ccdb の「スレッド = セッション」モデルは、インジェストごとに*新しい* Discord スレッド + Claude セッションを起動し、上流スレッドについて何も覚えていないからです。クライアントが供給する安定した `summary_key`（例: 上流スレッドのルートメッセージ ID）をキーとするコンパクトな**継続サマリー**をオプトインすれば、新しい `thread_summaries` テーブルに保存され、クライアントは**差分**だけを送りつつ、セッションは完全な履歴コンテキストを受け取れます:
+
+1. エクスポート前に、クライアントは `GET /api/ingest/summary?key=…`（外部、ingest-token 認証）を呼んで保存済みの `summary` + `marker` を読み取り、エクスポート範囲を `marker` より新しいメッセージに絞り込みます。
+2. `POST /api/ingest` は `summary_key` + `latest_marker` を受け取ります。ccdb は保存済みサマリーをコンテキストとしてプロンプトに注入し、セッションに更新版の保存を促します。
+3. セッションは自身の `result_id` と新しい `summary` を添えて `POST /api/ingest/summary`（内部コントロールプレーン、localhost — `/api/tasks` と同じ信頼モデル）を呼びます。ccdb はキーを解決し、`marker` を**インジェスト行から**前進させます。そのため読み取り位置は、サマリーが実際に保存されたときだけ前進します（失敗したセッションは同じ差分を再エクスポートし、メッセージをスキップしません）。
+
+`DELETE /api/ingest/summary?key=…` は完全な再サマリーを強制します。`marker` は ccdb にとって不透明で、セッションが触ることは決してないため、ずれることがありません。完全に後方互換かつ Zero-Config: `summary_key` を省略すればインジェストは従来どおり動作します。外部リスナーは `GET`（読み取り）ルートのみを公開します — サマリーの書き込みは localhost 限定の操作です。`ingest_results` に `summary_key`/`pending_marker` カラムが追加されます（既存 DB では自動マイグレーション）。
+
 ### スタートアップリジューム
 
 Bot の再起動中にセッションが中断された場合、Bot が再起動したときに自動的に再開されます。リジューム登録の方法は 3 つあります:
@@ -966,6 +976,9 @@ uv add "claude-code-discord-bridge[api]"
 | POST | `/api/spawn` | 新しい Discord スレッドを作成し Claude Code セッションを起動（非ブロッキング）。`auto_start: false` を指定するとユーザーの最初の返信まで Claude の起動を延期できる |
 | POST | `/api/ingest` | 認証済み外部スポーン（ブラウザ拡張機能 / webhook）。base64 添付ファイル対応。結果取得が設定されている場合 `result_id` を返す |
 | GET | `/api/ingest/{result_id}` | スポーンされたセッションの最終返信をポーリング（`status`/`result`/`error`/`thread_id`） |
+| GET | `/api/ingest/summary` | 長時間続くインジェストスレッドの継続サマリー + `marker` を `key` で読み取り（ingest-token 認証）。クライアントは差分だけをエクスポートできる |
+| POST | `/api/ingest/summary` | セッションから更新版の継続サマリー（`result_id` + `summary`）を保存 — localhost コントロールプレーン。ccdb が `marker` をインジェスト行から前進させる |
+| DELETE | `/api/ingest/summary` | `key` の保存済みサマリーをクリアし、次回インジェストで完全な再サマリーを強制 |
 | POST | `/api/mark-resume` | 次回 Bot 起動時のスレッド自動リジュームを登録 |
 | GET | `/api/lounge` | AI Lounge の最近のメッセージを取得 |
 | POST | `/api/lounge` | AI Lounge にメッセージを投稿（`label` オプション） |


### PR DESCRIPTION
## Summary

Syncs the docs with **#509 — running per-thread summaries for long ingest threads** (`GET`/`POST`/`DELETE /api/ingest/summary`), the last `[Unreleased]` feature not yet reflected in the README. (`/search` thread + body search were already synced in #507/#508.)

Both the English `README.md` and the Japanese `docs/ja/README.md` were updated in two places each:

1. **Prose** — a new subsection under *Authenticated External Ingest* (`### Startup Resume` boundary) explaining the running-summary flow: a client that keeps replying in one upstream thread (e.g. the Teams browser extension) reads the stored `summary` + `marker` via `GET /api/ingest/summary`, sends only the diff on `POST /api/ingest` (`summary_key` + `latest_marker`), and the session saves an updated summary via the localhost-only `POST /api/ingest/summary`. Marker advances from the ingest row, so a failed session re-exports the same diff and never skips messages. `DELETE …/summary` forces a full re-summary. Backward-compatible & Zero-Config.
2. **REST API endpoint table** — three new rows for `GET`/`POST`/`DELETE /api/ingest/summary`.

## 概要 (Japanese)

`#509`（長時間続くインジェストスレッドの継続サマリー機能、`/api/ingest/summary`）を README に反映。英語版・日本語版とも本文の新サブセクションとエンドポイント一覧表の2箇所を更新。`summary_key` を省略すれば従来どおり動作する後方互換・Zero-Config の追加。

## Test plan

- [x] Markdown table rows verified (3 columns / 4 pipes each) in both EN and JA
- [x] No links broken; `--` flag-injection and localhost trust-model wording matches `ext/api_server.py`
- [x] EN and JA prose kept structurally parallel; code identifiers (`summary_key`, `marker`, endpoint paths) left untranslated
- [ ] Rendered preview on GitHub looks correct

Docs-only change — no source code touched.
