### PR TITLE
[docs-sync] Sync JA README with verified attachment delivery (#527)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,7 @@ claude_discord/          # Installable Python package
     thread_renamer.py    # suggest_title() — background claude -p call for auto thread renaming
   ext/
     api_server.py        # REST API server (optional, requires aiohttp)
+    ingest_manifest.py   # Reconciles attachments_manifest against delivered files
   utils/
     logger.py            # Logging setup
 tests/                   # pytest test suite

--- a/README.md
+++ b/README.md
@@ -1167,6 +1167,7 @@ claude_discord/
     thread_renamer.py      # suggest_title() — background claude -p call for auto thread naming
   ext/
     api_server.py          # REST API (optional, requires aiohttp)
+    ingest_manifest.py     # Reconciles attachments_manifest against delivered files
   utils/
     logger.py              # Logging setup
 examples/

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -243,6 +243,35 @@ curl "$CCDB_API_URL/api/ingest/ab12…" -H "Authorization: Bearer $CCDB_INGEST_T
 
 このエンドポイントはオプトイン方式です。`ingest_token` が設定されていない場合、`POST` は `503` を返します。結果取得が利用できない場合、`POST` は `result_id` を省略し、`GET /api/ingest/{id}` は `503` を返します — スポーン動作は変わりません。リクエスト本文と添付ファイルは結果ストアに保存されません（状態、最終テキスト、スレッド ID のみ）。結果は最大 200 件です。
 
+#### 添付ファイル到達の検証 (`attachments_manifest`)
+
+クライアント側で添付ファイルが失われても、従来はそれが見えませんでした。ccdb は渡されたものを保存し、誰も検証できない件数を報告するだけだったため、セッションは受け取っていないファイルを持っているかのように回答してしまいます。**マニフェスト**を送れば、ccdb は到達を推測ではなく検証します — 上流で見つけた添付ごとに 1 エントリを送り、`status` でそのバイト列がこのリクエストに含まれるかどうかを ccdb に伝えます:
+
+```bash
+curl -X POST "$CCDB_API_URL/api/ingest" \
+  -H "Authorization: Bearer $CCDB_INGEST_TOKEN" -H "Content-Type: application/json" \
+  -d '{"content": "返信を作成して",
+       "attachments": [{"filename": "bundle.zip", "data": "<base64>"}],
+       "attachments_manifest": [
+         {"name": "shot.png",  "status": "embedded", "sha256": "…", "message": "返信 11"},
+         {"name": "debug.log", "status": "linked", "url": "https://…", "message": "返信 12",
+          "reason": "SharePoint download returned 403"}
+       ]}'
+# → {"status": "spawned", …, "attachments": {"verified": true, "complete": false,
+#      "missing": [], "not_delivered": [{"name": "debug.log", "message": "返信 12", …}]}}
+```
+
+| `status` | 意味 |
+|---|---|
+| `embedded`（デフォルト） | バイト列がこのリクエストに含まれる — ccdb は一致するファイルが届いていることを期待する |
+| `linked` | URL しか取得できなかった（ホストの権限がない、認証の壁など） |
+| `skipped` | 意図的に送らなかった（サイズ上限、フィルタ除外） |
+| `failed` | 取得またはダウンロードに失敗した |
+
+ccdb は各 `embedded` エントリを、届いたファイルに対して **sha256 を最優先**に、次に完全一致するファイル名、次にバンドラーが名前衝突時に付ける `4_image.png` 形式のインデックス接頭辞、最後にサイズ、の順で突合します。各ファイルは高々 1 回しか消費されないため、`image.png` という名前の添付 2 件が、実際に届いた 1 ファイルを両方とも「一致」と主張することはできません。説明のつかない不足は 4 通りで表面化します: 欠落したファイル名を挙げ、その内容を推測で補わないようセッションに指示する ⚠️ ブロックを**セッションプロンプトの先頭**に置き（最新メッセージ側で失われた場合は別途警告を追加）、ファイルの隣に `ATTACHMENTS-REPORT.md` の台帳を書き出し、上記レスポンスの `attachments` 判定を返し、ログに `WARNING` を出します。`message` を指定すると、プロンプトのパス一覧が上流メッセージごとにグループ化され、最新グループが最初に読むべきものとして印されます。
+
+`CCDB_INGEST_REQUIRE_COMPLETE=1`（または `ingest_require_complete=True`）を設定すると、欠落のあるインジェストは部分的な証拠でセッションを開始せず、`409` で**拒否**されます — 添付ファイルそのものが依頼の本体である用途に適しています。マニフェストを完全に省略した場合は何も変わりません: そのインジェストは `verified: false` として報告され、検証済みで完全とは決して報告されません。
+
 #### 長時間続くインジェストスレッドの継続サマリー (`/api/ingest/summary`)
 
 上流スレッド（特に Teams ブラウザ拡張機能）で何ヶ月も返信し続けるインジェストクライアントは、本来なら実行のたびに全履歴を再エクスポートしなければなりません — ccdb の「スレッド = セッション」モデルは、インジェストごとに*新しい* Discord スレッド + Claude セッションを起動し、上流スレッドについて何も覚えていないからです。クライアントが供給する安定した `summary_key`（例: 上流スレッドのルートメッセージ ID）をキーとするコンパクトな**継続サマリー**をオプトインすれば、新しい `thread_summaries` テーブルに保存され、クライアントは**差分**だけを送りつつ、セッションは完全な履歴コンテキストを受け取れます:
@@ -782,6 +811,8 @@ CHAT_ONLY_CHANNEL_IDS=444,555
 | `CCDB_LOG_FILE` | ログファイルのパス。設定するとデフォルトの stdout ハンドラに加えてローテーティングファイルハンドラ（10 MB × 5 バックアップ）が追加される。監視・アラートに便利 | （オプション） |
 | `API_HOST` | REST API バインドアドレス | `127.0.0.1` |
 | `API_PORT` | REST API ポート（設定すると REST API が有効になる） | （オプション） |
+| `CCDB_INGEST_TOKEN` | `POST /api/ingest` 用の Bearer トークン（`api_secret` とは独立）。未設定ならこのエンドポイントは `503` を返す | （オプション） |
+| `CCDB_INGEST_REQUIRE_COMPLETE` | `1` を設定すると、`attachments_manifest` によって添付ファイルの欠落が判明したインジェストを、部分的な証拠でセッションを開始せずに `409` で拒否する | `0` |
 
 ### パーミッションモード — `-p` モードで動作するもの
 
@@ -1138,6 +1169,7 @@ claude_discord/
     thread_renamer.py      # suggest_title() — スレッド自動リネーム用バックグラウンド claude -p 呼び出し
   ext/
     api_server.py          # REST API サーバー（オプション、aiohttp が必要）
+    ingest_manifest.py     # attachments_manifest と実際に届いたファイルの突合
   utils/
     logger.py              # ロギング設定
 examples/


### PR DESCRIPTION
## Summary

Documentation sync for #527 (*verify ingest attachment delivery instead of assuming it*, v3.3.0).

The English README was updated inside #527 itself, so this PR carries the parts that were left behind:

- **`docs/ja/README.md`** — translated the new **`#### Verified attachment delivery (attachments_manifest)`** section (rationale, `curl` example with the `attachments` verdict, the `embedded`/`linked`/`skipped`/`failed` status table, the sha256→name→index-prefix→size matching rule with single-consumption, the four ways a shortfall surfaces, and `CCDB_INGEST_REQUIRE_COMPLETE` / `409`).
- **`docs/ja/README.md`** — added the two new environment variable rows (`CCDB_INGEST_TOKEN`, `CCDB_INGEST_REQUIRE_COMPLETE`) that #527 added to the English table.
- **`README.md` / `docs/ja/README.md` / `CLAUDE.md`** — listed the new module `claude_discord/ext/ingest_manifest.py` in the project structure trees, which still stopped at `ext/api_server.py`.

Docs only — no code, no behaviour change.

## 概要

#527（インジェストの添付到達を「仮定」せず検証する、v3.3.0）のドキュメント同期です。

英語 README は #527 のコミット内で更新済みだったため、本 PR では取り残された分を反映します。

- **`docs/ja/README.md`** — 新セクション「**添付ファイル到達の検証 (`attachments_manifest`)**」を翻訳（背景、`attachments` 判定を含む `curl` 例、`embedded`/`linked`/`skipped`/`failed` のステータス表、sha256→ファイル名→インデックス接頭辞→サイズ の突合順と「各ファイルは高々1回しか消費しない」規則、欠落が表面化する4経路、`CCDB_INGEST_REQUIRE_COMPLETE` と `409`）。
- **`docs/ja/README.md`** — #527 が英語表に追加した環境変数 2 行（`CCDB_INGEST_TOKEN`、`CCDB_INGEST_REQUIRE_COMPLETE`）を追加。
- **`README.md` / `docs/ja/README.md` / `CLAUDE.md`** — 構成ツリーが `ext/api_server.py` で止まっていたため、新モジュール `claude_discord/ext/ingest_manifest.py` を追記。

ドキュメントのみの変更で、コード・挙動の変更はありません。

## Test plan

- [x] Verified against the source that `CCDB_INGEST_TOKEN` / `CCDB_INGEST_REQUIRE_COMPLETE` are the actual env names (`ext/api_server.py:262`) and that the `409` path and the `verified`/`complete`/`missing`/`not_delivered` response shape match `ext/ingest_manifest.py:445`.
- [ ] CI (ruff + pytest) — no source files touched.
