### PR TITLE
[docs-sync] Document verified attachment delivery in zh-CN/ko/es/pt-BR/fr (#527)

### DIFF
--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -236,6 +236,35 @@ curl "$CCDB_API_URL/api/ingest/ab12…" -H "Authorization: Bearer $CCDB_INGEST_T
 
 El endpoint es opcional: sin un `ingest_token` configurado, `POST` responde `503`. Cuando la recuperación de resultados no está disponible, `POST` simplemente omite `result_id` y `GET /api/ingest/{id}` devuelve `503` — por lo demás, el comportamiento del spawn no cambia. El cuerpo de la solicitud y los adjuntos **no** se persisten en el almacén de resultados (solo el estado, el texto final y el ID del hilo); los resultados están limitados a 200 filas.
 
+#### Entrega de adjuntos verificada (`attachments_manifest`)
+
+Un adjunto que se perdía del lado del cliente era invisible: ccdb guardaba lo que le entregaban y reportaba un conteo que nadie podía comprobar, así que la sesión respondía como si tuviera un archivo que nunca recibió. Envía un **manifiesto** y ccdb **verifica** la entrega en lugar de darla por hecha — una entrada por cada adjunto que encontraste en el origen, con `status` indicando si sus bytes vienen en esta solicitud:
+
+```bash
+curl -X POST "$CCDB_API_URL/api/ingest" \
+  -H "Authorization: Bearer $CCDB_INGEST_TOKEN" -H "Content-Type: application/json" \
+  -d '{"content": "Redacta una respuesta",
+       "attachments": [{"filename": "bundle.zip", "data": "<base64>"}],
+       "attachments_manifest": [
+         {"name": "shot.png",  "status": "embedded", "sha256": "…", "message": "返信 11"},
+         {"name": "debug.log", "status": "linked", "url": "https://…", "message": "返信 12",
+          "reason": "SharePoint download returned 403"}
+       ]}'
+# → {"status": "spawned", …, "attachments": {"verified": true, "complete": false,
+#      "missing": [], "not_delivered": [{"name": "debug.log", "message": "返信 12", …}]}}
+```
+
+| `status` | Significado |
+|---|---|
+| `embedded` (por defecto) | Los bytes vienen en esta solicitud — ccdb espera encontrar un archivo que coincida |
+| `linked` | Solo se obtuvo una URL (sin permiso sobre el host, muro de autenticación, …) |
+| `skipped` | No se envió deliberadamente (límite de tamaño, filtrado) |
+| `failed` | La captura o la descarga falló |
+
+ccdb empareja cada entrada `embedded` con un archivo entregado usando **primero el sha256**, luego el nombre exacto, luego el prefijo de índice tipo `4_image.png` que un empaquetador añade ante nombres en conflicto, y por último el tamaño — consumiendo cada archivo como máximo una vez, de modo que dos adjuntos llamados `image.png` no puedan reclamar ambos el único archivo que llegó. Todo lo que quede sin explicar se expone por cuatro vías: un bloque ⚠️ **al principio del prompt de la sesión** que nombra los archivos faltantes y le indica a la sesión que no invente su contenido (con un aviso adicional cuando la pérdida está en el mensaje más reciente), un libro mayor `ATTACHMENTS-REPORT.md` escrito junto a los archivos, el veredicto `attachments` de la respuesta anterior, y un `WARNING` en el log. Proporcionar `message` también agrupa la lista de rutas del prompt por mensaje de origen y marca el grupo más reciente como el que debe leerse primero.
+
+Define `CCDB_INGEST_REQUIRE_COMPLETE=1` (o `ingest_require_complete=True`) para **rechazar** con `409` una ingesta con pérdidas en lugar de iniciar una sesión con evidencia parcial — apropiado cuando los adjuntos *son* la solicitud. Omite el manifiesto por completo y nada cambia: la ingesta se reporta como `verified: false`, nunca como verificada y completa.
+
 ### Reanudación al Inicio
 
 Si el bot se reinicia a mitad de una sesión, las sesiones de Claude interrumpidas se reanudan automáticamente cuando el bot vuelve a estar en línea. Las sesiones se marcan para reanudar de tres formas:
@@ -739,6 +768,8 @@ En el modo solo-chat, las solicitudes de permisos y los prompts de `AskUserQuest
 | `CCDB_LOG_FILE` | Ruta a un archivo de log. Cuando se define, se añade un manejador de archivo rotativo (10 MB × 5 copias) junto al manejador de stdout por defecto. Útil para monitoreo y alertas. | (opcional) |
 | `API_HOST` | Dirección de enlace del REST API | `127.0.0.1` |
 | `API_PORT` | Puerto del REST API (habilita el REST API cuando se define) | (opcional) |
+| `CCDB_INGEST_TOKEN` | Token Bearer para `POST /api/ingest` (independiente de `api_secret`); si no se define, el endpoint responde `503` | (opcional) |
+| `CCDB_INGEST_REQUIRE_COMPLETE` | Ponlo en `1` para rechazar una ingesta con `409` cuando su `attachments_manifest` demuestre que se perdieron adjuntos, en vez de iniciar una sesión con evidencia parcial | `0` |
 
 ### Modos de Permisos — Qué Funciona en Modo `-p`
 
@@ -1089,6 +1120,7 @@ claude_discord/
     thread_renamer.py      # suggest_title() — background claude -p call for auto thread naming
   ext/
     api_server.py          # REST API (optional, requires aiohttp)
+    ingest_manifest.py     # Concilia attachments_manifest con los archivos entregados
   utils/
     logger.py              # Logging setup
 examples/

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -236,6 +236,35 @@ curl "$CCDB_API_URL/api/ingest/ab12…" -H "Authorization: Bearer $CCDB_INGEST_T
 
 L'endpoint est opt-in : sans `ingest_token` configuré, `POST` répond `503`. Lorsque la récupération de résultats est indisponible, `POST` omet simplement `result_id` et `GET /api/ingest/{id}` renvoie `503` — le comportement de spawn est par ailleurs inchangé. Le corps de la requête et les pièces jointes ne sont **pas** persistés dans le magasin de résultats (seulement le statut, le texte final et l'ID du fil) ; les résultats sont plafonnés à 200 lignes.
 
+#### Livraison de pièces jointes vérifiée (`attachments_manifest`)
+
+Une pièce jointe perdue côté client était jusqu'ici invisible : ccdb enregistrait ce qu'on lui donnait et annonçait un décompte que personne ne pouvait vérifier, si bien qu'une session répondait comme si elle disposait d'un fichier qu'elle n'avait jamais reçu. Envoyez un **manifeste** et ccdb **vérifie** la livraison au lieu de la présumer — une entrée par pièce jointe repérée en amont, avec `status` indiquant si ses octets figurent dans cette requête :
+
+```bash
+curl -X POST "$CCDB_API_URL/api/ingest" \
+  -H "Authorization: Bearer $CCDB_INGEST_TOKEN" -H "Content-Type: application/json" \
+  -d '{"content": "Rédige une réponse",
+       "attachments": [{"filename": "bundle.zip", "data": "<base64>"}],
+       "attachments_manifest": [
+         {"name": "shot.png",  "status": "embedded", "sha256": "…", "message": "返信 11"},
+         {"name": "debug.log", "status": "linked", "url": "https://…", "message": "返信 12",
+          "reason": "SharePoint download returned 403"}
+       ]}'
+# → {"status": "spawned", …, "attachments": {"verified": true, "complete": false,
+#      "missing": [], "not_delivered": [{"name": "debug.log", "message": "返信 12", …}]}}
+```
+
+| `status` | Signification |
+|---|---|
+| `embedded` (par défaut) | Les octets sont dans cette requête — ccdb s'attend à trouver un fichier correspondant |
+| `linked` | Seule une URL a pu être obtenue (pas de permission sur l'hôte, mur d'authentification, …) |
+| `skipped` | Délibérément non envoyé (limite de taille, filtré) |
+| `failed` | La capture ou le téléchargement a échoué |
+
+ccdb rapproche chaque entrée `embedded` d'un fichier livré en utilisant **d'abord le sha256**, puis le nom exact, puis le préfixe d'index de type `4_image.png` qu'un empaqueteur ajoute en cas de collision de noms, et enfin la taille — chaque fichier n'étant consommé qu'une seule fois, deux pièces jointes nommées `image.png` ne peuvent pas revendiquer toutes les deux l'unique fichier arrivé. Tout ce qui reste inexpliqué est signalé de quatre façons : un bloc ⚠️ **en tête du prompt de la session** qui nomme les fichiers manquants et enjoint à la session de ne pas inventer leur contenu (avec une mention supplémentaire lorsque la perte concerne le message le plus récent), un registre `ATTACHMENTS-REPORT.md` écrit à côté des fichiers, le verdict `attachments` dans la réponse ci-dessus, et un `WARNING` dans le log. Fournir `message` regroupe également la liste des chemins du prompt par message d'origine et marque le groupe le plus récent comme celui à lire en premier.
+
+Définissez `CCDB_INGEST_REQUIRE_COMPLETE=1` (ou `ingest_require_complete=True`) pour **refuser** une ingestion lacunaire avec un `409` plutôt que de démarrer une session sur des preuves partielles — pertinent lorsque les pièces jointes *sont* la requête. Omettez complètement le manifeste et rien ne change : l'ingestion est rapportée comme `verified: false`, jamais comme vérifiée-complète.
+
 ### Reprise au Démarrage
 
 Si le bot redémarre en pleine session, les sessions Claude interrompues sont automatiquement reprises quand le bot revient en ligne. Les sessions sont marquées pour reprise de trois façons :
@@ -739,6 +768,8 @@ En mode chat uniquement, les demandes de permission et les invites `AskUserQuest
 | `CCDB_LOG_FILE` | Chemin vers un fichier de log. Quand défini, un gestionnaire de fichier rotatif (10 Mo × 5 sauvegardes) est ajouté en plus du gestionnaire stdout par défaut. Utile pour la surveillance et les alertes. | (optionnel) |
 | `API_HOST` | Adresse de liaison de l'API REST | `127.0.0.1` |
 | `API_PORT` | Port de l'API REST (active l'API REST quand défini) | (optionnel) |
+| `CCDB_INGEST_TOKEN` | Jeton Bearer pour `POST /api/ingest` (indépendant de `api_secret`) ; non défini ⇒ l'endpoint répond `503` | (optionnel) |
+| `CCDB_INGEST_REQUIRE_COMPLETE` | Mettre à `1` pour refuser une ingestion avec un `409` quand son `attachments_manifest` prouve que des pièces jointes ont été perdues, au lieu de démarrer une session sur des preuves partielles | `0` |
 
 ### Modes de Permission — Ce Qui Fonctionne en Mode `-p`
 
@@ -1089,6 +1120,7 @@ claude_discord/
     thread_renamer.py      # suggest_title() — background claude -p call for auto thread naming
   ext/
     api_server.py          # REST API (optional, requires aiohttp)
+    ingest_manifest.py     # Rapproche attachments_manifest des fichiers livrés
   utils/
     logger.py              # Logging setup
 examples/

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -236,6 +236,35 @@ curl "$CCDB_API_URL/api/ingest/ab12…" -H "Authorization: Bearer $CCDB_INGEST_T
 
 이 엔드포인트는 옵트인 방식입니다: `ingest_token`이 구성되지 않으면 `POST`는 `503`을 반환합니다. 결과 조회를 사용할 수 없으면 `POST`는 단순히 `result_id`를 생략하고 `GET /api/ingest/{id}`는 `503`을 반환합니다 — 스폰 동작은 그 외에는 변경되지 않습니다. 요청 본문과 첨부 파일은 결과 저장소에 **저장되지 않습니다**(상태, 최종 텍스트, 스레드 ID만); 결과는 최대 200개 행으로 제한됩니다.
 
+#### 검증된 첨부 파일 전달 (`attachments_manifest`)
+
+클라이언트 쪽에서 첨부 파일이 사라져도 예전에는 아무도 알아챌 수 없었습니다. ccdb는 건네받은 것을 저장하고 아무도 대조할 수 없는 개수를 보고했기 때문에, 세션은 받은 적 없는 파일을 가진 것처럼 답변했습니다. **매니페스트**를 보내면 ccdb는 전달을 가정하는 대신 **검증**합니다 — 원본에서 찾은 첨부 파일마다 한 항목씩 나열하고, 그 바이트가 이 요청에 포함되어 있는지를 `status`로 알려주세요:
+
+```bash
+curl -X POST "$CCDB_API_URL/api/ingest" \
+  -H "Authorization: Bearer $CCDB_INGEST_TOKEN" -H "Content-Type: application/json" \
+  -d '{"content": "답장 초안을 작성해 줘",
+       "attachments": [{"filename": "bundle.zip", "data": "<base64>"}],
+       "attachments_manifest": [
+         {"name": "shot.png",  "status": "embedded", "sha256": "…", "message": "返信 11"},
+         {"name": "debug.log", "status": "linked", "url": "https://…", "message": "返信 12",
+          "reason": "SharePoint download returned 403"}
+       ]}'
+# → {"status": "spawned", …, "attachments": {"verified": true, "complete": false,
+#      "missing": [], "not_delivered": [{"name": "debug.log", "message": "返信 12", …}]}}
+```
+
+| `status` | 의미 |
+|---|---|
+| `embedded`(기본값) | 바이트가 이 요청에 포함됨 — ccdb는 대응하는 파일을 찾을 것으로 기대함 |
+| `linked` | URL만 얻음(호스트 권한 없음, 인증 벽 등) |
+| `skipped` | 의도적으로 보내지 않음(크기 제한, 필터링됨) |
+| `failed` | 캡처 또는 다운로드 실패 |
+
+ccdb는 각 `embedded` 항목을 실제 전달된 파일과 **sha256 우선**, 그다음 파일명 완전 일치, 그다음 번들러가 이름 충돌 시 붙이는 `4_image.png` 인덱스 접두사, 마지막으로 크기 순으로 대조합니다. 각 파일은 최대 한 번만 소비되므로 `image.png`라는 이름의 첨부 두 개가 도착한 파일 하나를 동시에 자기 것이라 주장할 수 없습니다. 설명되지 않은 것은 네 가지 경로로 드러납니다: **세션 프롬프트 최상단**의 ⚠️ 블록(누락된 파일을 나열하고 그 내용을 지어내지 말라고 세션에 지시하며, 최신 메시지에서 손실이 발생한 경우 별도 안내가 추가됨), 파일 옆에 기록되는 `ATTACHMENTS-REPORT.md` 원장, 위 응답의 `attachments` 판정, 그리고 로그의 `WARNING`입니다. `message`를 함께 보내면 프롬프트의 경로 목록이 원본 메시지 단위로 묶이고, 가장 최신 그룹이 먼저 읽어야 할 것으로 표시됩니다.
+
+`CCDB_INGEST_REQUIRE_COMPLETE=1`(또는 `ingest_require_complete=True`)을 설정하면 손실이 있는 인제스트를 불완전한 근거로 세션을 시작하는 대신 `409`로 **거부**합니다 — 첨부 파일 자체가 요청의 본체인 경우에 적합합니다. 매니페스트를 아예 생략하면 아무것도 달라지지 않습니다: 해당 인제스트는 `verified: false`로 보고되며, 검증 완료로 보고되는 일은 결코 없습니다.
+
 ### 시작 재개
 
 봇이 세션 도중 재시작되면, 중단된 Claude 세션이 봇이 다시 온라인이 될 때 자동으로 재개됩니다. 세션은 세 가지 방법으로 재개 대상으로 표시됩니다:
@@ -739,6 +768,8 @@ CHAT_ONLY_CHANNEL_IDS=444,555
 | `CCDB_LOG_FILE` | 로그 파일 경로. 설정 시 기본 stdout 핸들러에 더해 순환 파일 핸들러(10 MB × 5 백업)가 추가됨. 모니터링 및 알림에 유용. | (선택) |
 | `API_HOST` | REST API 바인드 주소 | `127.0.0.1` |
 | `API_PORT` | REST API 포트(설정 시 REST API 활성화) | (선택) |
+| `CCDB_INGEST_TOKEN` | `POST /api/ingest`용 Bearer 토큰(`api_secret`과 독립); 미설정 시 이 엔드포인트는 `503`을 반환 | (선택) |
+| `CCDB_INGEST_REQUIRE_COMPLETE` | `1`로 설정하면 `attachments_manifest`가 첨부 파일 누락을 입증할 때, 불완전한 근거로 세션을 시작하는 대신 `409`로 인제스트를 거부 | `0` |
 
 ### 권한 모드 — `-p` 모드에서 작동하는 것
 
@@ -1089,6 +1120,7 @@ claude_discord/
     thread_renamer.py      # suggest_title() — background claude -p call for auto thread naming
   ext/
     api_server.py          # REST API (optional, requires aiohttp)
+    ingest_manifest.py     # attachments_manifest와 실제 전달된 파일의 대조
   utils/
     logger.py              # Logging setup
 examples/

--- a/docs/pt-BR/README.md
+++ b/docs/pt-BR/README.md
@@ -236,6 +236,35 @@ curl "$CCDB_API_URL/api/ingest/ab12…" -H "Authorization: Bearer $CCDB_INGEST_T
 
 O endpoint é opt-in: sem `ingest_token` configurado, `POST` responde `503`. Quando a recuperação de resultados está indisponível, `POST` simplesmente omite `result_id` e `GET /api/ingest/{id}` retorna `503` — o comportamento de spawn permanece de resto inalterado. O corpo da requisição e os anexos **não** são persistidos no armazenamento de resultados (apenas status, o texto final e o id da thread); os resultados são limitados a 200 linhas.
 
+#### Entrega de anexos verificada (`attachments_manifest`)
+
+Um anexo perdido do lado do cliente era invisível: o ccdb salvava o que recebia e reportava uma contagem que ninguém podia conferir, então a sessão respondia como se tivesse um arquivo que nunca chegou. Envie um **manifesto** e o ccdb **verifica** a entrega em vez de presumi-la — uma entrada para cada anexo que você encontrou na origem, com `status` informando se os bytes dele estão nesta requisição:
+
+```bash
+curl -X POST "$CCDB_API_URL/api/ingest" \
+  -H "Authorization: Bearer $CCDB_INGEST_TOKEN" -H "Content-Type: application/json" \
+  -d '{"content": "Redija uma resposta",
+       "attachments": [{"filename": "bundle.zip", "data": "<base64>"}],
+       "attachments_manifest": [
+         {"name": "shot.png",  "status": "embedded", "sha256": "…", "message": "返信 11"},
+         {"name": "debug.log", "status": "linked", "url": "https://…", "message": "返信 12",
+          "reason": "SharePoint download returned 403"}
+       ]}'
+# → {"status": "spawned", …, "attachments": {"verified": true, "complete": false,
+#      "missing": [], "not_delivered": [{"name": "debug.log", "message": "返信 12", …}]}}
+```
+
+| `status` | Significado |
+|---|---|
+| `embedded` (padrão) | Os bytes estão nesta requisição — o ccdb espera encontrar um arquivo correspondente |
+| `linked` | Só foi possível obter uma URL (sem permissão no host, barreira de autenticação, …) |
+| `skipped` | Deliberadamente não enviado (limite de tamanho, filtrado) |
+| `failed` | A captura ou o download falhou |
+
+O ccdb casa cada entrada `embedded` com um arquivo entregue usando **primeiro o sha256**, depois o nome exato, depois o prefixo de índice no formato `4_image.png` que um empacotador adiciona em caso de nomes conflitantes, e por fim o tamanho — consumindo cada arquivo no máximo uma vez, de modo que dois anexos chamados `image.png` não possam ambos reivindicar o único arquivo que chegou. Tudo o que ficar sem explicação aparece de quatro formas: um bloco ⚠️ no **topo do prompt da sessão** nomeando os arquivos ausentes e instruindo a sessão a não inventar seu conteúdo (com um aviso extra quando a perda está na mensagem mais recente), um registro `ATTACHMENTS-REPORT.md` gravado ao lado dos arquivos, o veredito `attachments` na resposta acima, e um `WARNING` no log. Fornecer `message` também agrupa a lista de caminhos do prompt por mensagem de origem e marca o grupo mais recente como o que deve ser lido primeiro.
+
+Defina `CCDB_INGEST_REQUIRE_COMPLETE=1` (ou `ingest_require_complete=True`) para **recusar** uma ingestão com perdas retornando `409`, em vez de iniciar uma sessão com evidências parciais — apropriado quando os anexos *são* a requisição. Omita o manifesto por completo e nada muda: a ingestão é reportada como `verified: false`, nunca como verificada e completa.
+
 ### Retomada na Inicialização
 
 Se o bot reiniciar no meio de uma sessão, as sessões Claude interrompidas são automaticamente retomadas quando o bot volta a ficar online. As sessões são marcadas para retomada de três formas:
@@ -739,6 +768,8 @@ No modo somente-chat, solicitações de permissão e prompts de `AskUserQuestion
 | `CCDB_LOG_FILE` | Caminho para um arquivo de log. Quando definido, um manipulador de arquivo rotativo (10 MB × 5 backups) é adicionado ao lado do manipulador stdout padrão. Útil para monitoramento e alertas. | (opcional) |
 | `API_HOST` | Endereço de bind da REST API | `127.0.0.1` |
 | `API_PORT` | Porta da REST API (habilita a REST API quando definida) | (opcional) |
+| `CCDB_INGEST_TOKEN` | Token Bearer para `POST /api/ingest` (independente de `api_secret`); se não definido, o endpoint responde `503` | (opcional) |
+| `CCDB_INGEST_REQUIRE_COMPLETE` | Defina como `1` para recusar uma ingestão com `409` quando seu `attachments_manifest` provar que anexos se perderam, em vez de iniciar uma sessão com evidências parciais | `0` |
 
 ### Modos de Permissão — O Que Funciona no Modo `-p`
 
@@ -1089,6 +1120,7 @@ claude_discord/
     thread_renamer.py      # suggest_title() — background claude -p call for auto thread naming
   ext/
     api_server.py          # REST API (optional, requires aiohttp)
+    ingest_manifest.py     # Concilia attachments_manifest com os arquivos entregues
   utils/
     logger.py              # Logging setup
 examples/

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -236,6 +236,35 @@ curl "$CCDB_API_URL/api/ingest/ab12…" -H "Authorization: Bearer $CCDB_INGEST_T
 
 该端点为可选启用：未配置 `ingest_token` 时，`POST` 返回 `503`。结果检索不可用时，`POST` 仅省略 `result_id`，`GET /api/ingest/{id}` 返回 `503`——派生行为在其他方面不变。请求体和附件**不会**持久化到结果存储中（只存储状态、最终文本和线程 ID）；结果上限为 200 条。
 
+#### 已验证的附件投递 (`attachments_manifest`)
+
+在客户端一侧丢失的附件过去是不可见的：ccdb 保存它拿到的内容，并报告一个无人能核对的数量，于是会话会表现得好像它拥有一个从未收到的文件。发送一份**清单（manifest）**，ccdb 就会**验证**投递，而不是假定它成功——为你在上游发现的每个附件列出一条记录，用 `status` 告诉 ccdb 它的字节是否包含在本次请求中：
+
+```bash
+curl -X POST "$CCDB_API_URL/api/ingest" \
+  -H "Authorization: Bearer $CCDB_INGEST_TOKEN" -H "Content-Type: application/json" \
+  -d '{"content": "起草一份回复",
+       "attachments": [{"filename": "bundle.zip", "data": "<base64>"}],
+       "attachments_manifest": [
+         {"name": "shot.png",  "status": "embedded", "sha256": "…", "message": "返信 11"},
+         {"name": "debug.log", "status": "linked", "url": "https://…", "message": "返信 12",
+          "reason": "SharePoint download returned 403"}
+       ]}'
+# → {"status": "spawned", …, "attachments": {"verified": true, "complete": false,
+#      "missing": [], "not_delivered": [{"name": "debug.log", "message": "返信 12", …}]}}
+```
+
+| `status` | 含义 |
+|---|---|
+| `embedded`（默认） | 字节包含在本次请求中——ccdb 期望找到与之匹配的文件 |
+| `linked` | 只拿到了一个 URL（没有主机权限、认证墙等） |
+| `skipped` | 有意未发送（体积上限、被过滤掉） |
+| `failed` | 抓取或下载失败 |
+
+ccdb 将每条 `embedded` 记录与实际送达的文件进行匹配，顺序为：**优先 sha256**，然后是文件名精确匹配，然后是打包器在名称冲突时添加的 `4_image.png` 索引前缀，最后是文件大小——并且每个文件最多被消费一次，因此两个都叫 `image.png` 的附件不可能同时认领唯一送达的那个文件。任何无法核实的内容都会通过四种方式暴露出来：**会话提示词顶部**的 ⚠️ 区块（列出缺失文件，并要求会话不要编造其内容；当丢失发生在最新消息上时会另有提示）、与文件写在一起的 `ATTACHMENTS-REPORT.md` 账本、上面响应中的 `attachments` 结论，以及日志中的一条 `WARNING`。提供 `message` 还会让提示词中的路径列表按上游消息分组，并将最新的一组标记为应当优先阅读。
+
+设置 `CCDB_INGEST_REQUIRE_COMPLETE=1`（或 `ingest_require_complete=True`）可在附件丢失时以 `409` **拒绝**该次摄取，而不是基于不完整的证据启动会话——适用于附件本身*就是*请求内容的场景。完全不发送清单则一切照旧：该次摄取会被报告为 `verified: false`，而绝不会被报告为已验证且完整。
+
 ### 启动恢复
 
 如果 Bot 在会话进行中重启，被中断的 Claude 会话会在 Bot 重新上线时自动恢复。会话通过三种方式被标记为待恢复：
@@ -739,6 +768,8 @@ CHAT_ONLY_CHANNEL_IDS=444,555
 | `CCDB_LOG_FILE` | 日志文件路径。设置后，将在默认 stdout 处理器旁边添加一个轮转文件处理器（10 MB × 5 个备份）。对监控和告警很有用。 | （可选） |
 | `API_HOST` | REST API 绑定地址 | `127.0.0.1` |
 | `API_PORT` | REST API 端口（设置后启用 REST API） | （可选） |
+| `CCDB_INGEST_TOKEN` | `POST /api/ingest` 的 Bearer 令牌（独立于 `api_secret`）；未设置时该端点返回 `503` | （可选） |
+| `CCDB_INGEST_REQUIRE_COMPLETE` | 设为 `1` 时，若 `attachments_manifest` 证明附件已丢失，则以 `409` 拒绝该次摄取，而不是基于不完整的证据启动会话 | `0` |
 
 ### 权限模式 — 在 `-p` 模式下哪些有效
 
@@ -1089,6 +1120,7 @@ claude_discord/
     thread_renamer.py      # suggest_title() — 用于自动线程命名的后台 claude -p 调用
   ext/
     api_server.py          # REST API（可选，需要 aiohttp）
+    ingest_manifest.py     # 将 attachments_manifest 与实际送达的文件进行核对
   utils/
     logger.py              # 日志设置
 examples/


### PR DESCRIPTION
## Summary

`#527` added `attachments_manifest` reconciliation (`ext/ingest_manifest.py`) and documented it in the **English README only**. This PR propagates that documentation to the five translations that no other open PR touches.

**Coordination with #528:** a concurrent docs-sync session opened #528 two minutes before this branch was pushed; it covers `CLAUDE.md`, the English `README.md` structure tree and `docs/ja/README.md`. This PR originally included the same three files with different wording — they were dropped so the two PRs are complementary and merge without conflict. #528 owns EN + JA; this one owns zh-CN, ko, es, pt-BR, fr.

Docs only — no code, no behaviour change.

### What changed (per language: zh-CN, ko, es, pt-BR, fr)

| Location | Change |
|---|---|
| After the base `/api/ingest` section | New **"Verified attachment delivery (`attachments_manifest`)"** section |
| Environment-variable table | `CCDB_INGEST_TOKEN` and `CCDB_INGEST_REQUIRE_COMPLETE` rows |
| Project-structure tree | `ext/ingest_manifest.py` added under `ext/` |

Each translated section carries the same substance as the English source: the manifest `curl` example, the `status` table (`embedded` / `linked` / `skipped` / `failed`), the sha256 → exact name → `4_image.png` index prefix → size matching order with at-most-once consumption, the four ways a shortfall surfaces (⚠️ prompt block, `ATTACHMENTS-REPORT.md`, the `attachments` verdict in the response, the log `WARNING`), `message`-based prompt grouping, and `CCDB_INGEST_REQUIRE_COMPLETE=1` → `409`.

Documented behaviour was checked against `claude_discord/ext/ingest_manifest.py` and `claude_discord/ext/api_server.py` rather than taken from the changelog prose: the four status constants, the `verified` / `is_complete` / `missing` / `not_delivered` verdict fields, the `ATTACHMENTS-REPORT.md` write, and the `CCDB_INGEST_REQUIRE_COMPLETE` / `ingest_require_complete` gate all match.

### Known remaining gap (deliberately not addressed here)

These five translations are still at their v3.2.0 baseline and lack several **earlier** sections that only `ja` has been kept current with — most visibly `/api/ingest/summary` (`summary_key`). Full parity is a bulk re-sync of its own (cf. #503) and is out of scope for this commit-scoped sync. The section added here is self-contained and makes no forward references, so it reads correctly in those files as they stand.

---

## 概要 (Japanese)

`#527` で追加された `attachments_manifest` の照合機能（`ext/ingest_manifest.py`）は、**英語 README にしか記載されていませんでした**。本 PR は、他の PR が触れていない5言語の翻訳にその内容を反映します。

**#528 との調整:** 別セッションの docs-sync が本ブランチの push 2分前に #528 を作成しており、そちらが `CLAUDE.md`・英語 `README.md` の構造ツリー・`docs/ja/README.md` をカバーしています。本 PR には当初同じ3ファイルが別の訳文で含まれていましたが、競合を避けるため削除しました。#528 が EN + JA、本 PR が zh-CN / ko / es / pt-BR / fr を担当します。

ドキュメントのみの変更で、コードや動作の変更はありません。

### 変更内容（zh-CN / ko / es / pt-BR / fr の各言語）

| 箇所 | 変更 |
|---|---|
| `/api/ingest` セクションの直後 | **「添付ファイル配送の検証 (`attachments_manifest`)」**セクションを新設 |
| 環境変数テーブル | `CCDB_INGEST_TOKEN` と `CCDB_INGEST_REQUIRE_COMPLETE` の2行を追加 |
| Project Structure ツリー | `ext/` 配下に `ext/ingest_manifest.py` を追加 |

各言語版とも英語原文と同じ内容を保持しています: マニフェスト付き `curl` 例、`status` 表（`embedded` / `linked` / `skipped` / `failed`）、sha256 → 完全一致名 → `4_image.png` 形式のインデックス接頭辞 → サイズという突き合わせ順序と「1ファイルは最大1回だけ消費」、欠落が表面化する4経路（プロンプト先頭の ⚠️ ブロック、`ATTACHMENTS-REPORT.md`、レスポンスの `attachments` 判定、ログの `WARNING`）、`message` によるプロンプトのグループ化、`CCDB_INGEST_REQUIRE_COMPLETE=1` による `409` 拒否。

記述はチェンジログの文章を写すのではなく、`claude_discord/ext/ingest_manifest.py` と `claude_discord/ext/api_server.py` の実装と突き合わせて確認しました（4つの status 定数、`verified` / `is_complete` / `missing` / `not_delivered` の判定フィールド、`ATTACHMENTS-REPORT.md` の書き出し、`CCDB_INGEST_REQUIRE_COMPLETE` / `ingest_require_complete` のゲート — いずれも一致）。

### 残っている既知のギャップ（本 PR では意図的に対象外）

この5言語は v3.2.0 時点のままで、`ja` だけが追随してきた**それ以前の**セクション（特に `/api/ingest/summary` の `summary_key`）が未反映です。完全に揃えるには #503 のような一括再同期が必要なため、コミット単位の同期である本 PR では対象外としました。今回追加したセクションは自己完結しており前方参照もないため、現状のファイルでも問題なく読めます。

## Test plan

- [x] Code fences balanced in all five files (82 each — even)
- [x] `CCDB_INGEST_TOKEN` / `CCDB_INGEST_REQUIRE_COMPLETE` appear exactly once each as a table row per file (no duplicates)
- [x] `ingest_manifest.py` present in every project-structure tree
- [x] Insertion boundaries inspected — the new `####` section sits under the existing `/api/ingest` `###` heading and before the next `###` heading in every language
- [x] Documented API verified against the implementation, not just the changelog
- [x] No file overlap with #528 (`git diff --stat` touches only `docs/{zh-CN,ko,es,pt-BR,fr}/README.md`)
- [ ] CI (ruff + pytest, Python 3.10/3.11/3.12) — unaffected by docs, expected green
