### PR TITLE
[docs-sync] Document the inlined containment guard in _unique_path

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -17,7 +17,7 @@ The bridge's security goal is:
 | Flag injection via prompts | `--` separator prevents `-p`, `--resume` etc. in prompt text |
 | Session hijacking via crafted IDs | Strict regex validation: `^[a-f0-9\-]+$` |
 | Skill name injection | Strict regex validation: `^[\w-]+$` |
-| Path traversal via ingest attachments | Client filenames reduced to a safe basename, then re-checked against the ingest root at every filesystem call (`_contained_path`) |
+| Path traversal via ingest attachments | Client filenames reduced to a safe basename, then re-checked against the ingest root inside the function that makes each filesystem call (`_contained_path`, and the same test written out in `_unique_path`) |
 | Zip slip via ingest archives | Each archive member is resolved and refused if it escapes the extraction directory or the ingest root |
 | Secrets leaking to Claude subprocess | `_STRIPPED_ENV_KEYS` removes `DISCORD_BOT_TOKEN`, `CLAUDECODE`, etc. from subprocess env |
 | Claude reading Discord secrets via Bash tool | Environment stripping prevents `echo $DISCORD_BOT_TOKEN` in Claude's Bash |
@@ -99,11 +99,13 @@ if resolved != root and not resolved.startswith(root + os.sep):
 ```
 
 Why both:
-- The basename sanitiser lives far from the `open()` calls it protects. `_contained_path` re-checks *at the sink*, so every path ccdb opens, stats or writes under the ingest tree is verified — a future refactor can't silently bypass it
+- The basename sanitiser lives far from the `open()` calls it protects. The containment test re-checks *at the sink*, so every path ccdb opens, stats or writes under the ingest tree is verified — a future refactor can't silently bypass it
 - Returning `None` is a refusal, not a fallback path: callers skip the file rather than write it somewhere else
-- `_unique_path` re-checks every derived variant (`name_2.ext`), because those names are built from the same untrusted input
+- `_unique_path` builds its candidate list up front and re-checks *every* derived variant (`name_2.ext`, `name_3.ext`, …) before touching it, because those names are built from the same untrusted input
+- Running out of candidates is a refusal too. After 1000 same-named files `_unique_path` returns `None` rather than falling back to a `uuid`-suffixed name: 1000 identical filenames in one request is not a real export, and a random name nothing else can predict is worse than a clear error. A direct attachment becomes a `400`; a zip member is skipped
 - Comparing against `root + os.sep` — not bare `root` — is what stops a sibling directory like `ingest-evil` from passing a prefix test against `ingest`
 - The check is deliberately spelled `os.path.realpath` + `startswith` rather than `Path.resolve()` + `relative_to()`. The two are equivalent, but only the former is recognised as a path sanitiser by CodeQL; with the pathlib spelling the hardening was invisible to the very tool meant to verify it
+- For the same reason the test is *written out* in `_unique_path` instead of delegating to `_contained_path`. The two are identical, but a guard that lives behind a call boundary does not propagate for static analysis: with the delegated version CodeQL still reported both `exists()` calls as live path injections. Keeping the `realpath` + prefix test in the same function as the filesystem call it protects makes the guarantee local — to a reader and to the analyser alike. `_contained_path` remains for the paths handed to `hash_files()`, where the delegation *is* recognised
 
 Zip attachments are extracted member by member, and a member is skipped if it resolves outside the extraction directory or fails the ingest-root check.
 
@@ -205,6 +207,7 @@ Before merging changes to `runner.py`, `_run_helper.py`, `ext/api_server.py`, or
 - [ ] `--` separator present before user-supplied arguments
 - [ ] All external input validated (session IDs, skill names, channel IDs)
 - [ ] Any new filesystem write under the ingest root goes through `_contained_path` / `_unique_path`
+- [ ] Containment checks stay in the function that makes the filesystem call — don't "clean up" an inline guard into a helper, it stops propagating for CodeQL
 - [ ] `_STRIPPED_ENV_KEYS` covers any new secret variables
 - [ ] No string formatting in SQL queries (use `?` placeholders)
 - [ ] `allowed_user_ids` check present in any new message handler


### PR DESCRIPTION
## Summary

Follow-up documentation for #535, which inlined the ingest-root containment check into `_unique_path` instead of delegating it to `_contained_path`.

`docs/SECURITY.md` still described the delegated shape, so a reader following the doc would go looking for code that no longer exists — and, worse, would have no idea why the duplication is deliberate.

Changes to `docs/SECURITY.md`:

- **Threat table** — the ingest path-traversal row now says the check is re-established *inside the function that makes each filesystem call*, naming both `_contained_path` and the copy written out in `_unique_path`.
- **New bullet on analyser locality** — a guard behind a call boundary does not propagate for static analysis; with the delegated version CodeQL still reported both `exists()` calls in `_unique_path` as live path injections. This sits next to the existing bullet about *spelling* the check as `realpath` + `startswith`; together they cover both reasons the code looks the way it does. Notes that `_contained_path` remains for the `hash_files()` paths, where delegation is recognised.
- **New bullet on the behaviour change** — exhausting all 1000 candidates now returns `None` instead of falling back to a `uuid`-suffixed name. A direct attachment becomes a `400`; a zip member is skipped.
- **Candidate-list wording** — `_unique_path` builds the list up front and re-checks every variant before touching it.
- **Audit checklist** — a line telling the next refactor not to "clean up" the inline guard into a helper.

`README.md` / `CONTRIBUTING.md` need no change: the on-disk rename behaviour (`image.png` → `image_2.png`) is unchanged, and only the 1000-collision endpoint moved. `docs/ja/README.md` and `docs/ja/CONTRIBUTING.md` are already in sync with their English sources, so no translation work was required this round. `docs/SECURITY.md` has no translated counterpart.

Documentation only — no code, no tests touched.

---

## 概要

#535（インジェストルート封じ込めチェックを `_contained_path` への委譲をやめ `_unique_path` 内にインライン展開した変更）に対するドキュメント追随です。

`docs/SECURITY.md` は委譲していた頃の構造のまま書かれており、記述をたどった読者は既に存在しないコードを探すことになります。さらに悪いことに、なぜこの重複が意図的なのかが分かりません。

`docs/SECURITY.md` の変更点:

- **脅威テーブル** — インジェストのパストラバーサル行を、チェックが*各ファイルシステム呼び出しを行う関数の内部で*再確立される旨に更新。`_contained_path` と `_unique_path` に書き出されたコピーの両方を明記。
- **解析器のローカリティに関する新しい箇条書き** — 呼び出し境界の向こうにあるガードは静的解析に伝播しない。委譲版のままでは CodeQL が `_unique_path` の 2 つの `exists()` を依然としてパスインジェクションとして報告していた。既存の「`realpath` + `startswith` という*綴り方*」の項目と並べることで、このコードがこの形をしている理由が両面そろいます。`hash_files()` に渡すパスでは委譲が認識されるため `_contained_path` は残る旨も記載。
- **挙動変更に関する新しい箇条書き** — 1000 個の候補を使い切った場合、`uuid` 接尾辞付きの名前にフォールバックせず `None` を返すようになった。直接添付は `400`、zip メンバーはスキップ。
- **候補リストの記述** — `_unique_path` は候補を事前に構築し、触る前に全バリアントを再チェックする。
- **監査チェックリスト** — 次のリファクタがインラインのガードをヘルパーに「整理」しないよう 1 行追加。

`README.md` / `CONTRIBUTING.md` は変更不要です。ディスク上のリネーム挙動（`image.png` → `image_2.png`）は変わっておらず、動いたのは 1000 件衝突時の端点だけだからです。`docs/ja/README.md` と `docs/ja/CONTRIBUTING.md` は英語版と既に同期済みのため、今回は翻訳作業は発生していません。`docs/SECURITY.md` には翻訳版が存在しません。

ドキュメントのみの変更で、コード・テストには触れていません。

## Test plan

- [x] `git diff` reviewed — `docs/SECURITY.md` only
- [x] Every claim checked against `claude_discord/ext/api_server.py` at `5642a30`: `_unique_path` (L1485–), the `400` at L1570–1574, the zip-member skip at L1673–1679, and `_contained_path`'s surviving use at L1867
- [ ] CI green
