### PR TITLE
[docs-sync] Document CCDB_MODEL_DISCOVERY and the model_catalog API exception (#522)

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,6 +749,7 @@ In chat-only mode, permission requests and `AskUserQuestion` prompts are **alway
 | `CCDB_CODEX_COMMAND` | Explicit path to the OpenAI Codex CLI binary. Required when running the bot under systemd (default service PATH does not include `~/.npm-global/bin`). Falls back to `codex` (PATH). | (optional) |
 | `PATH` | Binary search path for the bot **and every CLI session it spawns** — sessions inherit the bot's environment. Set it in `.env` when running under systemd, which starts units with a minimal PATH and never reads `~/.bashrc` / `~/.profile`. See [Toolchain PATH](#toolchain-path--set-it-in-env). | (inherited from the parent process) |
 | `CCDB_MODEL` | Model to use (overrides `CLAUDE_MODEL`) | `sonnet` |
+| `CCDB_MODEL_DISCOVERY` | Set to `0` to stop the `/model` autocomplete from asking the Anthropic models endpoint which models your credentials can see, and always use the static suggestion list instead. Discovery is read-only, reuses the Claude Code CLI's own auth, and already falls back on its own when offline, unauthenticated, or on Bedrock/Vertex/Foundry | `1` |
 | `CCDB_PERMISSION_MODE` | Permission mode for CLI (overrides `CLAUDE_PERMISSION_MODE`) | `acceptEdits` |
 | `CCDB_DANGEROUSLY_SKIP_PERMISSIONS` | Skip all permission checks — overrides `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | `false` |
 | `CCDB_WORKING_DIR` | Working directory for CLI (overrides `CLAUDE_WORKING_DIR`) | current dir |

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -21,6 +21,8 @@ This document captures the "why" behind key architectural choices. Each decision
 - Larger resource footprint (one OS process per session)
 - Parsing stream-json instead of getting structured responses directly
 
+**The one sanctioned exception — `model_catalog.py`:** the `/model` autocomplete needs to *enumerate* models, and the CLI exposes no way to do that, so the suggestion list is read from `GET /v1/models` instead of a hardcoded constant that goes stale on every model launch. It is fenced in so it can never become a second execution path: read-only, reusing the CLI's own credentials (`ANTHROPIC_API_KEY` → `ANTHROPIC_AUTH_TOKEN` → `~/.claude/.credentials.json`), never logging the token, cached (6h; 5min on failure), stdlib `urllib` on a worker thread with a 5s timeout, and **strictly non-essential** — no credentials, no network, a third-party provider (Bedrock/Vertex/Foundry), or `CCDB_MODEL_DISCOVERY=0` all degrade to the static `SUGGESTED_MODELS` fallback rather than failing the command. No other code path may call the API directly.
+
 ## 2. Thread = Session (1:1 Mapping)
 
 **Decision:** Each Discord thread maps to exactly one Claude Code session via `--resume`.

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -267,6 +267,7 @@ ccdb 3.0 では、Bot を再起動せずにどの AI が次のセッションを
 
 - `/backend [name] [scope]` — バックエンドの表示または切り替え。`name` は `claude` または `codex`。`scope` は `thread`（このスレッドのみ）または `global`（サーバー全体のデフォルト）。`scope` を省略すると自動解決: スレッド内ではそのスレッドにスコープ、それ以外ではグローバルデフォルトを設定。
 - `/model [name] [scope]` — **現在の**バックエンドで使用するモデルの表示または切り替え。各バックエンドは独自のモデル設定を記憶するため、バックエンドを切り替えても好みのモデルが保持されます。バックエンドのモデルを未設定にすると、その CLI 自身のデフォルトに委ねられます（たとえば Codex は `~/.codex/config.toml` の `model` を使用するため、ccdb が特定バージョンに固定せずコンソールのデフォルトに追従します）。
+  `name` のオートコンプリートは**実行時に取得**されます。ccdb が Anthropic のモデル一覧エンドポイントへ（Claude Code CLI がすでに持っている認証情報を使って）アカウントから見えるモデルを問い合わせるため、今朝リリースされたばかりのモデルでも ccdb をアップグレードすることなくドロップダウンに現れます。エイリアス（`opus`、`sonnet` など）には、現時点でそのエイリアスが解決される実際のモデルが併記されます。オフライン時・未認証時・Bedrock/Vertex/Foundry 利用時は、小さな静的リストへ黙ってフォールバックします。`CCDB_MODEL_DISCOVERY=0` を設定すると常にその静的リストを使用します。Codex の候補は静的なままです（Codex CLI はモデル一覧を公開していないため）— 任意の id を直接入力すれば従来どおり動作します。
 - `/effort [level] [scope]` — 現在のバックエンドで使用する**推論の強度**の表示または切り替え。有効なレベルはバックエンドごとに異なり、Claude は `low/medium/high/max`、Codex は `minimal/low/medium/high/xhigh`（CLI の `model_reasoning_effort` にマッピング）を受け付けます。未設定にすると CLI のデフォルトに委ねられます。
 
 3 つのコマンドはいずれも `SettingsRepository` 経由で SQLite に永続化されるため、Bot を再起動しても設定が保持されます。引数なしで呼び出すと、現在のグローバルデフォルトとスレッドごとのオーバーライドを表示します。
@@ -750,6 +751,7 @@ CHAT_ONLY_CHANNEL_IDS=444,555
 | `CCDB_CODEX_COMMAND` | OpenAI Codex CLI バイナリの明示的なパス。systemd 下で Bot を実行する場合に必須（デフォルトのサービス PATH に `~/.npm-global/bin` が含まれない）。`codex`（PATH）へのフォールバックあり。 | （オプション） |
 | `PATH` | Bot **と Bot が起動する全 CLI セッション**のバイナリ検索パス（セッションは Bot の環境を継承）。systemd はユニットを最小限の PATH で起動し `~/.bashrc` / `~/.profile` を読まないため、systemd 運用時は `.env` に設定する。[ツールチェーンの PATH](#ツールチェーンの-path--env-に設定する) 参照 | （親プロセスから継承） |
 | `CCDB_MODEL` | 使用するモデル（`CLAUDE_MODEL` より優先） | `sonnet` |
+| `CCDB_MODEL_DISCOVERY` | `0` にすると、`/model` のオートコンプリートが Anthropic のモデル一覧エンドポイントへ「この認証情報から見えるモデル」を問い合わせるのをやめ、常に静的な候補リストを使用する。この問い合わせは読み取り専用で、Claude Code CLI 自身の認証情報を再利用し、オフライン時・未認証時・Bedrock/Vertex/Foundry 利用時には自動的にフォールバックする | `1` |
 | `CCDB_PERMISSION_MODE` | CLI のパーミッションモード（`CLAUDE_PERMISSION_MODE` より優先） | `acceptEdits` |
 | `CCDB_DANGEROUSLY_SKIP_PERMISSIONS` | 全パーミッションチェックをスキップ（`CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` より優先） | `false` |
 | `CCDB_WORKING_DIR` | CLI の作業ディレクトリ（`CLAUDE_WORKING_DIR` より優先） | カレントディレクトリ |


### PR DESCRIPTION
## Summary

Documentation sync for #522 (`feat: discover /model suggestions live instead of hardcoding them`).

That commit already updated `README.md` (the `/model` prose), `.env.example` and `CLAUDE.md`, so this PR fills the three gaps it left behind:

| File | Change |
|------|--------|
| `README.md` | `CCDB_MODEL_DISCOVERY` was documented in `.env.example` and in the `/model` prose, but was **missing from the Environment Variables reference table** — every other `CCDB_*` var is listed there. Added. |
| `docs/DESIGN_DECISIONS.md` | Decision 1 is titled *"CLI Subprocess, Not Direct API"* and now has a sanctioned exception. Added a note documenting `model_catalog.py`: why the exception exists (the CLI can't enumerate models), and the fences that keep it from becoming a second execution path. |
| `docs/ja/README.md` | Translated the new `/model` live-discovery paragraph, and added the `CCDB_MODEL_DISCOVERY` row to the Japanese environment-variable table. |

Every technical claim in the new `DESIGN_DECISIONS.md` paragraph was verified against `claude_discord/model_catalog.py` rather than copied from the changelog: `CACHE_TTL_SECONDS = 6 * 60 * 60`, `FAILURE_TTL_SECONDS = 5 * 60`, `REQUEST_TIMEOUT_SECONDS = 5.0`, stdlib `urllib` via `asyncio.to_thread`, and the credential order `ANTHROPIC_API_KEY` → `ANTHROPIC_AUTH_TOKEN` → `~/.claude/.credentials.json`.

Documentation only — no code, no behaviour change.

---

## 概要

#522（`/model` のモデル候補をハードコードせず実行時に取得する機能）に対するドキュメント同期です。

当該コミットで `README.md`（`/model` の説明文）・`.env.example`・`CLAUDE.md` はすでに更新済みだったため、本 PR は残された 3 つの穴を埋めます。

| ファイル | 変更内容 |
|----------|----------|
| `README.md` | `CCDB_MODEL_DISCOVERY` が `.env.example` と `/model` の説明文には載っていたものの、**環境変数リファレンス表に未掲載**でした（他の `CCDB_*` 変数はすべて掲載済み）。追加しました。 |
| `docs/DESIGN_DECISIONS.md` | 決定 1 は *「CLI Subprocess, Not Direct API」* というタイトルですが、そこに公式な例外ができました。`model_catalog.py` について、例外が必要な理由（CLI にモデル一覧を列挙する手段がない）と、それが第 2 の実行経路にならないための制約を追記しました。 |
| `docs/ja/README.md` | `/model` の実行時取得に関する新しい段落を翻訳し、日本語版の環境変数表に `CCDB_MODEL_DISCOVERY` の行を追加しました。 |

`DESIGN_DECISIONS.md` に追記した技術的記述は、CHANGELOG からの引き写しではなく `claude_discord/model_catalog.py` の実装で裏を取っています（`CACHE_TTL_SECONDS = 6 * 60 * 60`、`FAILURE_TTL_SECONDS = 5 * 60`、`REQUEST_TIMEOUT_SECONDS = 5.0`、`asyncio.to_thread` 経由の標準ライブラリ `urllib`、認証情報の優先順 `ANTHROPIC_API_KEY` → `ANTHROPIC_AUTH_TOKEN` → `~/.claude/.credentials.json`）。

ドキュメントのみの変更で、コードおよび挙動の変更はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
