### PR TITLE
[docs-sync] Document the ingest path-containment guard in SECURITY.md

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -17,6 +17,8 @@ The bridge's security goal is:
 | Flag injection via prompts | `--` separator prevents `-p`, `--resume` etc. in prompt text |
 | Session hijacking via crafted IDs | Strict regex validation: `^[a-f0-9\-]+$` |
 | Skill name injection | Strict regex validation: `^[\w-]+$` |
+| Path traversal via ingest attachments | Client filenames reduced to a safe basename, then re-checked against the ingest root at every filesystem call (`_contained_path`) |
+| Zip slip via ingest archives | Each archive member is resolved and refused if it escapes the extraction directory or the ingest root |
 | Secrets leaking to Claude subprocess | `_STRIPPED_ENV_KEYS` removes `DISCORD_BOT_TOKEN`, `CLAUDECODE`, etc. from subprocess env |
 | Claude reading Discord secrets via Bash tool | Environment stripping prevents `echo $DISCORD_BOT_TOKEN` in Claude's Bash |
 | Nesting detection bypass | `CLAUDECODE` env var stripped — subprocess won't think it's already inside Claude Code |
@@ -72,6 +74,38 @@ if not re.match(r"^[\w-]+$", name):
 ```
 
 Skill names are passed to Claude Code as `/{name}`. The regex ensures only alphanumeric characters, underscores, and hyphens are allowed.
+
+### Ingest Attachment Paths (api_server.py)
+
+`POST /api/ingest` accepts base64 attachments from untrusted external clients and writes them to disk under an ingest root, so both the filename and any zip member name are attacker-controlled. Two independent guards apply.
+
+First, the filename is reduced to a safe basename:
+
+```python
+name = os.path.basename(str(raw or "")).strip()
+name = _UNSAFE_FILENAME_RE.sub("_", name).lstrip(".")
+return name or f"attachment_{index}"
+```
+
+This strips directory components, replaces anything outside `[\w.\-]`, and drops leading dots so an attachment can't masquerade as a dotfile.
+
+Second, containment is re-established immediately before the filesystem call:
+
+```python
+root = os.path.realpath(str(self._ingest_root()))
+resolved = os.path.realpath(str(path))
+if resolved != root and not resolved.startswith(root + os.sep):
+    return None
+```
+
+Why both:
+- The basename sanitiser lives far from the `open()` calls it protects. `_contained_path` re-checks *at the sink*, so every path ccdb opens, stats or writes under the ingest tree is verified — a future refactor can't silently bypass it
+- Returning `None` is a refusal, not a fallback path: callers skip the file rather than write it somewhere else
+- `_unique_path` re-checks every derived variant (`name_2.ext`), because those names are built from the same untrusted input
+- Comparing against `root + os.sep` — not bare `root` — is what stops a sibling directory like `ingest-evil` from passing a prefix test against `ingest`
+- The check is deliberately spelled `os.path.realpath` + `startswith` rather than `Path.resolve()` + `relative_to()`. The two are equivalent, but only the former is recognised as a path sanitiser by CodeQL; with the pathlib spelling the hardening was invisible to the very tool meant to verify it
+
+Zip attachments are extracted member by member, and a member is skipped if it resolves outside the extraction directory or fails the ingest-root check.
 
 ## Environment Isolation
 
@@ -165,11 +199,12 @@ Key principles:
 
 ## Security Audit Checklist
 
-Before merging changes to `runner.py`, `_run_helper.py`, or any Cog:
+Before merging changes to `runner.py`, `_run_helper.py`, `ext/api_server.py`, or any Cog:
 
 - [ ] No `shell=True` in any subprocess call
 - [ ] `--` separator present before user-supplied arguments
 - [ ] All external input validated (session IDs, skill names, channel IDs)
+- [ ] Any new filesystem write under the ingest root goes through `_contained_path` / `_unique_path`
 - [ ] `_STRIPPED_ENV_KEYS` covers any new secret variables
 - [ ] No string formatting in SQL queries (use `?` placeholders)
 - [ ] `allowed_user_ids` check present in any new message handler


### PR DESCRIPTION
## Summary

#531 rewrote the ingest containment check so CodeQL recognises it as a path sanitiser. That change is **behaviour-neutral**, so by itself it warrants no user-facing documentation update.

Reviewing it did surface a real gap it did not create: `docs/SECURITY.md` documents the `runner.py` guards (prompt handling, session id, skill name) and says nothing about the ingest file-write path — even though `POST /api/ingest` writes **attacker-controlled** filenames and zip member names to disk. The project's security model doc omitted an entire class of guard.

## Changes (`docs/SECURITY.md` only)

- **New section** — "Ingest Attachment Paths (api_server.py)" under Input Validation, covering both guards and why the design needs both:
  - the basename sanitiser (`_safe_attachment_name`) and the containment re-check at the sink (`_contained_path`)
  - the sanitiser lives far from the `open()` calls it protects, so containment is re-established immediately before the filesystem call
  - `None` is a refusal, not a fallback path
  - `_unique_path` re-checks every derived `name_2.ext` variant, since those are built from the same untrusted input
  - comparing against `root + os.sep` rather than bare `root` is what stops a sibling like `ingest-evil` passing a prefix test against `ingest`
  - the `realpath` + `startswith` spelling is what makes the guard legible to CodeQL
- **Threat model table** — added path-traversal and zip-slip rows
- **Audit checklist** — scope extended to `ext/api_server.py`, plus an item for new writes under the ingest root

## Verification

- Code snippets are quoted **verbatim** from `api_server.py` (`_safe_attachment_name` L126-128, `_contained_path` L1477-1482); every claim was checked against the source, including the zip-member path
- Ran `pytest tests/test_api_server.py -k "contained or unique_path"` — 2 passed
- `docs/ja` is **unchanged and in sync**: it translates only `README.md` and `CONTRIBUTING.md` (no `docs/ja/SECURITY.md` exists), and both are already current — README 84/84 headings, 17/17 env-var rows, 24/24 API rows; CONTRIBUTING 12/12 headings

Docs only — no code, no behaviour change.

## 概要（日本語）

#531 は ingest の封じ込めチェックを CodeQL が sanitizer と認識できる書き方に変更したもので、**挙動は変わりません**。したがってその変更自体はドキュメント更新を必要としません。

ただし確認の過程で、`#531` が作ったわけではない既存のギャップが見つかりました。`docs/SECURITY.md` は `runner.py` の各ガードを記載している一方、`POST /api/ingest` が**攻撃者の制御下にある**ファイル名・zip メンバー名をディスクへ書き込む経路について一切触れていませんでした。

本 PR は `docs/SECURITY.md` に「Ingest Attachment Paths」節を追加し、basename サニタイズと書き込み直前の封じ込め再確認という二重防御と、その設計理由（`os.sep` による兄弟ディレクトリ対策、CodeQL に認識させる書き方など）を記載します。あわせて脅威モデル表とセキュリティ監査チェックリストも更新しました。

コード変更なし・挙動変更なし。`docs/ja` は README.md と CONTRIBUTING.md のみを翻訳対象としており、両者とも同期済みのため変更ありません。
